### PR TITLE
Update settings.py

### DIFF
--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -87,8 +87,8 @@ DRS_URL = os.environ.get("DRS_URL", f"http+unix://{NGINX_INTERNAL_SOCKET}/api/dr
 
 CANDIG_AUTHORIZATION = os.getenv("CANDIG_AUTHORIZATION", "")
 CANDIG_OPA_URL = os.getenv("OPA_URL", "")
-CANDIG_OPA_SECRET = os.getenv("CANDIG_OPA_SECRET", "my-secret-beacon-token")
-CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("CANDIG_OPA_SITE_ADMIN_KEY", "site-admin")
+CANDIG_OPA_SECRET = os.getenv("OPA_SECRET", "my-secret-beacon-token")
+CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("OPA_SITE_ADMIN_KEY", "site-admin")
 if exists("/run/secrets/opa-root-token"):
     with open("/run/secrets/opa-root-token", "r") as f:
         CANDIG_OPA_SECRET = f.read()


### PR DESCRIPTION
Related to the switch to candigv2-authx: the default names of the env vars have changed and should be updated.