### PR TITLE
Filter datasets on OPA result and consents

### DIFF
--- a/chord_metadata_service/chord/filters.py
+++ b/chord_metadata_service/chord/filters.py
@@ -18,7 +18,7 @@ def filter_datasets(qs, name, value):
     else:
         return qs
 
-
+# TODO   authorize_datasets(): remove the code == GRU filter, urgently.
 def authorize_datasets(qs, name, value):
     """
     Filter by authorized datasets.
@@ -31,6 +31,9 @@ def authorize_datasets(qs, name, value):
         return qs.filter(**{lookup: []})
     else:
         lookup = "__".join([name, "in"])
+
+        # TODO  THE FILTER BELOW IS JANKY; NEEDS TO BE REMOVED.
+        #       It is only here for the ClinDIG 4.3 demo.
         temp = qs.filter(**{lookup: value.split(",")}).distinct().filter(data_use__consent_code__primary_category__code='GRU')
         for t in temp:
             logger.warn(str(t.data_use))

--- a/chord_metadata_service/chord/filters.py
+++ b/chord_metadata_service/chord/filters.py
@@ -1,0 +1,49 @@
+import django_filters
+import logging
+
+logger = logging.getLogger(__name__)
+
+# HELPERS
+
+
+def filter_datasets(qs, name, value):
+    """
+    Filters by datasets.
+    If value is None, returns all objects regardless of datasets.
+    Otherwise, return objects that are in the specified datasets.
+    """
+    if value:
+        lookup = "__".join([name, "in"])
+        return qs.filter(**{lookup: value.split(",")}).distinct()
+    else:
+        return qs
+
+
+def authorize_datasets(qs, name, value):
+    """
+    Filter by authorized datasets.
+    If value is 'NO_DATASETS_AUTHORIZED', returns no objects.
+    Otherwise, returns objects that are in the specified datasets.
+    """
+    logger.warn(f"value is {value}")
+    if value == "NO_DATASETS_AUTHORIZED":
+        lookup = "__".join([name, "in"])
+        return qs.filter(**{lookup: []})
+    else:
+        lookup = "__".join([name, "in"])
+        temp = qs.filter(**{lookup: value.split(",")}).distinct().filter(data_use__consent_code__primary_category__code='GRU')
+        for t in temp:
+            logger.warn(str(t.data_use))
+            
+        return temp
+
+
+class AuthorizedDatasetFilter(django_filters.rest_framework.FilterSet):
+    datasets = django_filters.CharFilter(
+        method=filter_datasets, field_name="table_ownership__dataset__title",
+        label="Datasets"
+    )
+    authorized_datasets = django_filters.CharFilter(
+        method=authorize_datasets, field_name="table_ownership__dataset__title",
+        label="Authorized datasets"
+    )

--- a/chord_metadata_service/chord/tests/test_api.py
+++ b/chord_metadata_service/chord/tests/test_api.py
@@ -85,22 +85,22 @@ class CreateDatasetTest(APITestCase):
     @override_settings(AUTH_OVERRIDE=True)  # For permissions
     def test_create_dataset(self):
         for i, d in enumerate(self.valid_payloads, 1):
-            r = self.client.post(reverse("dataset-list"), data=json.dumps(d), content_type="application/json")
+            r = self.client.post('/api/datasets', data=json.dumps(d), content_type="application/json")
             self.assertEqual(r.status_code, status.HTTP_201_CREATED)
             self.assertEqual(Dataset.objects.count(), i)
             self.assertEqual(Dataset.objects.get(title=d["title"]).description, d["description"])
             self.assertDictEqual(Dataset.objects.get(title=d["title"]).data_use, d["data_use"])
 
         for d in self.invalid_payloads:
-            r = self.client.post(reverse("dataset-list"), data=json.dumps(d), content_type="application/json")
+            r = self.client.post('/api/datasets', data=json.dumps(d), content_type="application/json")
             self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
             self.assertEqual(Dataset.objects.count(), len(self.valid_payloads))
 
     @override_settings(AUTH_OVERRIDE=True)  # For permissions
     def test_dats(self):
-        r = self.client.post(reverse("dataset-list"), data=json.dumps(self.dats_valid_payload),
+        r = self.client.post('/api/datasets', data=json.dumps(self.dats_valid_payload),
                              content_type="application/json")
-        r_invalid = self.client.post(reverse("dataset-list"), data=json.dumps(self.dats_invalid_payload),
+        r_invalid = self.client.post('/api/datasets', data=json.dumps(self.dats_invalid_payload),
                                      content_type="application/json")
         self.assertEqual(r.status_code, status.HTTP_201_CREATED)
         self.assertEqual(r_invalid.status_code, status.HTTP_400_BAD_REQUEST)

--- a/chord_metadata_service/chord/tests/test_api_ingest.py
+++ b/chord_metadata_service/chord/tests/test_api_ingest.py
@@ -55,7 +55,7 @@ class IngestTest(APITestCase):
         r = self.client.post(reverse("project-list"), data=json.dumps(VALID_PROJECT_1), content_type="application/json")
         self.project = r.json()
 
-        r = self.client.post(reverse("dataset-list"), data=json.dumps(valid_dataset_1(self.project["identifier"])),
+        r = self.client.post('/api/datasets', data=json.dumps(valid_dataset_1(self.project["identifier"])),
                              content_type="application/json")
         self.dataset = r.json()
 

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -99,7 +99,7 @@ class TableTest(APITestCase):
         r = self.client.post(reverse("project-list"), data=json.dumps(VALID_PROJECT_1), content_type="application/json")
         self.project = r.json()
 
-        r = self.client.post(reverse("dataset-list"), data=json.dumps(valid_dataset_1(self.project["identifier"])),
+        r = self.client.post('/api/datasets', data=json.dumps(valid_dataset_1(self.project["identifier"])),
                              content_type="application/json")
         self.dataset = r.json()
 

--- a/chord_metadata_service/restapi/datasets_authz_middleware.py
+++ b/chord_metadata_service/restapi/datasets_authz_middleware.py
@@ -14,7 +14,7 @@ class DatasetsAuthzMiddleware:
         self.get_response = get_response
         self.authorize_datasets = 'NO_DATASETS_AUTHORIZED'
         self.authorized_paths = [
-            "^/api/phenopackets/?.*", "^/api/diagnoses/?.*", "^/api/diseases/?.*",
+            "^/api/phenopackets/?.*", "^/api/diagnoses/?.*", "^/api/diseases/?.*", "^/api/datasets/?.*",
             "^/api/genes/?.*", "^/api/genomicinterpretations/?.*", "^/api/htsfiles/?.*", "^/api/individuals/?.*",
             "^/api/interpretations/?.*", "^/api/metadata/?.*", "^/api/phenopackets/?.*", "^/api/phenotypicfeatures/?.*",
             "^/api/procedures/?.*", "^/api/variants/?.*", "^/api/biosamples/?.*", "^/api/labsvital/?.*",

--- a/chord_metadata_service/restapi/tests/test_dataset_authz_middleware.py
+++ b/chord_metadata_service/restapi/tests/test_dataset_authz_middleware.py
@@ -66,16 +66,16 @@ class GetPhenopacketsWithOpaTest(APITestCase):
         response = self.client.get('/api/phenopackets')
         self.assertEqual(response.status_code, 403)
 
-    @override_settings(CANDIG_AUTHORIZATION='OPA')
-    def test_get_phenopackets_with_invalid_OPA_config_2(self):
-        """
-        Test that the /api/datasets returns 200 with 2 datasets even if OPA is malconfigured,
-        as this endpoint is not covered under the middleware.
-        """
-        response = self.client.get('/api/datasets')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data = response.json()
-        self.assertEqual(len(response_data["results"]), 2)
+    # @override_settings(CANDIG_AUTHORIZATION='OPA')
+    # def test_get_phenopackets_with_invalid_OPA_config_2(self):
+    #     """
+    #     Test that the /api/datasets returns 200 with 2 datasets even if OPA is malconfigured,
+    #     as this endpoint is not covered under the middleware.
+    #     """
+    #     response = self.client.get('/api/datasets')
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
+    #     response_data = response.json()
+    #     self.assertEqual(len(response_data["results"]), 2)
 
     @override_settings(CANDIG_AUTHORIZATION='OPA')
     def test_get_phenopackets_with_invalid_OPA_config_3(self):

--- a/chord_metadata_service/restapi/tests/test_jsonld.py
+++ b/chord_metadata_service/restapi/tests/test_jsonld.py
@@ -1,4 +1,4 @@
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase, APIClient
 from django.test import override_settings
 from rest_framework import status
 from chord_metadata_service.chord.tests.constants import (
@@ -7,6 +7,7 @@ from chord_metadata_service.chord.tests.constants import (
     dats_dataset,
 )
 from chord_metadata_service.restapi.tests.utils import get_response
+import json
 
 
 class JSONLDDatasetTest(APITestCase):
@@ -16,7 +17,12 @@ class JSONLDDatasetTest(APITestCase):
         self.project = project.json()
         self.creators = VALID_DATS_CREATORS
         self.dataset = dats_dataset(self.project['identifier'], self.creators)
-        get_response('dataset-list', self.dataset)
+        client = APIClient()
+        client.post(
+            '/api/datasets',
+            data=json.dumps(self.dataset),
+            content_type='application/json'
+        )
 
     def test_jsonld(self):
         get_resp = self.client.get('/api/datasets?format=json-ld')

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -20,7 +20,7 @@ router = routers.DefaultRouter(trailing_slash=False)
 
 # CHORD app urls
 router.register(r'projects', chord_views.ProjectViewSet)
-router.register(r'datasets', chord_views.DatasetViewSet)
+router.register(r'datasets', chord_views.DatasetViewSet, basename="datasets")
 router.register(r'table_ownership', chord_views.TableOwnershipViewSet)
 router.register(r'tables', chord_views.TableViewSet)
 


### PR DESCRIPTION
Find a dataset in Katsu:
```
curl "http://candig-dev.hpc4healthlocal:5080/katsu/api/datasets" -H 'Authorization: Bearer <token>'
```

For one of those datasets, find its identifier and do a GET:
```
curl "http://candig-dev.hpc4healthlocal:5080/katsu/api/datasets/<identifier>" -H 'Authorization: Bearer <token>'
```
You will get a result like this:
```
{
  "identifier": "dbe0d540-0726-4eba-9ad5-c7f633640090",
  "table_ownership": [
    {
      "table_id": "open1",
      "service_id": "service"
    }
  ],
  "n_of_tables": 1,
  "title": "open1",
  "description": "",
  "contact_info": "",
  "data_use": {
    "consent_code": {
      "primary_category": {
        "code": "GRU"
      },
      "secondary_categories": [
        {
          "code": "GSO"
        }
      ]
    },
    "data_use_requirements": [
      {
        "code": "COL"
      },
      {
        "code": "PUB"
      }
    ]
  },
  "linked_field_sets": [],
  "version": "version_2022-03-31 03:21:00.450858+00:00",
  "created": "2022-03-31T03:21:00.456066Z",
  "updated": "2022-03-31T03:21:00.456084Z",
  "project": "312caab5-1f1f-467d-a83c-8dbc73333025"
}
```
If you then PATCH that dataset, changing its primary data use category to 'POA' instead of 'GRU':
```
curl -X "PATCH" "http://candig-dev.hpc4healthlocal:5080/katsu/api/datasets/dbe0d540-0726-4eba-9ad5-c7f633640090" \
     -H 'Authorization: Bearer <token> \
     -d $'{
  "data_use": {
    "data_use_requirements": [
      {
        "code": "COL"
      },
      {
        "code": "PUB"
      }
    ],
    "consent_code": {
      "primary_category": {
        "code": "POA"
      },
      "secondary_categories": [
        {
          "code": "GSO"
        }
      ]
    }
  }
}'
```
and try to GET it again:
```
curl "http://candig-dev.hpc4healthlocal:5080/katsu/api/datasets/<identifier>" -H 'Authorization: Bearer <token>'
```
you'll get:
```
{
  "detail": "Not found."
}
```
Note: you can also run the exact same PATCH command with "GRU" to reset it back the way it was.
```
curl -X "PATCH" "http://candig-dev.hpc4healthlocal:5080/katsu/api/datasets/dbe0d540-0726-4eba-9ad5-c7f633640090" \
     -H 'Authorization: Bearer <token> \
     -d $'{
  "data_use": {
    "data_use_requirements": [
      {
        "code": "COL"
      },
      {
        "code": "PUB"
      }
    ],
    "consent_code": {
      "primary_category": {
        "code": "GRU"
      },
      "secondary_categories": [
        {
          "code": "GSO"
        }
      ]
    }
  }
}'
```