### PR TITLE
Sonchau/moh part 12

### DIFF
--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -135,9 +135,9 @@ MIDDLEWARE = [
 ]
 
 # This middlewares are specific to the CANDIG service
-if os.getenv("INSIDE_CANDIG", ""):
-    MIDDLEWARE.append('chord_metadata_service.restapi.preflight_req_middleware.PreflightRequestMiddleware')
-    MIDDLEWARE.append('chord_metadata_service.restapi.candig_authz_middleware.CandigAuthzMiddleware')
+# if os.getenv("INSIDE_CANDIG", ""):
+#     MIDDLEWARE.append('chord_metadata_service.restapi.preflight_req_middleware.PreflightRequestMiddleware')
+#     MIDDLEWARE.append('chord_metadata_service.restapi.candig_authz_middleware.CandigAuthzMiddleware')
 
 CORS_ALLOWED_ORIGINS = []
 

--- a/chord_metadata_service/metadata/urls.py
+++ b/chord_metadata_service/metadata/urls.py
@@ -17,16 +17,21 @@ from django.contrib import admin
 from django.urls import path, include
 from chord_metadata_service.restapi import api_views, urls as restapi_urls
 from chord_metadata_service.chord import urls as chord_urls
+from chord_metadata_service.mohpackets import urls as moh_urls
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 # TODO: django.conf.settings breaks reverse(), how to import properly?
 from .settings import DEBUG
 
 urlpatterns = [
-    path('api/', include(restapi_urls)),
-    path('service-info', api_views.service_info, name="service-info"),
-    *chord_urls.urlpatterns,  # TODO: Use include? can we double up?
-    *([path('admin/', admin.site.urls)] if DEBUG else []),
+    # ==== NON CANDIG API ====
+    # path('api/', include(restapi_urls)),
+    # path('service-info', api_views.service_info, name="service-info"),
+    # *chord_urls.urlpatterns,  # TODO: Use include? can we double up?
+    # *([path('admin/', admin.site.urls)] if DEBUG else []),
+    # ==== NON CANDIG API END ====
+    
+    path("api/moh/v1/", include(moh_urls)),
     # OpenAPI 3 documentation with Swagger UI
     path('schema/', SpectacularAPIView.as_view(), name="schema"),
     path('', SpectacularSwaggerView.as_view(), name="swagger-ui"),

--- a/chord_metadata_service/mohpackets/api_views.py
+++ b/chord_metadata_service/mohpackets/api_views.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets
+from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
 from chord_metadata_service.mohpackets.filters import (
     ProgramFilter,
@@ -174,3 +175,24 @@ class ComorbidityViewSet(viewsets.ModelViewSet):
     filterset_class = ComorbidityFilter
     permission_classes = [CanDIGAdminOrReadOnly]
     queryset = Comorbidity.objects.all()
+
+###############################################
+#                                             #
+#           CUSTOM API ENDPOINTS              #
+#                                             #
+###############################################
+
+# TODO: redo this overview endpoint
+def moh_overview(_request):
+    """
+        Return a summary of the statistics for the database:
+        - cohort_count: number of datasets
+        - individual_count: number of individuals
+        - ethnicity: the count of each ethenicity
+        - gender: the count of each gender
+    """
+    return Response({
+        "cohort_count": Program.objects.count(),
+        "individual_count": Donor.objects.count(),
+        # where to get ethnicity and gender?
+    })

--- a/chord_metadata_service/mohpackets/data/README.md
+++ b/chord_metadata_service/mohpackets/data/README.md
@@ -16,7 +16,7 @@ Then, generate the data and download it as a JSON file.
 To convert the JSON file to Django fixtures, use the following command from the root folder:
 
 ```
-    python chord_metadata_service/mohpackets/data/convert.py
+python chord_metadata_service/mohpackets/data/convert.py
 ```
 
 To load the fixtures into local database, you can use the following command from the root folder:
@@ -45,5 +45,5 @@ python manage.py loaddata chord_metadata_service/mohpackets/data/fixtures/Comorb
 *Note:* To clean up data (this will **delete everything** in the database, not just MoH data)
 
 ```
-    python manage.py flush
+python manage.py flush
 ```

--- a/chord_metadata_service/mohpackets/filters.py
+++ b/chord_metadata_service/mohpackets/filters.py
@@ -32,6 +32,7 @@ from chord_metadata_service.mohpackets.models import (
     
 """
 
+
 class ProgramFilter(filters.FilterSet):
     class Meta:
         model = Program
@@ -41,7 +42,7 @@ class ProgramFilter(filters.FilterSet):
 class DonorFilter(filters.FilterSet):
     class Meta:
         model = Donor
-        fields = '__all__'
+        fields = "__all__"
 
 
 class SpecimenFilter(filters.FilterSet):

--- a/chord_metadata_service/mohpackets/models.py
+++ b/chord_metadata_service/mohpackets/models.py
@@ -119,7 +119,7 @@ class SampleRegistration(models.Model):
     sample_type = models.CharField(max_length=128, null=False, blank=False)
 
     def __str__(self):
-        return f"SampleRegistration ID: {self.sample_registration_id}"
+        return f"SampleRegistration ID: {self.submitter_sample_id}"
 
 
 class Treatment(models.Model):

--- a/chord_metadata_service/mohpackets/urls.py
+++ b/chord_metadata_service/mohpackets/urls.py
@@ -1,0 +1,34 @@
+from rest_framework import routers
+from chord_metadata_service.mohpackets.api_views import (
+    ProgramViewSet,
+    DonorViewSet,
+    SpecimenViewSet,
+    SampleRegistrationViewSet,
+    PrimaryDiagnosisViewSet,
+    TreatmentViewSet,
+    ChemotherapyViewSet,
+    HormoneTherapyViewSet,
+    RadiationViewSet,
+    ImmunotherapyViewSet,
+    SurgeryViewSet,
+    FollowUpViewSet,
+    BiomarkerViewSet,
+    ComorbidityViewSet,
+)
+
+router = routers.SimpleRouter()
+router.register(r'programs', ProgramViewSet)
+router.register(r'donors', DonorViewSet)
+router.register(r'specimens', SpecimenViewSet)
+router.register(r'sample_registrations', SampleRegistrationViewSet)
+router.register(r'primary_diagnoses', PrimaryDiagnosisViewSet)
+router.register(r'treatments', TreatmentViewSet)
+router.register(r'chemotherapies', ChemotherapyViewSet)
+router.register(r'hormone_therapies', HormoneTherapyViewSet)
+router.register(r'radiations', RadiationViewSet)
+router.register(r'immunotherapies', ImmunotherapyViewSet)
+router.register(r'surgeries', SurgeryViewSet)
+router.register(r'follow_ups', FollowUpViewSet)
+router.register(r'biomarkers', BiomarkerViewSet)
+router.register(r'comorbidities', ComorbidityViewSet)
+urlpatterns = router.urls


### PR DESCRIPTION
- create some basic urls for the endpoint
- phase out candig middlewares. These parts will be implemented at the query call. This will make it less confusing to see the request flow and keep the decision close to the source as possible. It also makes testing easier.