### PR TITLE
fix:  add middleware only for Candig

### DIFF
--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -118,7 +118,6 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'chord_metadata_service.restapi.preflight_req_middleware.PreflightRequestMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -126,8 +125,12 @@ MIDDLEWARE = [
     'bento_lib.auth.django_remote_user.BentoRemoteUserMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'chord_metadata_service.restapi.candig_authz_middleware.CandigAuthzMiddleware',
 ]
+
+# This middlewares are specific to the CANDIG service
+if os.getenv("INSIDE_CANDIG", ""):
+    MIDDLEWARE.append('chord_metadata_service.restapi.preflight_req_middleware.PreflightRequestMiddleware')
+    MIDDLEWARE.append('chord_metadata_service.restapi.candig_authz_middleware.CandigAuthzMiddleware')
 
 CORS_ALLOWED_ORIGINS = []
 

--- a/chord_metadata_service/metadata/test_settings.py
+++ b/chord_metadata_service/metadata/test_settings.py
@@ -1,4 +1,5 @@
 from .settings import *
 
-AUTH_OVERRIDE=True
+# This allowed to run the tests without keycloak running and we cannot get the token from keycloak
+# If we figure out to do the integration tests, we can remove this
 CANDIG_AUTHORIZATION=''


### PR DESCRIPTION
separate Candig specific middleware from bento so the rest api test won't require candig auth anymore. Now if env INSIDE_CANDIG is set to true, it will include the auth middleware process. 

Trying to make the PR small and easy to understand. I will make another PR for the authorization fix