### PR TITLE
Fixed NoReverseMatch exceptions resulting from change to Individual view

### DIFF
--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -21,7 +21,7 @@ class CreateIndividualTest(APITestCase):
         """ POST a new individual. """
 
         response = self.client.post(
-            reverse('individual-list'),
+            reverse('individuals-list'),
             data=json.dumps(self.valid_payload),
             content_type='application/json'
         )
@@ -33,7 +33,7 @@ class CreateIndividualTest(APITestCase):
         """ POST a new individual with invalid data. """
 
         invalid_response = self.client.post(
-            reverse('individual-list'),
+            reverse('individuals-list'),
             data=json.dumps(self.invalid_payload),
             content_type='application/json'
         )
@@ -73,7 +73,7 @@ class UpdateIndividualTest(APITestCase):
 
         response = self.client.put(
             reverse(
-                'individual-detail',
+                'individuals-detail',
                 kwargs={'pk': self.individual_one.id}
                 ),
             data=json.dumps(self.put_valid_payload),
@@ -86,7 +86,7 @@ class UpdateIndividualTest(APITestCase):
 
         response = self.client.put(
             reverse(
-                'individual-detail',
+                'individuals-detail',
                 kwargs={'pk': self.individual_one.id}
                 ),
             data=json.dumps(self.invalid_payload),
@@ -106,7 +106,7 @@ class DeleteIndividualTest(APITestCase):
 
         response = self.client.delete(
             reverse(
-                'individual-detail',
+                'individuals-detail',
                 kwargs={'pk': self.individual_one.id}
                 )
             )
@@ -117,7 +117,7 @@ class DeleteIndividualTest(APITestCase):
 
         response = self.client.delete(
             reverse(
-                'individual-detail',
+                'individuals-detail',
                 kwargs={'pk': 'patient:what'}
                 )
             )

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -77,8 +77,8 @@ class FHIRIndividualTest(APITestCase):
         self.individual_second = VALID_INDIVIDUAL_2
 
     def test_get_fhir(self):
-        response_1 = get_response('individual-list', self.individual)
-        response_2 = get_response('individual-list', self.individual_second)
+        response_1 = get_response('individuals-list', self.individual)
+        response_2 = get_response('individuals-list', self.individual_second)
         print(response_1.data, response_2.data)
         get_resp = self.client.get('/api/individuals?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Right now, in the `develop` branch, if you run `python manage.py test`, tests depending on the `Individual` view don't pass. This is because when I made changes in this PR: https://github.com/CanDIG/katsu/pull/10
I made some changes to the `Individual` view and I forgot to update the tests to account for this change. This PR fixes those issues so that all the tests should pass now when you run `python manage.py test`.