### PR TITLE
tweaks following #63

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apk add --no-cache \
 RUN mkdir /app
 WORKDIR /app
 ADD ./requirements.txt /app
+ADD ./requirements-dev.txt /app
 RUN pip install -r requirements-dev.txt
 
 COPY . /app/chord_metadata_service

--- a/chord_metadata_service/restapi/candig_authz_middleware.py
+++ b/chord_metadata_service/restapi/candig_authz_middleware.py
@@ -131,7 +131,10 @@ class CandigAuthzMiddleware:
         try:
             response = requests.post(
                 settings.CANDIG_OPA_URL + "/v1/data/idp/" + settings.CANDIG_OPA_SITE_ADMIN_KEY,
-                headers={"Authorization": f"Bearer {settings.CANDIG_OPA_SECRET}"},
+                headers={
+                    "X-Opa": f"{settings.CANDIG_OPA_SECRET}",
+                    "Authorization": f"Bearer {token}"
+                },
                 json={
                     "input": {
                             "token": token


### PR DESCRIPTION
Two tiny fixes from testing PR #63 ...

I tested by ingesting the mohccn-data set with katsu_ingest.py and then accessing the api/mcodepackets endpoint. It works fine! If user1 has access to the test data but user2 doesn't, only user1 can see the data.