### PR TITLE
Add sha to schema description

### DIFF
--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -78,8 +78,7 @@ jobs:
             // Update description to include sha
             let schemaLines = schemaYml.split('\n')
             for (let i = 0; i < schemaLines.length; ++i) {
-              let descMatch = /description: This is the RESTful API for the MoH Service./.exec(schemaLines[i]);
-              if (descMatch) {
+              if ("description: This is the RESTful API for the MoH Service." === schemaLines[i].trim()) {
                 schemaLines[i] += ' Based on commit "' + schemaSha + '".';
               }
             }

--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -30,10 +30,10 @@ jobs:
       - name: Create package.json file
         run: |
           echo '{"name": "my-project", "version": "1.0.0"}' > package.json
-          
+
       - name: Install npm
         run: npm install
-      
+
       - name: Install widdershins
         run: npm install -g widdershins
 
@@ -43,7 +43,7 @@ jobs:
       - name: Convert schema to OpenAPI documentation
         run: |
           npx widdershins ./chord_metadata_service/mohpackets/docs/schema.yml -o ./chord_metadata_service/mohpackets/docs/openapi.md -u ./chord_metadata_service/mohpackets/docs/widdershins/templates/openapi3 -c true --omitHeader true
-      
+
       - name: Install octokit/rest
         run: npm install @octokit/rest
 
@@ -66,13 +66,22 @@ jobs:
               });
               return data.sha;
             }
-            
+
             const schemaSha = await getFileSha('schema.yml');
             const openApiSha = await getFileSha('openapi.md');
 
             // Read the content of updated files
-            const schemaYml = fs.readFileSync(`./${repoPath}schema.yml`, 'utf8');
+            let schemaYml = fs.readFileSync(`./${repoPath}schema.yml`, 'utf8');
             const openApiMd = fs.readFileSync(`./${repoPath}openapi.md`, 'utf8');
+
+            // Update description to include sha
+            let schemaLines = schemaYml.split('\n')
+            for (let i = 0; i < schemaLines.length; ++i) {
+              if /description: This is the RESTful API for the MoH Service./.exec(schemaLines[i]) {
+                schemaLines[i] += ' Based on commit "' + schemaSha + '".'
+              }
+            }
+            schemaYml = schemaLines.join('\n')
 
             // Commit and push changes
             await octokit.request(`PUT /repos/{owner}/{repo}/contents/${repoPath}{path}`, {
@@ -95,6 +104,6 @@ jobs:
               branch: `${{ github.head_ref }}`
             });
 
-          
+
 
 

--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -3,7 +3,6 @@ name: Docs
 on:
   pull_request:
     types: [review_requested, ready_for_review]
-  workflow_dispatch:
 
 jobs:
   generate-moh-schema:

--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -76,13 +76,14 @@ jobs:
             const openApiMd = fs.readFileSync(`./${repoPath}openapi.md`, 'utf8');
 
             // Update description to include sha
-            let schemaLines = schemaYml.split('\n')
+            let schemaLines = schemaYml.split('\n');
             for (let i = 0; i < schemaLines.length; ++i) {
               if ("description: This is the RESTful API for the MoH Service." === schemaLines[i].trim()) {
                 schemaLines[i] += ' Based on commit "' + schemaSha + '".';
               }
             }
-            schemaYml = schemaLines.join('\n')
+            schemaYml = schemaLines.join('\n');
+            fs.writeFileSync(`./${repoPath}schema.yml`, schemaYml, 'utf8');
 
             // Commit and push changes
             await octokit.request(`PUT /repos/{owner}/{repo}/contents/${repoPath}{path}`, {

--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -89,7 +89,7 @@ jobs:
             let schemaLines = schemaYml.split('\n');
             for (let i = 0; i < schemaLines.length; ++i) {
               if ("description: This is the RESTful API for the MoH Service." === schemaLines[i].trim()) {
-                schemaLines[i] += ' Based on commit "' + schemaSha + '".';
+                schemaLines[i] += ' Based on commit "' + repoSha + '".';
               }
             }
             schemaYml = schemaLines.join('\n');

--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -3,6 +3,7 @@ name: Docs
 on:
   pull_request:
     types: [review_requested, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   generate-moh-schema:

--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -67,14 +67,25 @@ jobs:
               return data.sha;
             }
 
+            // get last commit sha for repo
+            const getRepoSha = async () => {
+              const { data } = await octokit.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `${{ github.head_ref }}`
+              });
+              return data.sha;
+            }
+
             const schemaSha = await getFileSha('schema.yml');
             const openApiSha = await getFileSha('openapi.md');
+            const repoSha = await getRepoSha();
 
             // Read the content of updated files
             let schemaYml = fs.readFileSync(`./${repoPath}schema.yml`, 'utf8');
             const openApiMd = fs.readFileSync(`./${repoPath}openapi.md`, 'utf8');
 
-            // Update description to include sha
+            // Update description to include sha of
             let schemaLines = schemaYml.split('\n');
             for (let i = 0; i < schemaLines.length; ++i) {
               if ("description: This is the RESTful API for the MoH Service." === schemaLines[i].trim()) {

--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -78,8 +78,9 @@ jobs:
             // Update description to include sha
             let schemaLines = schemaYml.split('\n')
             for (let i = 0; i < schemaLines.length; ++i) {
-              if /description: This is the RESTful API for the MoH Service./.exec(schemaLines[i]) {
-                schemaLines[i] += ' Based on commit "' + schemaSha + '".'
+              let descMatch = /description: This is the RESTful API for the MoH Service./.exec(schemaLines[i]);
+              if (descMatch) {
+                schemaLines[i] += ' Based on commit "' + schemaSha + '".';
               }
             }
             schemaYml = schemaLines.join('\n')

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "f55a803eb81688294595a746480c91c6f94b915d".
+  description: This is the RESTful API for the MoH Service. Based on commit "5b1eb57c863f5379649ccbfa93ca07b100663792".
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "c7543f8c3d8d6627c46ff782da761013150233c5".
+  description: This is the RESTful API for the MoH Service. Based on commit "9702325aecdb0634053bbe27f23f7146a66e30c7".
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "5ccf376ca62fdf22c9de5b389ea7fe342547eb52".
+  description: This is the RESTful API for the MoH Service. Based on commit "aea2d6b78812c1a66dd3d766399fda48bfa13902".
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "4b7838270e993d49383b9183b3e03725ebabf687".
+  description: This is the RESTful API for the MoH Service. Based on commit "c7543f8c3d8d6627c46ff782da761013150233c5".
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "5b1eb57c863f5379649ccbfa93ca07b100663792".
+  description: This is the RESTful API for the MoH Service. Based on commit "5ccf376ca62fdf22c9de5b389ea7fe342547eb52".
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "9702325aecdb0634053bbe27f23f7146a66e30c7".
+  description: This is the RESTful API for the MoH Service. Based on commit "961f3d59aab1db9830a57fb5e1bbc9a81aa2d33b".
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "45cf1f48d25b107d9d0eb02281321a648a248710".
+  description: This is the RESTful API for the MoH Service. Based on commit "f55a803eb81688294595a746480c91c6f94b915d".
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service.
+  description: This is the RESTful API for the MoH Service. Based on commit "4b7838270e993d49383b9183b3e03725ebabf687".
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "961f3d59aab1db9830a57fb5e1bbc9a81aa2d33b".
+  description: This is the RESTful API for the MoH Service. Based on commit "45cf1f48d25b107d9d0eb02281321a648a248710".
 paths:
   /v2/authorized/biomarkers/:
     get:


### PR DESCRIPTION
I updated the schema generation action so that it adds the head ref sha (or at least the last known sha) to the description in the OpenAPI schema.

You can test this by looking at the sha listed in the description, e.g.
```
 description: This is the RESTful API for the MoH Service. Based on commit "5ccf376ca62fdf22c9de5b389ea7fe342547eb52".
```

and checking it out in katsu:
```
cd lib/katsu/katsu_service
git checkout -b test 5ccf376ca62fdf22c9de5b389ea7fe342547eb52
git log
```

and see that the top of the log is the last commit of the branch.

```
commit 5ccf376ca62fdf22c9de5b389ea7fe342547eb52 (HEAD -> test, origin/daisieh/github-sha, daisieh/github-sha)
Merge: e2a7ed63 19a643b1
Author: Daisie Huang <daisieh@gmail.com>
Date:   Fri Jun 9 11:24:11 2023 -0700
```