### PR TITLE
DIG-895: Use candigv2-authx module

### DIFF
--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -86,7 +86,7 @@ DRS_URL = os.environ.get("DRS_URL", f"http+unix://{NGINX_INTERNAL_SOCKET}/api/dr
 # Candig-specific settings
 
 CANDIG_AUTHORIZATION = os.getenv("CANDIG_AUTHORIZATION", "")
-CANDIG_OPA_URL = os.getenv("CANDIG_OPA_URL", "")
+CANDIG_OPA_URL = os.getenv("OPA_URL", "")
 CANDIG_OPA_SECRET = os.getenv("CANDIG_OPA_SECRET", "my-secret-beacon-token")
 CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("CANDIG_OPA_SITE_ADMIN_KEY", "site-admin")
 if exists("/run/secrets/opa-root-token"):

--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -16,7 +16,7 @@ import logging
 import json
 from os.path import exists
 
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 from dotenv import load_dotenv
 
 from .. import __version__

--- a/chord_metadata_service/restapi/candig_authz_middleware.py
+++ b/chord_metadata_service/restapi/candig_authz_middleware.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseForbidden
 import requests
 import re
 import json
-import authx.auth
+from authx.auth import get_opa_datasets, is_site_admin
 
 
 class CandigAuthzMiddleware:
@@ -51,7 +51,7 @@ class CandigAuthzMiddleware:
                 request.GET.update({'authorized_datasets': self.authorize_datasets})
             elif self.is_authorized_post(request):
                 request.POST = request.POST.copy()  # Make request.POST mutable
-                if not authx.auth.is_site_admin(request, opa_url, opa_secret, site_admin_key=opa_site_admin):
+                if not is_site_admin(request, opa_url, opa_secret, site_admin_key=opa_site_admin):
                     error_response = {"error": "You do not have permission to POST"}
                     response = HttpResponseForbidden(json.dumps(error_response))
                     response["Content-Type"] = "application/json"

--- a/chord_metadata_service/restapi/candig_authz_middleware.py
+++ b/chord_metadata_service/restapi/candig_authz_middleware.py
@@ -40,8 +40,12 @@ class CandigAuthzMiddleware:
                     response = HttpResponseForbidden(json.dumps(error_response))
                     response["Content-Type"] = "application/json"
                     return response
-                opa_res_datasets = authx.auth.get_opa_datasets(request, opa_url, opa_secret)
-                if len(opa_res_datasets) == 0:
+                try:
+                    opa_res_datasets = get_opa_datasets(request, opa_url, opa_secret)
+                except Exception as e:
+                    response = HttpResponseForbidden(e)
+                    return response
+                if opa_res_datasets is not None and len(opa_res_datasets) == 0:
                     self.authorize_datasets = 'NO_DATASETS_AUTHORIZED'
                 elif type(opa_res_datasets) == tuple and opa_res_datasets[0] == "error":  # error response
                     return opa_res_datasets[1]

--- a/chord_metadata_service/restapi/candig_authz_middleware.py
+++ b/chord_metadata_service/restapi/candig_authz_middleware.py
@@ -40,7 +40,7 @@ class CandigAuthzMiddleware:
                     response["Content-Type"] = "application/json"
                     return response
                 try:
-                    opa_res_datasets = get_opa_datasets(request, opa_url=opa_url, opa_secret)
+                    opa_res_datasets = get_opa_datasets(request, opa_url=opa_url, admin_secret=opa_secret)
                 except Exception as e:
                     response = HttpResponseForbidden(e)
                     return response
@@ -54,7 +54,7 @@ class CandigAuthzMiddleware:
                 request.GET.update({'authorized_datasets': self.authorize_datasets})
             elif self.is_authorized_post(request):
                 request.POST = request.POST.copy()  # Make request.POST mutable
-                if not is_site_admin(request, opa_url=opa_url, opa_secret, site_admin_key=opa_site_admin):
+                if not is_site_admin(request, opa_url=opa_url, admin_secret=opa_secret, site_admin_key=opa_site_admin):
                     error_response = {"error": "You do not have permission to POST"}
                     response = HttpResponseForbidden(json.dumps(error_response))
                     response["Content-Type"] = "application/json"

--- a/chord_metadata_service/restapi/candig_authz_middleware.py
+++ b/chord_metadata_service/restapi/candig_authz_middleware.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.http import HttpResponseForbidden
-import requests
 import re
 import json
 from authx.auth import get_opa_datasets, is_site_admin
@@ -41,7 +40,7 @@ class CandigAuthzMiddleware:
                     response["Content-Type"] = "application/json"
                     return response
                 try:
-                    opa_res_datasets = get_opa_datasets(request, opa_url, opa_secret)
+                    opa_res_datasets = get_opa_datasets(request, opa_url=opa_url, opa_secret)
                 except Exception as e:
                     response = HttpResponseForbidden(e)
                     return response
@@ -55,7 +54,7 @@ class CandigAuthzMiddleware:
                 request.GET.update({'authorized_datasets': self.authorize_datasets})
             elif self.is_authorized_post(request):
                 request.POST = request.POST.copy()  # Make request.POST mutable
-                if not is_site_admin(request, opa_url, opa_secret, site_admin_key=opa_site_admin):
+                if not is_site_admin(request, opa_url=opa_url, opa_secret, site_admin_key=opa_site_admin):
                     error_response = {"error": "You do not have permission to POST"}
                     response = HttpResponseForbidden(json.dumps(error_response))
                     response["Content-Type"] = "application/json"

--- a/chord_metadata_service/restapi/tests/test_dataset_authz_middleware.py
+++ b/chord_metadata_service/restapi/tests/test_dataset_authz_middleware.py
@@ -88,7 +88,7 @@ class GetPhenopacketsWithOpaTest(APITestCase):
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 1)
 
-    @override_settings(CANDIG_AUTHORIZATION='OPA', CANDIG_OPA_URL='http://0.0.0.0', CACHE_TIME=0)
+    @override_settings(CANDIG_AUTHORIZATION='OPA', OPA_URL='http://0.0.0.0', CACHE_TIME=0)
     def test_get_phenopackets_with_invalid_OPA_config_3(self):
         """
         Test that the server returns 403 for /api/phenopackets if the OPA Server cannot be reached.

--- a/chord_metadata_service/restapi/tests/test_dataset_authz_middleware.py
+++ b/chord_metadata_service/restapi/tests/test_dataset_authz_middleware.py
@@ -88,10 +88,11 @@ class GetPhenopacketsWithOpaTest(APITestCase):
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 1)
 
-    @override_settings(CANDIG_AUTHORIZATION='OPA', CANDIG_OPA_URL='0.0.0.0', CACHE_TIME=0)
+    @override_settings(CANDIG_AUTHORIZATION='OPA', CANDIG_OPA_URL='http://0.0.0.0', CACHE_TIME=0)
     def test_get_phenopackets_with_invalid_OPA_config_3(self):
         """
         Test that the server returns 403 for /api/phenopackets if the OPA Server cannot be reached.
         """
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + "testtesttest")
         response = self.client.get('/api/phenopackets')
         self.assertEqual(response.status_code, 403)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bento-lib==3.2.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@main
 Django==4.1.1
 django-autocomplete-light==3.9.4
 django-cors-headers==3.7.0


### PR DESCRIPTION
Centralize authx methods in the candigv2-authx module. To test, make build-chord-metadata and then make compose-chord-metadata, then check to see if a call like /api/datasets still works as expected; that is, it returns only datasets authorized for that user.