### PR TITLE
Update build status badge to the CanDIG fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Katsu Metadata Service
 
-![Build Status](https://travis-ci.com/bento-platform/katsu.svg?branch=master)
+[![Build Status](https://travis-ci.com/CanDIG/katsu.svg?branch=develop)](https://travis-ci.com/CanDIG/katsu)
 [![codecov](https://codecov.io/gh/bento-platform/katsu/branch/master/graph/badge.svg)](https://codecov.io/gh/bento-platform/katsu)
 
 ## License


### PR DESCRIPTION
The current badge in README still points to the results from the bento katsu.

This PR edits the README so that the build status badge reflects, and links to, the travis results for CanDIG/katsu.