### PR TITLE
Small tweaks for mcodepacket and no auth

### DIFF
--- a/chord_metadata_service/mcode/mcode_ingest.py
+++ b/chord_metadata_service/mcode/mcode_ingest.py
@@ -228,11 +228,11 @@ def ingest_mcodepacket(mcodepacket_data, table_id):
                 id=ms["id"],
                 defaults={
                     "medication_code": ms["medication_code"],
-                    "termination_reason": ms["termination_reason"],
-                    "treatment_intent": ms["treatment_intent"],
-                    "start_date": ms["start_date"],
-                    "end_date": ms["end_date"],
-                    "extra_properties": ms["extra_properties"]
+                    "termination_reason": ms.get("termination_reason", None),
+                    "treatment_intent": ms.get("treatment_intent", None),
+                    "start_date": ms.get("start_date", None),
+                    "end_date": ms.get("end_date", None),
+                    "extra_properties": ms.get("extra_properties", None)
                 }
             )
             _logger_message(ms_created, medication_statement)
@@ -259,7 +259,6 @@ def ingest_mcodepacket(mcodepacket_data, table_id):
                     "extra_properties": tm.get("extra_properties", None)
                 }
             )
-            logger.info(f"hi {tm['extra_properties']} {tumor_marker.extra_properties}")
             _logger_message(tm_created, tumor_marker)
             tumor_markers.append(tumor_marker.id)
 

--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -81,10 +81,10 @@ DRS_URL = os.environ.get("DRS_URL", f"http+unix://{NGINX_INTERNAL_SOCKET}/api/dr
 
 # Candig-specific settings
 
-CANDIG_AUTHORIZATION = os.environ.get("CANDIG_AUTHORIZATION")
-CANDIG_OPA_URL = os.environ.get("CANDIG_OPA_URL")
+CANDIG_AUTHORIZATION = os.getenv("CANDIG_AUTHORIZATION", "")
+CANDIG_OPA_URL = os.getenv("CANDIG_OPA_URL", "")
 CANDIG_OPA_SECRET = os.getenv("CANDIG_OPA_SECRET", "my-secret-beacon-token")
-CANDIG_OPA_SITE_ADMIN_KEY = os.environ.get("CANDIG_OPA_SITE_ADMIN_KEY")
+CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("CANDIG_OPA_SITE_ADMIN_KEY", "site-admin")
 
 # Application definition
 


### PR DESCRIPTION
I updated some of the calls in settings.py so that there will be default values even if the env vars are not set. I also fixed defaults for some mcodepacket values that are not required.