### PR TITLE
Sonchau/fix authorize: remove the get_queryset 

### DIFF
--- a/chord_metadata_service/chord/api_views.py
+++ b/chord_metadata_service/chord/api_views.py
@@ -59,16 +59,7 @@ class DatasetViewSet(CHORDPublicModelViewSet):
 
     serializer_class = DatasetSerializer
     renderer_classes = tuple(CHORDModelViewSet.renderer_classes) + (JSONLDDatasetRenderer, RDFDatasetRenderer,)
-    
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = Dataset.objects\
-                .filter(table_ownership__dataset__title__in=allowed_datasets)
-        else:
-            queryset = Dataset.objects.all().order_by("title")
-        return queryset
-
+    queryset = Dataset.objects.all().order_by("title")
 
 
 class TableOwnershipViewSet(CHORDPublicModelViewSet):

--- a/chord_metadata_service/mcode/api_views.py
+++ b/chord_metadata_service/mcode/api_views.py
@@ -32,15 +32,6 @@ class GeneticSpecimenViewSet(McodeModelViewSet):
     filter_class = f.GeneticSpecimenFilter
     queryset = m.GeneticSpecimen.objects.all()
 
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.GeneticSpecimen.objects\
-    #             .filter(genomicsreport__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-    #     else:
-    #         queryset = m.GeneticSpecimen.objects.all()
-    #     return queryset
-
 
 class CancerGeneticVariantViewSet(McodeModelViewSet):
     serializer_class = s.CancerGeneticVariantSerializer
@@ -53,15 +44,6 @@ class GenomicRegionStudiedViewSet(McodeModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filter_class = f.GenomicRegionStudiedFilter
     queryset = m.GenomicRegionStudied.objects.all()
-
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.GenomicRegionStudied.objects\
-    #             .filter(genomicsreport__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-    #     else:
-    #         queryset = m.GenomicRegionStudied.objects.all()
-    #     return queryset
 
 
 GENOMIC_REPORT_PREFETCH = (
@@ -87,15 +69,6 @@ class LabsVitalViewSet(McodeModelViewSet):
     filter_class = f.LabsVitalFilter
     queryset = m.LabsVital.objects.all()
 
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.LabsVital.objects\
-    #             .filter(individual__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-    #     else:
-    #         queryset = m.LabsVital.objects.all()
-    #     return queryset
-
 
 CANCER_CONDITION_PREFETCH = (
     "tnmstaging_set",
@@ -115,15 +88,6 @@ class TNMStagingViewSet(McodeModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filter_class = f.TNMStagingFilter
     queryset = m.TNMStaging.objects.all()
-
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.TNMStaging.objects\
-    #             .filter(cancer_condition__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-    #     else:
-    #         queryset = m.TNMStaging.objects.all()
-    #     return queryset
 
 
 CANCER_RELATED_PROCEDURE = (
@@ -145,15 +109,6 @@ class MedicationStatementViewSet(McodeModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filter_class = f.MedicationStatementFilter
     queryset = m.MedicationStatement.objects.all()
-
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.MedicationStatement.objects\
-    #             .filter(mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-    #     else:
-    #         queryset = m.MedicationStatement.objects.all()
-    #     return queryset
 
 
 MCODEPACKET_PREFETCH = (

--- a/chord_metadata_service/mcode/api_views.py
+++ b/chord_metadata_service/mcode/api_views.py
@@ -30,44 +30,38 @@ class GeneticSpecimenViewSet(McodeModelViewSet):
     renderer_classes = tuple(McodeModelViewSet.renderer_classes) + (ARGORenderer,)
     filter_backends = [DjangoFilterBackend]
     filter_class = f.GeneticSpecimenFilter
+    queryset = m.GeneticSpecimen.objects.all()
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.GeneticSpecimen.objects\
-                .filter(genomicsreport__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.GeneticSpecimen.objects.all()
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.GeneticSpecimen.objects\
+    #             .filter(genomicsreport__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
+    #     else:
+    #         queryset = m.GeneticSpecimen.objects.all()
+    #     return queryset
 
 
 class CancerGeneticVariantViewSet(McodeModelViewSet):
     serializer_class = s.CancerGeneticVariantSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.CancerGeneticVariantFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.CancerGeneticVariant.objects\
-                .filter(genomicsreport__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.CancerGeneticVariant.objects.all()
-        return queryset
+    queryset = m.CancerGeneticVariant.objects.all()
 
 class GenomicRegionStudiedViewSet(McodeModelViewSet):
     serializer_class = s.GenomicRegionStudiedSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.GenomicRegionStudiedFilter
+    queryset = m.GenomicRegionStudied.objects.all()
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.GenomicRegionStudied.objects\
-                .filter(genomicsreport__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.GenomicRegionStudied.objects.all()
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.GenomicRegionStudied.objects\
+    #             .filter(genomicsreport__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
+    #     else:
+    #         queryset = m.GenomicRegionStudied.objects.all()
+    #     return queryset
 
 
 GENOMIC_REPORT_PREFETCH = (
@@ -84,30 +78,23 @@ class GenomicsReportViewSet(McodeModelViewSet):
     serializer_class = s.GenomicsReportSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.GenomicsReportFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.GenomicsReport.objects\
-                .filter(mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.GenomicsReport.objects.all()
-        return queryset
+    queryset = m.GenomicsReport.objects.all()
 
 
 class LabsVitalViewSet(McodeModelViewSet):
     serializer_class = s.LabsVitalSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.LabsVitalFilter
+    queryset = m.LabsVital.objects.all()
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.LabsVital.objects\
-                .filter(individual__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.LabsVital.objects.all()
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.LabsVital.objects\
+    #             .filter(individual__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
+    #     else:
+    #         queryset = m.LabsVital.objects.all()
+    #     return queryset
 
 
 CANCER_CONDITION_PREFETCH = (
@@ -120,30 +107,23 @@ class CancerConditionViewSet(McodeModelViewSet):
     renderer_classes = tuple(McodeModelViewSet.renderer_classes) + (ARGORenderer,)
     filter_backends = [DjangoFilterBackend]
     filter_class = f.CancerConditionFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.CancerCondition.objects\
-                .filter(mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.CancerCondition.objects.all()
-        return queryset
+    queryset = m.CancerCondition.objects.all()
 
 
 class TNMStagingViewSet(McodeModelViewSet):
     serializer_class = s.TNMStagingSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.TNMStagingFilter
+    queryset = m.TNMStaging.objects.all()
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.TNMStaging.objects\
-                .filter(cancer_condition__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.TNMStaging.objects.all()
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.TNMStaging.objects\
+    #             .filter(cancer_condition__mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
+    #     else:
+    #         queryset = m.TNMStaging.objects.all()
+    #     return queryset
 
 
 CANCER_RELATED_PROCEDURE = (
@@ -156,15 +136,7 @@ class CancerRelatedProcedureViewSet(McodeModelViewSet):
     renderer_classes = tuple(McodeModelViewSet.renderer_classes) + (ARGORenderer,)
     filter_backends = [DjangoFilterBackend]
     filter_class = f.CancerRelatedProcedureFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.CancerRelatedProcedure.objects\
-                .filter(mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.CancerRelatedProcedure.objects.all()
-        return queryset
+    queryset = m.CancerRelatedProcedure.objects.all()
 
 
 class MedicationStatementViewSet(McodeModelViewSet):
@@ -172,15 +144,16 @@ class MedicationStatementViewSet(McodeModelViewSet):
     renderer_classes = tuple(McodeModelViewSet.renderer_classes) + (ARGORenderer,)
     filter_backends = [DjangoFilterBackend]
     filter_class = f.MedicationStatementFilter
+    queryset = m.MedicationStatement.objects.all()
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.MedicationStatement.objects\
-                .filter(mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.MedicationStatement.objects.all()
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.MedicationStatement.objects\
+    #             .filter(mcodepacket__table__ownership_record__dataset__title__in=allowed_datasets)
+    #     else:
+    #         queryset = m.MedicationStatement.objects.all()
+    #     return queryset
 
 
 MCODEPACKET_PREFETCH = (
@@ -200,15 +173,7 @@ class MCodePacketViewSet(McodeModelViewSet):
     renderer_classes = tuple(McodeModelViewSet.renderer_classes) + (ARGORenderer,)
     filter_backends = [DjangoFilterBackend]
     filter_class = f.MCodePacketFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.MCodePacket.objects\
-                .filter(table__ownership_record__dataset__title__in=allowed_datasets)
-        else:
-            queryset = m.MCodePacket.objects.all()
-        return queryset
+    queryset = m.MCodePacket.objects.all()
 
 
 @api_view(["GET"])

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -36,21 +36,11 @@ class IndividualViewSet(viewsets.ModelViewSet):
     filter_class = IndividualFilter
     ordering_fields = ["id"]
     search_fields = ["sex", "ethnicity"]
+    queryset = Individual.objects.all().prefetch_related(
+        *(f"biosamples__{p}" for p in BIOSAMPLE_PREFETCH),
+        *(f"phenopackets__{p}" for p in PHENOPACKET_PREFETCH if p != "subject"),
+    ).order_by("id")
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = Individual.objects.\
-                filter(phenopackets__table__ownership_record__dataset__title__in=allowed_datasets).\
-                prefetch_related(*(f"biosamples__{p}" for p in BIOSAMPLE_PREFETCH),
-                                 *(f"phenopackets__{p}" for p in PHENOPACKET_PREFETCH if p != "subject")).\
-                order_by("id")
-        else:
-            queryset = Individual.objects.all().prefetch_related(
-                *(f"biosamples__{p}" for p in BIOSAMPLE_PREFETCH),
-                *(f"phenopackets__{p}" for p in PHENOPACKET_PREFETCH if p != "subject"),
-            ).order_by("id")
-        return queryset
 
     # Cache page for the requested url, default to 2 hours.
     @method_decorator(cache_page(settings.CACHE_TIME))

--- a/chord_metadata_service/phenopackets/api_views.py
+++ b/chord_metadata_service/phenopackets/api_views.py
@@ -40,17 +40,7 @@ class PhenotypicFeatureViewSet(ExtendedPhenopacketsModelViewSet):
     serializer_class = s.PhenotypicFeatureSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.PhenotypicFeatureFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.PhenotypicFeature.objects.filter(
-                phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .filter(biosample__phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .order_by("id")
-        else:
-            queryset = m.PhenotypicFeature.objects.all().order_by("id")
-        return queryset
+    queryset = m.PhenotypicFeature.objects.all().order_by("id")
 
 
 class ProcedureViewSet(ExtendedPhenopacketsModelViewSet):
@@ -65,16 +55,17 @@ class ProcedureViewSet(ExtendedPhenopacketsModelViewSet):
     serializer_class = s.ProcedureSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.ProcedureFilter
+    queryset = m.Procedure.objects.all().order_by("id")
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.Procedure.objects.filter(
-                biosample__phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .order_by("id")
-        else:
-            queryset = m.Procedure.objects.all().order_by("id")
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.Procedure.objects.filter(
+    #             biosample__phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
+    #             .order_by("id")
+    #     else:
+    #         queryset = m.Procedure.objects.all().order_by("id")
+    #     return queryset
 
 
 class HtsFileViewSet(ExtendedPhenopacketsModelViewSet):
@@ -88,16 +79,7 @@ class HtsFileViewSet(ExtendedPhenopacketsModelViewSet):
     """
     serializer_class = s.HtsFileSerializer
     filter_backends = [DjangoFilterBackend]
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.HtsFile.objects\
-                .filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .order_by("uri")
-        else:
-            queryset = m.HtsFile.objects.all().order_by("uri")
-        return queryset
+    queryset = m.HtsFile.objects.all().order_by("uri")
 
 
 class GeneViewSet(ExtendedPhenopacketsModelViewSet):
@@ -112,15 +94,16 @@ class GeneViewSet(ExtendedPhenopacketsModelViewSet):
     serializer_class = s.GeneSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.GeneFilter
+    queryset = m.Gene.objects.all().order_by("id")
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.Gene.objects.filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .order_by("id")
-        else:
-            queryset = m.Gene.objects.all().order_by("id")
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.Gene.objects.filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
+    #             .order_by("id")
+    #     else:
+    #         queryset = m.Gene.objects.all().order_by("id")
+    #     return queryset
 
 
 class VariantViewSet(ExtendedPhenopacketsModelViewSet):
@@ -135,16 +118,7 @@ class VariantViewSet(ExtendedPhenopacketsModelViewSet):
     serializer_class = s.VariantSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.VariantFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.Variant.objects\
-                .filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .order_by("id")
-        else:
-            queryset = m.Variant.objects.all().order_by("id")
-        return queryset
+    queryset = m.Variant.objects.all().order_by("id")
 
 
 class DiseaseViewSet(ExtendedPhenopacketsModelViewSet):
@@ -159,16 +133,17 @@ class DiseaseViewSet(ExtendedPhenopacketsModelViewSet):
     serializer_class = s.DiseaseSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.DiseaseFilter
+    queryset = m.Disease.objects.all().order_by("id")
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.Disease.objects\
-                .filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .order_by("id")
-        else:
-            queryset = m.Disease.objects.all().order_by("id")
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.Disease.objects\
+    #             .filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
+    #             .order_by("id")
+    #     else:
+    #         queryset = m.Disease.objects.all().order_by("id")
+    #     return queryset
 
 
 META_DATA_PREFETCH = (
@@ -188,16 +163,7 @@ class MetaDataViewSet(PhenopacketsModelViewSet):
     serializer_class = s.MetaDataSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.MetaDataFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.MetaData.objects\
-                .filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .prefetch_related(*META_DATA_PREFETCH).order_by("id")
-        else:
-            queryset = m.MetaData.objects.all().prefetch_related(*META_DATA_PREFETCH).order_by("id")
-        return queryset
+    queryset = m.MetaData.objects.all().prefetch_related(*META_DATA_PREFETCH).order_by("id")
 
 
 BIOSAMPLE_PREFETCH = (
@@ -228,16 +194,17 @@ class BiosampleViewSet(ExtendedPhenopacketsModelViewSet):
     serializer_class = s.BiosampleSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.BiosampleFilter
+    queryset = m.Biosample.objects.all().prefetch_related(*BIOSAMPLE_PREFETCH).order_by("id")
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.Biosample.objects.filter(
-                phenopacket__table__ownership_record__dataset__title__in=allowed_datasets).\
-                prefetch_related(*BIOSAMPLE_PREFETCH).select_related(*BIOSAMPLE_SELECT_REL).order_by("id")
-        else:
-            queryset = m.Biosample.objects.all().prefetch_related(*BIOSAMPLE_PREFETCH).order_by("id")
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.Biosample.objects.filter(
+    #             phenopacket__table__ownership_record__dataset__title__in=allowed_datasets).\
+    #             prefetch_related(*BIOSAMPLE_PREFETCH).select_related(*BIOSAMPLE_SELECT_REL).order_by("id")
+    #     else:
+    #         queryset = m.Biosample.objects.all().prefetch_related(*BIOSAMPLE_PREFETCH).order_by("id")
+    #     return queryset
 
 
 PHENOPACKET_PREFETCH = (
@@ -269,15 +236,7 @@ class PhenopacketViewSet(ExtendedPhenopacketsModelViewSet):
     serializer_class = s.PhenopacketSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.PhenopacketFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.Phenopacket.objects.filter(table__ownership_record__dataset__title__in=allowed_datasets).\
-                prefetch_related(*PHENOPACKET_PREFETCH).select_related(*PHENOPACKET_SELECT_REL).order_by("id")
-        else:
-            queryset = m.Phenopacket.objects.all().prefetch_related(*PHENOPACKET_PREFETCH).order_by("id")
-        return queryset
+    queryset = m.Phenopacket.objects.all().prefetch_related(*PHENOPACKET_PREFETCH).order_by("id")
 
 
 class GenomicInterpretationViewSet(PhenopacketsModelViewSet):
@@ -307,16 +266,17 @@ class DiagnosisViewSet(PhenopacketsModelViewSet):
     serializer_class = s.DiagnosisSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.DiagnosisFilter
+    queryset = m.Diagnosis.objects.all().order_by("id")
 
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.Diagnosis.objects.filter(
-                disease__phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .order_by("id")
-        else:
-            queryset = m.Diagnosis.objects.all().order_by("id")
-        return queryset
+    # def get_queryset(self):
+    #     if hasattr(self.request, "allowed_datasets"):
+    #         allowed_datasets = self.request.allowed_datasets
+    #         queryset = m.Diagnosis.objects.filter(
+    #             disease__phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
+    #             .order_by("id")
+    #     else:
+    #         queryset = m.Diagnosis.objects.all().order_by("id")
+    #     return queryset
 
 
 class InterpretationViewSet(PhenopacketsModelViewSet):
@@ -331,16 +291,7 @@ class InterpretationViewSet(PhenopacketsModelViewSet):
     serializer_class = s.InterpretationSerializer
     filter_backends = [DjangoFilterBackend]
     filter_class = f.InterpretationFilter
-
-    def get_queryset(self):
-        if hasattr(self.request, "allowed_datasets"):
-            allowed_datasets = self.request.allowed_datasets
-            queryset = m.Interpretation.objects.filter(
-                phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-                .order_by("id")
-        else:
-            queryset = m.Interpretation.objects.all().order_by("id")
-        return queryset
+    queryset = m.Interpretation.objects.all().order_by("id")
 
 
 @api_view(["GET"])

--- a/chord_metadata_service/phenopackets/api_views.py
+++ b/chord_metadata_service/phenopackets/api_views.py
@@ -57,16 +57,6 @@ class ProcedureViewSet(ExtendedPhenopacketsModelViewSet):
     filter_class = f.ProcedureFilter
     queryset = m.Procedure.objects.all().order_by("id")
 
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.Procedure.objects.filter(
-    #             biosample__phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-    #             .order_by("id")
-    #     else:
-    #         queryset = m.Procedure.objects.all().order_by("id")
-    #     return queryset
-
 
 class HtsFileViewSet(ExtendedPhenopacketsModelViewSet):
     """
@@ -95,15 +85,6 @@ class GeneViewSet(ExtendedPhenopacketsModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filter_class = f.GeneFilter
     queryset = m.Gene.objects.all().order_by("id")
-
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.Gene.objects.filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-    #             .order_by("id")
-    #     else:
-    #         queryset = m.Gene.objects.all().order_by("id")
-    #     return queryset
 
 
 class VariantViewSet(ExtendedPhenopacketsModelViewSet):
@@ -134,16 +115,6 @@ class DiseaseViewSet(ExtendedPhenopacketsModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filter_class = f.DiseaseFilter
     queryset = m.Disease.objects.all().order_by("id")
-
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.Disease.objects\
-    #             .filter(phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-    #             .order_by("id")
-    #     else:
-    #         queryset = m.Disease.objects.all().order_by("id")
-    #     return queryset
 
 
 META_DATA_PREFETCH = (
@@ -195,16 +166,6 @@ class BiosampleViewSet(ExtendedPhenopacketsModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filter_class = f.BiosampleFilter
     queryset = m.Biosample.objects.all().prefetch_related(*BIOSAMPLE_PREFETCH).order_by("id")
-
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.Biosample.objects.filter(
-    #             phenopacket__table__ownership_record__dataset__title__in=allowed_datasets).\
-    #             prefetch_related(*BIOSAMPLE_PREFETCH).select_related(*BIOSAMPLE_SELECT_REL).order_by("id")
-    #     else:
-    #         queryset = m.Biosample.objects.all().prefetch_related(*BIOSAMPLE_PREFETCH).order_by("id")
-    #     return queryset
 
 
 PHENOPACKET_PREFETCH = (
@@ -267,16 +228,6 @@ class DiagnosisViewSet(PhenopacketsModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filter_class = f.DiagnosisFilter
     queryset = m.Diagnosis.objects.all().order_by("id")
-
-    # def get_queryset(self):
-    #     if hasattr(self.request, "allowed_datasets"):
-    #         allowed_datasets = self.request.allowed_datasets
-    #         queryset = m.Diagnosis.objects.filter(
-    #             disease__phenopacket__table__ownership_record__dataset__title__in=allowed_datasets)\
-    #             .order_by("id")
-    #     else:
-    #         queryset = m.Diagnosis.objects.all().order_by("id")
-    #     return queryset
 
 
 class InterpretationViewSet(PhenopacketsModelViewSet):

--- a/chord_metadata_service/restapi/candig_authz_middleware.py
+++ b/chord_metadata_service/restapi/candig_authz_middleware.py
@@ -52,7 +52,9 @@ class CandigAuthzMiddleware:
                     response = HttpResponseForbidden(json.dumps(error_response))
                     response["Content-Type"] = "application/json"
                     return response
-        
+
+        # if CANDIG_AUTHORIZATION is unknown, mean no authorization
+        self.authorize_datasets = 'NO_DATASETS_AUTHORIZED'
         return self.get_response(request)
 
     


### PR DESCRIPTION
This PR revert(remove) the get_queryset. 

Fixed #56: I simply added self.authorized_datasets = NO_DATASETS_AUTHORIZED, so if users don't have CANDIG_AUTHORIZATION, it doesn't matter what they put in the URL. Note that this is not the fix for the integration test, and the test for the authorized_datasets is a bit misleading, but we don't have anything better at the moment.

Fixes #57: all the get_queryset removed, hence take care of the typo allowed_datasets. Now the filter class should only use the authorized_datasets