### PR TITLE
Authorization header still required

### DIFF
--- a/chord_metadata_service/restapi/candig_authz_middleware.py
+++ b/chord_metadata_service/restapi/candig_authz_middleware.py
@@ -99,7 +99,10 @@ class CandigAuthzMiddleware:
         try:
             response = requests.post(
                 settings.CANDIG_OPA_URL + "/v1/data/permissions/datasets",
-                headers={"X-Opa": f"{settings.CANDIG_OPA_SECRET}"},
+                headers={
+                    "X-Opa": f"{settings.CANDIG_OPA_SECRET}",
+                    "Authorization": f"Bearer {token}"
+                },
                 json={
                     "input": {
                             "token": token,


### PR DESCRIPTION
Tyk needs the user's bearer token still, even though OPA doesn't use that. Altogether, what is needed are:

* the bearer token (for tyk)
* the X-Opa token (for opa authz.rego)
* the input body bearer token (for datasets)