### PR TITLE
Update OPA middleware to authorize `/api/individuals` endpoint

### DIFF
--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -1,6 +1,7 @@
 import json
 import csv
 import io
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -129,6 +130,7 @@ class IndividualCSVRendererTest(APITestCase):
     def setUp(self):
         self.individual_one = Individual.objects.create(**c.VALID_INDIVIDUAL)
 
+    @override_settings(CANDIG_OPA_URL=None)
     def test_csv_export(self):
         get_resp = self.client.get('/api/individuals?format=csv')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)

--- a/chord_metadata_service/phenopackets/api_views.py
+++ b/chord_metadata_service/phenopackets/api_views.py
@@ -183,7 +183,7 @@ class PhenopacketViewSet(ExtendedPhenopacketsModelViewSet):
     def get_queryset(self):
         if hasattr(self.request, "allowed_datasets"):
             allowed_datasets = self.request.allowed_datasets
-            queryset = m.Phenopacket.objects.filter(table__ownership_record__dataset__in=allowed_datasets).\
+            queryset = m.Phenopacket.objects.filter(table__ownership_record__dataset__title__in=allowed_datasets).\
                 prefetch_related(*PHENOPACKET_PREFETCH).order_by("id")
         else:
             queryset = m.Phenopacket.objects.all().prefetch_related(*PHENOPACKET_PREFETCH).order_by("id")

--- a/chord_metadata_service/phenopackets/tests/test_phenopackets_api.py
+++ b/chord_metadata_service/phenopackets/tests/test_phenopackets_api.py
@@ -67,9 +67,9 @@ class PhenopacketsAPITest(TestCase):
         """
         responses.add(
             responses.POST,
-            url=settings.CANDIG_OPA_URL + "/v1/data/permissions",
+            url=settings.CANDIG_OPA_URL + "/v1/data/ga4ghPassport/tokenControlledAccessREMS",
             json={
-                "datasets": [str(self.dataset2.identifier)]
+                "result": [str(self.dataset2.title)]
             },
             status=200
         )
@@ -89,9 +89,9 @@ class PhenopacketsAPITest(TestCase):
         """
         responses.add(
             responses.POST,
-            url=settings.CANDIG_OPA_URL + "/v1/data/permissions",
+            url=settings.CANDIG_OPA_URL + "/v1/data/ga4ghPassport/tokenControlledAccessREMS",
             json={
-                "datasets": []
+                "result": []
             },
             status=200
         )
@@ -109,9 +109,9 @@ class PhenopacketsAPITest(TestCase):
         """
         responses.add(
             responses.POST,
-            url=settings.CANDIG_OPA_URL + "/v1/data/permissions",
+            url=settings.CANDIG_OPA_URL + "/v1/data/ga4ghPassport/tokenControlledAccessREMS",
             json={
-                "datasets": [str(self.dataset1.identifier), str(self.dataset2.identifier)]
+                "result": [str(self.dataset1.title), str(self.dataset2.title)]
             },
             status=200
         )
@@ -133,7 +133,7 @@ class PhenopacketsAPITest(TestCase):
         """
         responses.add(
             responses.POST,
-            url=settings.CANDIG_OPA_URL + "/v1/data/permissions",
+            url=settings.CANDIG_OPA_URL + "/v1/data/ga4ghPassport/tokenControlledAccessREMS",
             body=requests.exceptions.RequestException()
         )
 

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -1,5 +1,6 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
+from django.test import override_settings
 
 from chord_metadata_service.patients.models import Individual
 from chord_metadata_service.patients.tests.constants import VALID_INDIVIDUAL, VALID_INDIVIDUAL_2
@@ -43,6 +44,7 @@ class FHIRPhenopacketTest(APITestCase):
         )
         self.phenopacket.biosamples.set([self.biosample_1, self.biosample_2])
 
+    @override_settings(CANDIG_OPA_URL=None)
     def test_get_fhir(self):
         get_resp = self.client.get('/api/phenopackets?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -22,7 +22,7 @@ router.register(r'tables', chord_views.TableViewSet)
 router.register(r'experiments', experiment_views.ExperimentViewSet)
 
 # Patients app urls
-router.register(r'individuals', individual_views.IndividualViewSet)
+router.register(r'individuals', individual_views.IndividualViewSet, basename="individuals")
 
 # Phenopackets app urls
 router.register(r'phenotypicfeatures', phenopacket_views.PhenotypicFeatureViewSet)


### PR DESCRIPTION
I have updated the middleware to authorize the `/api/individuals` endpoint. I have updated `IndividualViewSet` to filter individuals by the datasets returned by OPA if the OPA middleware is used, and to return all individuals if the OPA middleware is not used. I had to make a minor change to the way filtering works for both `/api/individuals` and `/api/phenopackets`. Previously, I was filtering datasets by their ID but now it filters datasets by their title. I had to make this change in order to be compatible with OPA. As a result of the modifications made to the OPA middleware and to the filtering change, a few unit tests broke and I had to modify them to make them compatible.