### PR TITLE
Sonchau/service info

### DIFF
--- a/chord_metadata_service/mohpackets/api_discovery.py
+++ b/chord_metadata_service/mohpackets/api_discovery.py
@@ -502,7 +502,7 @@ def service_info(_request):
     return JsonResponse(
         {
             "name": "katsu",
-            "description": "A CanDIG clinical service",
+            "description": "A CanDIG clinical data service",
             "version": settings.KATSU_VERSION,
             "schema_url": schema_url,
         },

--- a/chord_metadata_service/mohpackets/api_discovery.py
+++ b/chord_metadata_service/mohpackets/api_discovery.py
@@ -1,7 +1,6 @@
 from collections import Counter, defaultdict
 from datetime import date, datetime
 
-import yaml
 from django.conf import settings
 from django.db.models import Count
 from django.http import JsonResponse

--- a/chord_metadata_service/mohpackets/api_discovery.py
+++ b/chord_metadata_service/mohpackets/api_discovery.py
@@ -46,7 +46,7 @@ from chord_metadata_service.mohpackets.permissible_values import (
 )
 from chord_metadata_service.mohpackets.throttling import MoHRateThrottle
 
-from .utils import get_schema_version
+from .utils import get_schema_url
 
 """
     This module inheriting from the base views and adding the discovery mixin,
@@ -498,14 +498,14 @@ def diagnosis_age_count(_request):
 )
 @api_view(["GET"])
 def service_info(_request):
-    schema_version = get_schema_version()
+    schema_url = get_schema_url()
 
     return JsonResponse(
         {
             "name": "katsu",
             "description": "A CanDIG clinical service",
             "version": settings.KATSU_VERSION,
-            "schema": schema_version,
+            "schema_url": schema_url,
         },
         status=status.HTTP_200_OK,
         safe=False,

--- a/chord_metadata_service/mohpackets/api_ingest.py
+++ b/chord_metadata_service/mohpackets/api_ingest.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.db import transaction
-from django.http import JsonResponse
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -27,7 +26,6 @@ from chord_metadata_service.mohpackets.serializers import (
     SurgerySerializer,
     TreatmentSerializer,
 )
-from chord_metadata_service.mohpackets.utils import __version__
 
 """
     This module contains the API endpoints for ingesting bulk data into the database.
@@ -452,12 +450,3 @@ def ingest_exposures(request):
         status=status.HTTP_201_CREATED,
         data={f"{len(objs)} exposures were created."},
     )
-
-
-@extend_schema(
-    responses={200: OpenApiTypes.STR},
-)
-@api_view(["GET"])
-@permission_classes([CanDIGAdminOrReadOnly])
-def version_check(_request):
-    return JsonResponse({"version": __version__}, status=status.HTTP_200_OK)

--- a/chord_metadata_service/mohpackets/docs/openapi.md
+++ b/chord_metadata_service/mohpackets/docs/openapi.md
@@ -1,5 +1,5 @@
 
-<h1 id="moh-service-api">MoH Service API v1.0.0</h1>
+<h1 id="moh-service-api">MoH Service API v2.3.0</h1>
 
 This is the RESTful API for the MoH Service.
 

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 2.3.0
-  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/562fa54db3491234a37cee39d9941f2b4badc5da/chord_metadata_service/mohpackets/docs/schema.yml
+  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/f4e61b81936a555c6bc7552745a1ae03a838fe2c/chord_metadata_service/mohpackets/docs/schema.yml
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
   title: MoH Service API
-  version: 1.0.0
-  description: This is the RESTful API for the MoH Service. Based on commit "cf86bc4ed0ab83f1fa54e2e58a74f6be965455e0".
+  version: 2.3.0
+  description: This is the RESTful API for the MoH Service.
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: MoH Service API
   version: 2.3.0
-  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/556b96e26385c4f5f0f7327cb8420809a2e64f8a/chord_metadata_service/mohpackets/docs/schema.yml
+  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/562fa54db3491234a37cee39d9941f2b4badc5da/chord_metadata_service/mohpackets/docs/schema.yml
 paths:
   /v2/authorized/biomarkers/:
     get:

--- a/chord_metadata_service/mohpackets/urls.py
+++ b/chord_metadata_service/mohpackets/urls.py
@@ -41,6 +41,7 @@ from chord_metadata_service.mohpackets.api_discovery import (
     gender_count,
     individual_count,
     patient_per_cohort_count,
+    service_info,
     treatment_type_count,
 )
 from chord_metadata_service.mohpackets.api_ingest import (
@@ -59,7 +60,6 @@ from chord_metadata_service.mohpackets.api_ingest import (
     ingest_specimens,
     ingest_surgeries,
     ingest_treatments,
-    version_check,
 )
 
 # ================== AUTHORIZED API ================== #
@@ -123,7 +123,7 @@ urlpatterns = [
     path("authorized/", include(router.urls)),
     path("discovery/", include(discovery_router.urls)),
     path("ingest/", include(ingest_patterns)),
-    path("version_check", version_check),
+    path("service-info", service_info),
     path(
         "discovery/overview/",
         include(

--- a/chord_metadata_service/mohpackets/utils.py
+++ b/chord_metadata_service/mohpackets/utils.py
@@ -1,7 +1,10 @@
+import logging
 import re
 
 import yaml
 from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
 
 
 def get_schema_url():
@@ -25,5 +28,8 @@ def get_schema_url():
                 # Cache the schema_version so we won't read it each time
                 cache.set("schema_url", schema_url)
         except Exception as e:
+            logger.debug(
+                f"An error occurred while fetching the schema URL. Details: {str(e)}"
+            )
             schema_url = None
     return schema_url

--- a/chord_metadata_service/mohpackets/utils.py
+++ b/chord_metadata_service/mohpackets/utils.py
@@ -1,82 +1,18 @@
-import os
-import subprocess
-
-#####################################################
-#                                                   #
-#   CURRENT KATSU VERSION, MAKE CHANGE IF NEEDED    #
-#                                                   #
-#####################################################
-
-# Format: major.minor.patch.status
-VERSION = (2, 3, 0, "stable")
+import yaml
+from django.core.cache import cache
 
 
-def get_version():
-    """
-    Returns a version number in a standard format
-
-    Versioning Stages:
-        - Dev: work in progress during active development.
-        - Alpha: early releases with new features for testing
-        - Beta: later releases, some bugs may still exist.
-        - RC: stable releases pending user testing and feedback.
-        - Stable: ready for production.
-
-    Examples:
-        >>> VERSION = (1, 0, 0, "dev")
-        >>> get_version()
-        '1.0.0.dev<git_hash>'
-
-        >>> VERSION = (1, 0, 0, "alpha")
-        >>> get_version()
-        '1.0.0.a'
-
-        >>> VERSION = (1, 0, 0, "beta")
-        >>> get_version()
-        '1.0.0.b'
-
-        >>> VERSION = (1, 0, 0, "rc")
-        >>> get_version()
-        '1.0.0.rc'
-
-        >>> VERSION = (1, 0, 0, "stable")
-        >>> get_version()
-        '1.0.0'
-    """
-
-    major, minor, patch, status = VERSION[:4]
-
-    version_string = f"{major}.{minor}.{patch}"
-
-    if status == "dev":
-        git_hash = get_git_hash()
-        version_string += f".dev.{git_hash}" if git_hash is not None else ".dev"
-    elif status in ("alpha", "beta", "rc"):
-        version_string += f".{status[0]}"
-    elif status != "stable":
-        return "Invalid version"
-
-    return version_string
-
-
-def get_git_hash():
-    """Return the git hash of the latest changeset."""
-    try:
-        # Repository may not be found if __file__ is undefined, e.g. in a frozen module.
-        if "__file__" not in globals():
-            return None
-        repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        git_log = subprocess.run(
-            "git rev-parse --short HEAD",
-            capture_output=True,
-            shell=True,
-            cwd=repo_dir,
-            text=True,
-        )
-        git_hash = git_log.stdout.strip()
-        return git_hash
-    except Exception:
-        return None
-
-
-__version__ = get_version()
+def get_schema_version():
+    schema_version = cache.get("schema_version")
+    if schema_version is None:
+        try:
+            with open(
+                "chord_metadata_service/mohpackets/docs/schema.yml", "r"
+            ) as yaml_file:
+                data = yaml.safe_load(yaml_file)
+                schema_version = data["info"]["version"]
+                # Cache the schema_version so we won't read it each time
+                cache.set("schema_version", schema_version)
+        except Exception as e:
+            schema_version = None
+    return schema_version

--- a/chord_metadata_service/mohpackets/utils.py
+++ b/chord_metadata_service/mohpackets/utils.py
@@ -1,18 +1,29 @@
+import re
+
 import yaml
 from django.core.cache import cache
 
 
-def get_schema_version():
-    schema_version = cache.get("schema_version")
-    if schema_version is None:
+def get_schema_url():
+    """
+    Retrieve the schema URL either from cached or by parsing a YAML file.
+    It first checks if the URL is cached in "schema_url".
+    If not cached, it reads the YAML file and extracts the URL from the "description".
+    """
+
+    schema_url = cache.get("schema_url")
+    url_pattern = r"https://[^\s]+"  # get everything after https
+
+    if schema_url is None:
         try:
             with open(
                 "chord_metadata_service/mohpackets/docs/schema.yml", "r"
             ) as yaml_file:
                 data = yaml.safe_load(yaml_file)
-                schema_version = data["info"]["version"]
+                desc_str = data["info"]["description"]
+                schema_url = re.search(url_pattern, desc_str).group()
                 # Cache the schema_version so we won't read it each time
-                cache.set("schema_version", schema_version)
+                cache.set("schema_url", schema_url)
         except Exception as e:
-            schema_version = None
-    return schema_version
+            schema_url = None
+    return schema_url

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: false

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -208,13 +208,18 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {"moh_rate_limit": "60/minute"},
 }
 
+# CURRENT KATSU VERSION ACCORDING TO MODEL CHANGES
+# ------------------------------------------------
+
+KATSU_VERSION = "2.3.0"
+
 # DRF Spectacular settings
 # ------------------------
 
 SPECTACULAR_SETTINGS = {
     "TITLE": "MoH Service API",
     "DESCRIPTION": ("This is the RESTful API for the MoH Service."),
-    "VERSION": "1.0.0",
+    "VERSION": KATSU_VERSION,
     # include schema endpoint into schema
     "SERVE_INCLUDE_SCHEMA": False,
     # Filter out the url patterns we don't want documented


### PR DESCRIPTION
#### What's new:

- Renamed the endpoint from "version_check" to "service-info" for consistency with other services.
- Moved "service-info" to the "discovery" section instead of "ingest."
- Updated return details to include the schema used.
- Reworked the "katsu" version, which is now moved into settings.
- Improved the schema to include the "katsu" version instead of the static "1.0.0."

#### How to test:
- Open "/v2/service-info" and observe the response in the following format:

```
  {
            "name": "katsu",
            "description": "A CanDIG clinical service",
            "version": ...,
            "schema_url": ...,
   }
```