### PR TITLE
Modified workflow to recursively checkout submodules

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Push to GitHub Packages
         uses: docker/build-push-action@v1
         with:


### PR DESCRIPTION
I modified the GitHub Action workflow to recursively checkout submodules since the `dats` submodule doesn't seem to be in the container on GHCR.