### PR TITLE
katsu validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ tox
 Run all tests for mohpackets:
 
 ```bash
-python manage.py test chord_metadata_service.mohpackets
+python manage.py test chord_metadata_service/mohpackets/tests/
 ```
 
 Run each test:
 
 ```bash
-python manage.py test chord_metadata_service.mohpackets.tests.<test_name>
+python manage.py test chord_metadata_service.mohpackets.tests.endpoints.<test_name>
 ```
 
 Test and create `coverage` HTML report:

--- a/chord_metadata_service/mohpackets/docs/schema.json
+++ b/chord_metadata_service/mohpackets/docs/schema.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "MoH Service API",
         "version": "3.0.0",
-        "description": "This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/5c640ce73d080b89ec2bdd80857bf826213dab04/chord_metadata_service/mohpackets/docs/schema.json"
+        "description": "This is the RESTful API for the MoH Service."
     },
     "paths": {
         "/v2/service-info": {
@@ -4822,16 +4822,10 @@
             "ProgramIngestSchema": {
                 "properties": {
                     "program_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Program Id"
+                        "maxLength": 64,
+                        "pattern": "^[A-Za-z0-9\\-\\._]{1,64}",
+                        "title": "Program Id",
+                        "type": "string"
                     },
                     "metadata": {
                         "anyOf": [
@@ -4855,2140 +4849,11 @@
                         "type": "string"
                     }
                 },
-                "title": "ProgramIngestSchema",
-                "type": "object"
-            },
-            "DonorIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "gender": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Gender"
-                    },
-                    "sex_at_birth": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Sex At Birth"
-                    },
-                    "is_deceased": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Is Deceased"
-                    },
-                    "lost_to_followup_after_clinical_event_identifier": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Lost To Followup After Clinical Event Identifier"
-                    },
-                    "lost_to_followup_reason": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Lost To Followup Reason"
-                    },
-                    "date_alive_after_lost_to_followup": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Date Alive After Lost To Followup"
-                    },
-                    "cause_of_death": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cause Of Death"
-                    },
-                    "date_of_birth": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Date Of Birth"
-                    },
-                    "date_of_death": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Date Of Death"
-                    },
-                    "primary_site": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Primary Site"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id"
-                ],
-                "title": "DonorIngestSchema",
-                "type": "object"
-            },
-            "BiomarkerIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_specimen_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Specimen Id"
-                    },
-                    "submitter_primary_diagnosis_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Primary Diagnosis Id"
-                    },
-                    "submitter_treatment_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Treatment Id"
-                    },
-                    "submitter_follow_up_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Follow Up Id"
-                    },
-                    "test_date": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Test Date"
-                    },
-                    "psa_level": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Psa Level"
-                    },
-                    "ca125": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Ca125"
-                    },
-                    "cea": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cea"
-                    },
-                    "er_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Er Status"
-                    },
-                    "er_percent_positive": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Er Percent Positive"
-                    },
-                    "pr_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pr Status"
-                    },
-                    "pr_percent_positive": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pr Percent Positive"
-                    },
-                    "her2_ihc_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Her2 Ihc Status"
-                    },
-                    "her2_ish_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Her2 Ish Status"
-                    },
-                    "hpv_ihc_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Hpv Ihc Status"
-                    },
-                    "hpv_pcr_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Hpv Pcr Status"
-                    },
-                    "hpv_strain": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Hpv Strain"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id"
-                ],
-                "title": "BiomarkerIngestSchema",
-                "type": "object"
-            },
-            "ChemotherapyIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_treatment_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Treatment Id",
-                        "type": "string"
-                    },
-                    "drug_reference_database": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Reference Database"
-                    },
-                    "drug_name": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Name"
-                    },
-                    "drug_reference_identifier": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Reference Identifier"
-                    },
-                    "chemotherapy_drug_dose_units": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Chemotherapy Drug Dose Units"
-                    },
-                    "prescribed_cumulative_drug_dose": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Prescribed Cumulative Drug Dose"
-                    },
-                    "actual_cumulative_drug_dose": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Actual Cumulative Drug Dose"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id",
-                    "submitter_treatment_id"
-                ],
-                "title": "ChemotherapyIngestSchema",
-                "type": "object"
-            },
-            "ComorbidityIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "prior_malignancy": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Prior Malignancy"
-                    },
-                    "laterality_of_prior_malignancy": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Laterality Of Prior Malignancy"
-                    },
-                    "age_at_comorbidity_diagnosis": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Age At Comorbidity Diagnosis"
-                    },
-                    "comorbidity_type_code": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Comorbidity Type Code"
-                    },
-                    "comorbidity_treatment_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Comorbidity Treatment Status"
-                    },
-                    "comorbidity_treatment": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Comorbidity Treatment"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id"
-                ],
-                "title": "ComorbidityIngestSchema",
-                "type": "object"
-            },
-            "ExposureIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "tobacco_smoking_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tobacco Smoking Status"
-                    },
-                    "tobacco_type": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tobacco Type"
-                    },
-                    "pack_years_smoked": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pack Years Smoked"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id"
-                ],
-                "title": "ExposureIngestSchema",
-                "type": "object"
-            },
-            "FollowUpIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "treatment_uuid_id": {
-                        "anyOf": [
-                            {
-                                "format": "uuid",
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Treatment Uuid"
-                    },
-                    "primary_diagnosis_uuid_id": {
-                        "anyOf": [
-                            {
-                                "format": "uuid",
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Primary Diagnosis Uuid"
-                    },
-                    "submitter_follow_up_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Follow Up Id",
-                        "type": "string"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_primary_diagnosis_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Primary Diagnosis Id"
-                    },
-                    "submitter_treatment_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Treatment Id"
-                    },
-                    "date_of_followup": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Date Of Followup"
-                    },
-                    "disease_status_at_followup": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Disease Status At Followup"
-                    },
-                    "relapse_type": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Relapse Type"
-                    },
-                    "date_of_relapse": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Date Of Relapse"
-                    },
-                    "method_of_progression_status": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Method Of Progression Status"
-                    },
-                    "anatomic_site_progression_or_recurrence": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Anatomic Site Progression Or Recurrence"
-                    },
-                    "recurrence_tumour_staging_system": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Recurrence Tumour Staging System"
-                    },
-                    "recurrence_t_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Recurrence T Category"
-                    },
-                    "recurrence_n_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Recurrence N Category"
-                    },
-                    "recurrence_m_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Recurrence M Category"
-                    },
-                    "recurrence_stage_group": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Recurrence Stage Group"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_follow_up_id",
-                    "submitter_donor_id"
-                ],
-                "title": "FollowUpIngestSchema",
-                "type": "object"
-            },
-            "HormoneTherapyIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_treatment_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Treatment Id",
-                        "type": "string"
-                    },
-                    "drug_reference_database": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Reference Database"
-                    },
-                    "drug_name": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Name"
-                    },
-                    "drug_reference_identifier": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Reference Identifier"
-                    },
-                    "hormone_drug_dose_units": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Hormone Drug Dose Units"
-                    },
-                    "prescribed_cumulative_drug_dose": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Prescribed Cumulative Drug Dose"
-                    },
-                    "actual_cumulative_drug_dose": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Actual Cumulative Drug Dose"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id",
-                    "submitter_treatment_id"
-                ],
-                "title": "HormoneTherapyIngestSchema",
-                "type": "object"
-            },
-            "ImmunotherapyIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_treatment_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Treatment Id",
-                        "type": "string"
-                    },
-                    "drug_reference_database": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Reference Database"
-                    },
-                    "immunotherapy_type": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Immunotherapy Type"
-                    },
-                    "drug_name": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Name"
-                    },
-                    "drug_reference_identifier": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Drug Reference Identifier"
-                    },
-                    "immunotherapy_drug_dose_units": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Immunotherapy Drug Dose Units"
-                    },
-                    "prescribed_cumulative_drug_dose": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Prescribed Cumulative Drug Dose"
-                    },
-                    "actual_cumulative_drug_dose": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Actual Cumulative Drug Dose"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id",
-                    "submitter_treatment_id"
-                ],
-                "title": "ImmunotherapyIngestSchema",
-                "type": "object"
-            },
-            "PrimaryDiagnosisIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_primary_diagnosis_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Primary Diagnosis Id"
-                    },
-                    "submitter_donor_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Donor Id"
-                    },
-                    "date_of_diagnosis": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Date Of Diagnosis"
-                    },
-                    "cancer_type_code": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cancer Type Code"
-                    },
-                    "basis_of_diagnosis": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Basis Of Diagnosis"
-                    },
-                    "laterality": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Laterality"
-                    },
-                    "lymph_nodes_examined_status": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Lymph Nodes Examined Status"
-                    },
-                    "lymph_nodes_examined_method": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Lymph Nodes Examined Method"
-                    },
-                    "number_lymph_nodes_positive": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Number Lymph Nodes Positive"
-                    },
-                    "clinical_tumour_staging_system": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Clinical Tumour Staging System"
-                    },
-                    "clinical_t_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Clinical T Category"
-                    },
-                    "clinical_n_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Clinical N Category"
-                    },
-                    "clinical_m_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Clinical M Category"
-                    },
-                    "clinical_stage_group": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Clinical Stage Group"
-                    }
-                },
                 "required": [
                     "program_id"
                 ],
-                "title": "PrimaryDiagnosisIngestSchema",
+                "title": "ProgramIngestSchema",
                 "type": "object"
-            },
-            "RadiationIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_treatment_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Treatment Id",
-                        "type": "string"
-                    },
-                    "radiation_therapy_modality": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Radiation Therapy Modality"
-                    },
-                    "radiation_therapy_type": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Radiation Therapy Type"
-                    },
-                    "radiation_therapy_fractions": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Radiation Therapy Fractions"
-                    },
-                    "radiation_therapy_dosage": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Radiation Therapy Dosage"
-                    },
-                    "anatomical_site_irradiated": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Anatomical Site Irradiated"
-                    },
-                    "radiation_boost": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Radiation Boost"
-                    },
-                    "reference_radiation_treatment_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Reference Radiation Treatment Id"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id",
-                    "submitter_treatment_id"
-                ],
-                "title": "RadiationIngestSchema",
-                "type": "object"
-            },
-            "SampleRegistrationIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_sample_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Sample Id",
-                        "type": "string"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_specimen_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Specimen Id",
-                        "type": "string"
-                    },
-                    "specimen_tissue_source": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Specimen Tissue Source"
-                    },
-                    "tumour_normal_designation": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tumour Normal Designation"
-                    },
-                    "specimen_type": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Specimen Type"
-                    },
-                    "sample_type": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Sample Type"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_sample_id",
-                    "submitter_donor_id",
-                    "submitter_specimen_id"
-                ],
-                "title": "SampleRegistrationIngestSchema",
-                "type": "object"
-            },
-            "SpecimenIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_specimen_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Specimen Id",
-                        "type": "string"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_primary_diagnosis_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Primary Diagnosis Id",
-                        "type": "string"
-                    },
-                    "pathological_tumour_staging_system": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pathological Tumour Staging System"
-                    },
-                    "pathological_t_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pathological T Category"
-                    },
-                    "pathological_n_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pathological N Category"
-                    },
-                    "pathological_m_category": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pathological M Category"
-                    },
-                    "pathological_stage_group": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Pathological Stage Group"
-                    },
-                    "specimen_collection_date": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Specimen Collection Date"
-                    },
-                    "specimen_storage": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Specimen Storage"
-                    },
-                    "specimen_processing": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Specimen Processing"
-                    },
-                    "tumour_histological_type": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tumour Histological Type"
-                    },
-                    "specimen_anatomic_location": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Specimen Anatomic Location"
-                    },
-                    "specimen_laterality": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Specimen Laterality"
-                    },
-                    "reference_pathology_confirmed_diagnosis": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Reference Pathology Confirmed Diagnosis"
-                    },
-                    "reference_pathology_confirmed_tumour_presence": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Reference Pathology Confirmed Tumour Presence"
-                    },
-                    "tumour_grading_system": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tumour Grading System"
-                    },
-                    "tumour_grade": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tumour Grade"
-                    },
-                    "percent_tumour_cells_range": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Percent Tumour Cells Range"
-                    },
-                    "percent_tumour_cells_measurement_method": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Percent Tumour Cells Measurement Method"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_specimen_id",
-                    "submitter_donor_id",
-                    "submitter_primary_diagnosis_id"
-                ],
-                "title": "SpecimenIngestSchema",
-                "type": "object"
-            },
-            "SurgeryIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_treatment_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Treatment Id",
-                        "type": "string"
-                    },
-                    "submitter_specimen_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Submitter Specimen Id"
-                    },
-                    "surgery_type": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Surgery Type"
-                    },
-                    "surgery_site": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Surgery Site"
-                    },
-                    "surgery_location": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Surgery Location"
-                    },
-                    "tumour_length": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tumour Length"
-                    },
-                    "tumour_width": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tumour Width"
-                    },
-                    "greatest_dimension_tumour": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Greatest Dimension Tumour"
-                    },
-                    "tumour_focality": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Tumour Focality"
-                    },
-                    "residual_tumour_classification": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Residual Tumour Classification"
-                    },
-                    "margin_types_involved": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Margin Types Involved"
-                    },
-                    "margin_types_not_involved": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Margin Types Not Involved"
-                    },
-                    "margin_types_not_assessed": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Margin Types Not Assessed"
-                    },
-                    "lymphovascular_invasion": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Lymphovascular Invasion"
-                    },
-                    "perineural_invasion": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Perineural Invasion"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_donor_id",
-                    "submitter_treatment_id"
-                ],
-                "title": "SurgeryIngestSchema",
-                "type": "object"
-            },
-            "TreatmentIngestSchema": {
-                "properties": {
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Uuid"
-                    },
-                    "submitter_treatment_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Treatment Id",
-                        "type": "string"
-                    },
-                    "submitter_donor_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "submitter_primary_diagnosis_id": {
-                        "maxLength": 64,
-                        "title": "Submitter Primary Diagnosis Id",
-                        "type": "string"
-                    },
-                    "treatment_type": {
-                        "anyOf": [
-                            {
-                                "items": {},
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Treatment Type"
-                    },
-                    "is_primary_treatment": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Is Primary Treatment"
-                    },
-                    "line_of_treatment": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Line Of Treatment"
-                    },
-                    "treatment_start_date": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Treatment Start Date"
-                    },
-                    "treatment_end_date": {
-                        "anyOf": [
-                            {
-                                "maxLength": 32,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Treatment End Date"
-                    },
-                    "treatment_setting": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Treatment Setting"
-                    },
-                    "treatment_intent": {
-                        "anyOf": [
-                            {
-                                "maxLength": 128,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Treatment Intent"
-                    },
-                    "days_per_cycle": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Days Per Cycle"
-                    },
-                    "number_of_cycles": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Number Of Cycles"
-                    },
-                    "response_to_treatment_criteria_method": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Response To Treatment Criteria Method"
-                    },
-                    "response_to_treatment": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Response To Treatment"
-                    },
-                    "status_of_treatment": {
-                        "anyOf": [
-                            {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Status Of Treatment"
-                    }
-                },
-                "required": [
-                    "program_id",
-                    "submitter_treatment_id",
-                    "submitter_donor_id",
-                    "submitter_primary_diagnosis_id"
-                ],
-                "title": "TreatmentIngestSchema",
-                "type": "object"
-            },
-            "BasisOfDiagnosisEnum": {
-                "enum": [
-                    "Clinical investigation",
-                    "Clinical",
-                    "Cytology",
-                    "Death certificate only",
-                    "Histology of a metastasis",
-                    "Histology of a primary tumour",
-                    "Specific tumour markers",
-                    "Unknown"
-                ],
-                "title": "BasisOfDiagnosisEnum",
-                "type": "string"
             },
             "CauseOfDeathEnum": {
                 "enum": [
@@ -6999,50 +4864,12 @@
                 "title": "CauseOfDeathEnum",
                 "type": "string"
             },
-            "CellsMeasureMethodEnum": {
-                "enum": [
-                    "Genomics",
-                    "Image analysis",
-                    "Pathology estimate by percent nuclei",
-                    "Unknown"
-                ],
-                "title": "CellsMeasureMethodEnum",
-                "type": "string"
-            },
-            "ConfirmedDiagnosisTumourEnum": {
-                "enum": [
-                    "Yes",
-                    "No",
-                    "Not done",
-                    "Unknown"
-                ],
-                "title": "ConfirmedDiagnosisTumourEnum",
-                "type": "string"
-            },
-            "DiseaseStatusFollowupEnum": {
-                "enum": [
-                    "Complete remission",
-                    "Distant progression",
-                    "Loco-regional progression",
-                    "No evidence of disease",
-                    "Partial remission",
-                    "Progression not otherwise specified",
-                    "Relapse or recurrence",
-                    "Stable"
-                ],
-                "title": "DiseaseStatusFollowupEnum",
-                "type": "string"
-            },
-            "DonorWithClinicalDataSchema": {
+            "DonorIngestSchema": {
                 "properties": {
                     "submitter_donor_id": {
                         "maxLength": 64,
                         "pattern": "^[A-Za-z0-9\\-\\._]{1,64}",
                         "title": "Submitter Donor Id",
-                        "type": "string"
-                    },
-                    "program_id": {
-                        "title": "Program Id",
                         "type": "string"
                     },
                     "gender": {
@@ -7161,6 +4988,3245 @@
                         ],
                         "title": "Primary Site"
                     },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "submitter_donor_id",
+                    "program_id"
+                ],
+                "title": "DonorIngestSchema",
+                "type": "object"
+            },
+            "GenderEnum": {
+                "enum": [
+                    "Man",
+                    "Woman",
+                    "Non-binary"
+                ],
+                "title": "GenderEnum",
+                "type": "string"
+            },
+            "LostToFollowupReasonEnum": {
+                "enum": [
+                    "Completed study",
+                    "Discharged to palliative care",
+                    "Lost contact",
+                    "Not applicable",
+                    "Unknown",
+                    "Withdrew from study"
+                ],
+                "title": "LostToFollowupReasonEnum",
+                "type": "string"
+            },
+            "PrimarySiteEnum": {
+                "enum": [
+                    "Accessory sinuses",
+                    "Adrenal gland",
+                    "Anus and anal canal",
+                    "Base of tongue",
+                    "Bladder",
+                    "Bones, joints and articular cartilage of limbs",
+                    "Bones, joints and articular cartilage of other and unspecified sites",
+                    "Brain",
+                    "Breast",
+                    "Bronchus and lung",
+                    "Cervix uteri",
+                    "Colon",
+                    "Connective, subcutaneous and other soft tissues",
+                    "Corpus uteri",
+                    "Esophagus",
+                    "Eye and adnexa",
+                    "Floor of mouth",
+                    "Gallbladder",
+                    "Gum",
+                    "Heart, mediastinum, and pleura",
+                    "Hematopoietic and reticuloendothelial systems",
+                    "Hypopharynx",
+                    "Kidney",
+                    "Larynx",
+                    "Lip",
+                    "Liver and intrahepatic bile ducts",
+                    "Lymph nodes",
+                    "Meninges",
+                    "Nasal cavity and middle ear",
+                    "Nasopharynx",
+                    "Oropharynx",
+                    "Other and ill-defined digestive organs",
+                    "Other and ill-defined sites",
+                    "Other and ill-defined sites in lip, oral cavity and pharynx",
+                    "Other and ill-defined sites within respiratory system and intrathoracic organs",
+                    "Other and unspecified female genital organs",
+                    "Other and unspecified major salivary glands",
+                    "Other and unspecified male genital organs",
+                    "Other and unspecified parts of biliary tract",
+                    "Other and unspecified parts of mouth",
+                    "Other and unspecified parts of tongue",
+                    "Other and unspecified urinary organs",
+                    "Other endocrine glands and related structures",
+                    "Ovary",
+                    "Palate",
+                    "Pancreas",
+                    "Parotid gland",
+                    "Penis",
+                    "Peripheral nerves and autonomic nervous system",
+                    "Placenta",
+                    "Prostate gland",
+                    "Pyriform sinus",
+                    "Rectosigmoid junction",
+                    "Rectum",
+                    "Renal pelvis",
+                    "Retroperitoneum and peritoneum",
+                    "Skin",
+                    "Small intestine",
+                    "Spinal cord, cranial nerves, and other parts of central nervous system",
+                    "Stomach",
+                    "Testis",
+                    "Thymus",
+                    "Thyroid gland",
+                    "Tonsil",
+                    "Trachea",
+                    "Ureter",
+                    "Uterus, NOS",
+                    "Vagina",
+                    "Vulva",
+                    "Unknown primary site"
+                ],
+                "title": "PrimarySiteEnum",
+                "type": "string"
+            },
+            "SexAtBirthEnum": {
+                "enum": [
+                    "Male",
+                    "Female",
+                    "Other",
+                    "Unknown"
+                ],
+                "title": "SexAtBirthEnum",
+                "type": "string"
+            },
+            "BiomarkerIngestSchema": {
+                "properties": {
+                    "submitter_specimen_id": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Submitter Specimen Id"
+                    },
+                    "submitter_primary_diagnosis_id": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Submitter Primary Diagnosis Id"
+                    },
+                    "submitter_treatment_id": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Submitter Treatment Id"
+                    },
+                    "submitter_follow_up_id": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Submitter Follow Up Id"
+                    },
+                    "test_date": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Test Date"
+                    },
+                    "psa_level": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Psa Level"
+                    },
+                    "ca125": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Ca125"
+                    },
+                    "cea": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cea"
+                    },
+                    "er_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ErPrHpvStatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "er_percent_positive": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Er Percent Positive"
+                    },
+                    "pr_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ErPrHpvStatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "pr_percent_positive": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pr Percent Positive"
+                    },
+                    "her2_ihc_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/Her2StatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "her2_ish_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/Her2StatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "hpv_ihc_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ErPrHpvStatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "hpv_pcr_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ErPrHpvStatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "hpv_strain": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/HpvStrainEnum"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Hpv Strain"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "submitter_donor_id"
+                ],
+                "title": "BiomarkerIngestSchema",
+                "type": "object"
+            },
+            "ErPrHpvStatusEnum": {
+                "enum": [
+                    "Cannot be determined",
+                    "Negative",
+                    "Not applicable",
+                    "Positive",
+                    "Unknown"
+                ],
+                "title": "ErPrHpvStatusEnum",
+                "type": "string"
+            },
+            "Her2StatusEnum": {
+                "enum": [
+                    "Cannot be determined",
+                    "Equivocal",
+                    "Positive",
+                    "Negative",
+                    "Not applicable",
+                    "Unknown"
+                ],
+                "title": "Her2StatusEnum",
+                "type": "string"
+            },
+            "HpvStrainEnum": {
+                "enum": [
+                    "HPV16",
+                    "HPV18",
+                    "HPV31",
+                    "HPV33",
+                    "HPV35",
+                    "HPV39",
+                    "HPV45",
+                    "HPV51",
+                    "HPV52",
+                    "HPV56",
+                    "HPV58",
+                    "HPV59",
+                    "HPV66",
+                    "HPV68",
+                    "HPV73"
+                ],
+                "title": "HpvStrainEnum",
+                "type": "string"
+            },
+            "ChemotherapyIngestSchema": {
+                "properties": {
+                    "drug_reference_database": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DrugReferenceDbEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "drug_name": {
+                        "anyOf": [
+                            {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Drug Name"
+                    },
+                    "drug_reference_identifier": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Drug Reference Identifier"
+                    },
+                    "chemotherapy_drug_dose_units": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DosageUnitsEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "prescribed_cumulative_drug_dose": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prescribed Cumulative Drug Dose"
+                    },
+                    "actual_cumulative_drug_dose": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Actual Cumulative Drug Dose"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_treatment_id": {
+                        "title": "Submitter Treatment Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "submitter_donor_id",
+                    "submitter_treatment_id"
+                ],
+                "title": "ChemotherapyIngestSchema",
+                "type": "object"
+            },
+            "DosageUnitsEnum": {
+                "enum": [
+                    "mg/m2",
+                    "IU/m2",
+                    "IU/kg",
+                    "ug/m2",
+                    "g/m2",
+                    "mg/kg",
+                    "cells/kg"
+                ],
+                "title": "DosageUnitsEnum",
+                "type": "string"
+            },
+            "DrugReferenceDbEnum": {
+                "enum": [
+                    "RxNorm",
+                    "PubChem",
+                    "NCI Thesaurus"
+                ],
+                "title": "DrugReferenceDbEnum",
+                "type": "string"
+            },
+            "ComorbidityIngestSchema": {
+                "properties": {
+                    "prior_malignancy": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uBooleanEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "laterality_of_prior_malignancy": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/MalignancyLateralityEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "age_at_comorbidity_diagnosis": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Age At Comorbidity Diagnosis"
+                    },
+                    "comorbidity_type_code": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "pattern": "^[A-Z][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Comorbidity Type Code"
+                    },
+                    "comorbidity_treatment_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uBooleanEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "comorbidity_treatment": {
+                        "anyOf": [
+                            {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Comorbidity Treatment"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "submitter_donor_id"
+                ],
+                "title": "ComorbidityIngestSchema",
+                "type": "object"
+            },
+            "MalignancyLateralityEnum": {
+                "enum": [
+                    "Bilateral",
+                    "Left",
+                    "Midline",
+                    "Not applicable",
+                    "Right",
+                    "Unilateral, Side not specified",
+                    "Unknown"
+                ],
+                "title": "MalignancyLateralityEnum",
+                "type": "string"
+            },
+            "uBooleanEnum": {
+                "enum": [
+                    "Yes",
+                    "No",
+                    "Unknown"
+                ],
+                "title": "uBooleanEnum",
+                "type": "string"
+            },
+            "ExposureIngestSchema": {
+                "properties": {
+                    "tobacco_smoking_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SmokingStatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "tobacco_type": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/TobaccoTypeEnum"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tobacco Type"
+                    },
+                    "pack_years_smoked": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pack Years Smoked"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "submitter_donor_id"
+                ],
+                "title": "ExposureIngestSchema",
+                "type": "object"
+            },
+            "SmokingStatusEnum": {
+                "enum": [
+                    "Current reformed smoker for <= 15 years",
+                    "Current reformed smoker for > 15 years",
+                    "Current reformed smoker, duration not specified",
+                    "Current smoker",
+                    "Lifelong non-smoker (<100 cigarettes smoked in lifetime)",
+                    "Not applicable",
+                    "Smoking history not documented"
+                ],
+                "title": "SmokingStatusEnum",
+                "type": "string"
+            },
+            "TobaccoTypeEnum": {
+                "enum": [
+                    "Chewing Tobacco",
+                    "Cigar",
+                    "Cigarettes",
+                    "Electronic cigarettes",
+                    "Not applicable",
+                    "Pipe",
+                    "Roll-ups",
+                    "Snuff",
+                    "Unknown",
+                    "Waterpipe"
+                ],
+                "title": "TobaccoTypeEnum",
+                "type": "string"
+            },
+            "DiseaseStatusFollowupEnum": {
+                "enum": [
+                    "Complete remission",
+                    "Distant progression",
+                    "Loco-regional progression",
+                    "No evidence of disease",
+                    "Partial remission",
+                    "Progression not otherwise specified",
+                    "Relapse or recurrence",
+                    "Stable"
+                ],
+                "title": "DiseaseStatusFollowupEnum",
+                "type": "string"
+            },
+            "FollowUpIngestSchema": {
+                "properties": {
+                    "submitter_follow_up_id": {
+                        "maxLength": 64,
+                        "pattern": "^[A-Za-z0-9\\-\\._]{1,64}",
+                        "title": "Submitter Follow Up Id",
+                        "type": "string"
+                    },
+                    "date_of_followup": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Date Of Followup"
+                    },
+                    "disease_status_at_followup": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DiseaseStatusFollowupEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "relapse_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/RelapseTypeEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "date_of_relapse": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Date Of Relapse"
+                    },
+                    "method_of_progression_status": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/ProgressionStatusMethodEnum"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Method Of Progression Status"
+                    },
+                    "anatomic_site_progression_or_recurrence": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Anatomic Site Progression Or Recurrence"
+                    },
+                    "recurrence_tumour_staging_system": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TumourStagingSystemEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "recurrence_t_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "recurrence_n_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/NCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "recurrence_m_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/MCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "recurrence_stage_group": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StageGroupEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_primary_diagnosis_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Submitter Primary Diagnosis Id"
+                    },
+                    "submitter_treatment_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Submitter Treatment Id"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "submitter_follow_up_id",
+                    "program_id",
+                    "submitter_donor_id"
+                ],
+                "title": "FollowUpIngestSchema",
+                "type": "object"
+            },
+            "MCategoryEnum": {
+                "enum": [
+                    "M0",
+                    "M0(i+)",
+                    "M1",
+                    "M1a",
+                    "M1a(0)",
+                    "M1a(1)",
+                    "M1b",
+                    "M1b(0)",
+                    "M1b(1)",
+                    "M1c",
+                    "M1c(0)",
+                    "M1c(1)",
+                    "M1d",
+                    "M1d(0)",
+                    "M1d(1)",
+                    "M1e",
+                    "MX"
+                ],
+                "title": "MCategoryEnum",
+                "type": "string"
+            },
+            "NCategoryEnum": {
+                "enum": [
+                    "N0",
+                    "N0a",
+                    "N0a (biopsy)",
+                    "N0b",
+                    "N0b (no biopsy)",
+                    "N0(i+)",
+                    "N0(i-)",
+                    "N0(mol+)",
+                    "N0(mol-)",
+                    "N1",
+                    "N1a",
+                    "N1a(sn)",
+                    "N1b",
+                    "N1c",
+                    "N1mi",
+                    "N2",
+                    "N2a",
+                    "N2b",
+                    "N2c",
+                    "N2mi",
+                    "N3",
+                    "N3a",
+                    "N3b",
+                    "N3c",
+                    "N4",
+                    "NX"
+                ],
+                "title": "NCategoryEnum",
+                "type": "string"
+            },
+            "ProgressionStatusMethodEnum": {
+                "enum": [
+                    "Imaging (procedure)",
+                    "Histopathology test (procedure)",
+                    "Assessment of symptom control (procedure)",
+                    "Physical examination procedure (procedure)",
+                    "Tumor marker measurement (procedure)",
+                    "Laboratory data interpretation (procedure)"
+                ],
+                "title": "ProgressionStatusMethodEnum",
+                "type": "string"
+            },
+            "RelapseTypeEnum": {
+                "enum": [
+                    "Distant recurrence/metastasis",
+                    "Local recurrence",
+                    "Local recurrence and distant metastasis",
+                    "Progression (liquid tumours)",
+                    "Biochemical progression"
+                ],
+                "title": "RelapseTypeEnum",
+                "type": "string"
+            },
+            "StageGroupEnum": {
+                "enum": [
+                    "Stage 0",
+                    "Stage 0a",
+                    "Stage 0is",
+                    "Stage 1",
+                    "Stage 1A",
+                    "Stage 1B",
+                    "Stage A",
+                    "Stage B",
+                    "Stage C",
+                    "Stage I",
+                    "Stage IA",
+                    "Stage IA1",
+                    "Stage IA2",
+                    "Stage IA3",
+                    "Stage IAB",
+                    "Stage IAE",
+                    "Stage IAES",
+                    "Stage IAS",
+                    "Stage IB",
+                    "Stage IB1",
+                    "Stage IB2",
+                    "Stage IBE",
+                    "Stage IBES",
+                    "Stage IBS",
+                    "Stage IC",
+                    "Stage IE",
+                    "Stage IEA",
+                    "Stage IEB",
+                    "Stage IES",
+                    "Stage II",
+                    "Stage II bulky",
+                    "Stage IIA",
+                    "Stage IIA1",
+                    "Stage IIA2",
+                    "Stage IIAE",
+                    "Stage IIAES",
+                    "Stage IIAS",
+                    "Stage IIB",
+                    "Stage IIBE",
+                    "Stage IIBES",
+                    "Stage IIBS",
+                    "Stage IIC",
+                    "Stage IIE",
+                    "Stage IIEA",
+                    "Stage IIEB",
+                    "Stage IIES",
+                    "Stage III",
+                    "Stage IIIA",
+                    "Stage IIIA1",
+                    "Stage IIIA2",
+                    "Stage IIIAE",
+                    "Stage IIIAES",
+                    "Stage IIIAS",
+                    "Stage IIIB",
+                    "Stage IIIBE",
+                    "Stage IIIBES",
+                    "Stage IIIBS",
+                    "Stage IIIC",
+                    "Stage IIIC1",
+                    "Stage IIIC2",
+                    "Stage IIID",
+                    "Stage IIIE",
+                    "Stage IIIES",
+                    "Stage IIIS",
+                    "Stage IIS",
+                    "Stage IS",
+                    "Stage IV",
+                    "Stage IVA",
+                    "Stage IVA1",
+                    "Stage IVA2",
+                    "Stage IVAE",
+                    "Stage IVAES",
+                    "Stage IVAS",
+                    "Stage IVB",
+                    "Stage IVBE",
+                    "Stage IVBES",
+                    "Stage IVBS",
+                    "Stage IVC",
+                    "Stage IVE",
+                    "Stage IVES",
+                    "Stage IVS",
+                    "In situ",
+                    "Localized",
+                    "Regionalized",
+                    "Distant",
+                    "Stage L1",
+                    "Stage L2",
+                    "Stage M",
+                    "Stage Ms",
+                    "Stage 2A",
+                    "Stage 2B",
+                    "Stage 3",
+                    "Stage 4",
+                    "Stage 4S",
+                    "Occult Carcinoma"
+                ],
+                "title": "StageGroupEnum",
+                "type": "string"
+            },
+            "TCategoryEnum": {
+                "enum": [
+                    "T0",
+                    "T1",
+                    "T1a",
+                    "T1a1",
+                    "T1a2",
+                    "T1a(s)",
+                    "T1a(m)",
+                    "T1b",
+                    "T1b1",
+                    "T1b2",
+                    "T1b(s)",
+                    "T1b(m)",
+                    "T1c",
+                    "T1d",
+                    "T1mi",
+                    "T2",
+                    "T2(s)",
+                    "T2(m)",
+                    "T2a",
+                    "T2a1",
+                    "T2a2",
+                    "T2b",
+                    "T2c",
+                    "T2d",
+                    "T3",
+                    "T3(s)",
+                    "T3(m)",
+                    "T3a",
+                    "T3b",
+                    "T3c",
+                    "T3d",
+                    "T3e",
+                    "T4",
+                    "T4a",
+                    "T4a(s)",
+                    "T4a(m)",
+                    "T4b",
+                    "T4b(s)",
+                    "T4b(m)",
+                    "T4c",
+                    "T4d",
+                    "T4e",
+                    "Ta",
+                    "Tis",
+                    "Tis(DCIS)",
+                    "Tis(LAMN)",
+                    "Tis(LCIS)",
+                    "Tis(Paget)",
+                    "Tis(Paget's)",
+                    "Tis pu",
+                    "Tis pd",
+                    "TX"
+                ],
+                "title": "TCategoryEnum",
+                "type": "string"
+            },
+            "TumourStagingSystemEnum": {
+                "enum": [
+                    "AJCC 8th edition",
+                    "AJCC 7th edition",
+                    "AJCC 6th edition",
+                    "Ann Arbor staging system",
+                    "Binet staging system",
+                    "Durie-Salmon staging system",
+                    "FIGO staging system",
+                    "International Neuroblastoma Risk Group Staging System",
+                    "International Neuroblastoma Staging System",
+                    "Lugano staging system",
+                    "Rai staging system",
+                    "Revised International staging system (RISS)",
+                    "SEER staging system",
+                    "St Jude staging system"
+                ],
+                "title": "TumourStagingSystemEnum",
+                "type": "string"
+            },
+            "HormoneTherapyIngestSchema": {
+                "properties": {
+                    "drug_reference_database": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DrugReferenceDbEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "drug_name": {
+                        "anyOf": [
+                            {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Drug Name"
+                    },
+                    "drug_reference_identifier": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Drug Reference Identifier"
+                    },
+                    "hormone_drug_dose_units": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DosageUnitsEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "prescribed_cumulative_drug_dose": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prescribed Cumulative Drug Dose"
+                    },
+                    "actual_cumulative_drug_dose": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Actual Cumulative Drug Dose"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_treatment_id": {
+                        "title": "Submitter Treatment Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "submitter_donor_id",
+                    "submitter_treatment_id"
+                ],
+                "title": "HormoneTherapyIngestSchema",
+                "type": "object"
+            },
+            "ImmunotherapyIngestSchema": {
+                "properties": {
+                    "drug_reference_database": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DrugReferenceDbEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "immunotherapy_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ImmunotherapyTypeEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "drug_name": {
+                        "anyOf": [
+                            {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Drug Name"
+                    },
+                    "drug_reference_identifier": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Drug Reference Identifier"
+                    },
+                    "immunotherapy_drug_dose_units": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DosageUnitsEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "prescribed_cumulative_drug_dose": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prescribed Cumulative Drug Dose"
+                    },
+                    "actual_cumulative_drug_dose": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Actual Cumulative Drug Dose"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_treatment_id": {
+                        "title": "Submitter Treatment Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "submitter_donor_id",
+                    "submitter_treatment_id"
+                ],
+                "title": "ImmunotherapyIngestSchema",
+                "type": "object"
+            },
+            "ImmunotherapyTypeEnum": {
+                "enum": [
+                    "Cell-based",
+                    "Immune checkpoint inhibitors",
+                    "Monoclonal antibodies other than immune checkpoint inhibitors",
+                    "Other immunomodulatory substances"
+                ],
+                "title": "ImmunotherapyTypeEnum",
+                "type": "string"
+            },
+            "BasisOfDiagnosisEnum": {
+                "enum": [
+                    "Clinical investigation",
+                    "Clinical",
+                    "Cytology",
+                    "Death certificate only",
+                    "Histology of a metastasis",
+                    "Histology of a primary tumour",
+                    "Specific tumour markers",
+                    "Unknown"
+                ],
+                "title": "BasisOfDiagnosisEnum",
+                "type": "string"
+            },
+            "LymphNodeMethodEnum": {
+                "enum": [
+                    "Imaging",
+                    "Lymph node dissection/pathological exam",
+                    "Physical palpation of patient"
+                ],
+                "title": "LymphNodeMethodEnum",
+                "type": "string"
+            },
+            "LymphNodeStatusEnum": {
+                "enum": [
+                    "Cannot be determined",
+                    "No",
+                    "No lymph nodes found in resected specimen",
+                    "Not applicable",
+                    "Yes"
+                ],
+                "title": "LymphNodeStatusEnum",
+                "type": "string"
+            },
+            "PrimaryDiagnosisIngestSchema": {
+                "properties": {
+                    "submitter_primary_diagnosis_id": {
+                        "maxLength": 64,
+                        "pattern": "^[A-Za-z0-9\\-\\._]{1,64}",
+                        "title": "Submitter Primary Diagnosis Id",
+                        "type": "string"
+                    },
+                    "date_of_diagnosis": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Date Of Diagnosis"
+                    },
+                    "cancer_type_code": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cancer Type Code"
+                    },
+                    "basis_of_diagnosis": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/BasisOfDiagnosisEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "laterality": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/PrimaryDiagnosisLateralityEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "lymph_nodes_examined_status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/LymphNodeStatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "lymph_nodes_examined_method": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/LymphNodeMethodEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "number_lymph_nodes_positive": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Number Lymph Nodes Positive"
+                    },
+                    "clinical_tumour_staging_system": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TumourStagingSystemEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "clinical_t_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "clinical_n_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/NCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "clinical_m_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/MCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "clinical_stage_group": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StageGroupEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "submitter_primary_diagnosis_id",
+                    "program_id",
+                    "submitter_donor_id"
+                ],
+                "title": "PrimaryDiagnosisIngestSchema",
+                "type": "object"
+            },
+            "PrimaryDiagnosisLateralityEnum": {
+                "enum": [
+                    "Bilateral",
+                    "Left",
+                    "Midline",
+                    "Not a paired site",
+                    "Right",
+                    "Unilateral, side not specified",
+                    "Unknown"
+                ],
+                "title": "PrimaryDiagnosisLateralityEnum",
+                "type": "string"
+            },
+            "RadiationAnatomicalSiteEnum": {
+                "enum": [
+                    "Left Abdomen",
+                    "Whole Abdomen",
+                    "Right Abdomen",
+                    "Lower Abdomen",
+                    "Left Lower Abdomen",
+                    "Right Lower Abdomen",
+                    "Upper Abdomen",
+                    "Left Upper Abdomen",
+                    "Right Upper Abdomen",
+                    "Left Adrenal",
+                    "Right Adrenal",
+                    "Bilateral Ankle",
+                    "Left Ankle",
+                    "Right Ankle",
+                    "Bilateral Antrum (Bull's Eye)",
+                    "Left Antrum",
+                    "Right Antrum",
+                    "Anus",
+                    "Lower Left Arm",
+                    "Lower Right Arm",
+                    "Bilateral Arms",
+                    "Left Arm",
+                    "Right Arm",
+                    "Upper Left Arm",
+                    "Upper Right Arm",
+                    "Left Axilla",
+                    "Right Axilla",
+                    "Skin or Soft Tissue of Back",
+                    "Bile Duct",
+                    "Bladder",
+                    "Lower Body",
+                    "Middle Body",
+                    "Upper Body",
+                    "Whole Body",
+                    "Boost - Area Previously Treated",
+                    "Brain",
+                    "Left Breast Boost",
+                    "Right Breast Boost",
+                    "Bilateral Breast",
+                    "Left Breast",
+                    "Right Breast",
+                    "Bilateral Breasts with Nodes",
+                    "Left Breast with Nodes",
+                    "Right Breast with Nodes",
+                    "Bilateral Buttocks",
+                    "Left Buttock",
+                    "Right Buttock",
+                    "Inner Canthus",
+                    "Outer Canthus",
+                    "Cervix",
+                    "Bilateral Chest Lung & Area Involve",
+                    "Left Chest",
+                    "Right Chest",
+                    "Chin",
+                    "Left Cheek",
+                    "Right Cheek",
+                    "Bilateral Chest Wall (W/o Breast)",
+                    "Left Chest Wall",
+                    "Right Chest Wall",
+                    "Bilateral Clavicle",
+                    "Left Clavicle",
+                    "Right Clavicle",
+                    "Coccyx",
+                    "Colon",
+                    "Whole C.N.S. (Medulla Techinque)",
+                    "Csf Spine (Medull Tech 2 Diff Machi",
+                    "Left Chestwall Boost",
+                    "Right Chestwall Boost",
+                    "Bilateral Chestwall with Nodes",
+                    "Left Chestwall with Nodes",
+                    "Right Chestwall with Nodes",
+                    "Left Ear",
+                    "Right Ear",
+                    "Epigastrium",
+                    "Lower Esophagus",
+                    "Middle Esophagus",
+                    "Upper Esophagus",
+                    "Entire Esophagus",
+                    "Ethmoid Sinus",
+                    "Bilateral Eyes",
+                    "Left Eye",
+                    "Right Eye",
+                    "Bilateral Face",
+                    "Left Face",
+                    "Right Face",
+                    "Left Fallopian Tubes",
+                    "Right Fallopian Tubes",
+                    "Bilateral Femur",
+                    "Left Femur",
+                    "Right Femur",
+                    "Left Fibula",
+                    "Right Fibula",
+                    "Finger (Including Thumbs)",
+                    "Floor of Mouth (Boosts)",
+                    "Bilateral Feet",
+                    "Left Foot",
+                    "Right Foot",
+                    "Forehead",
+                    "Posterior Fossa",
+                    "Gall Bladder",
+                    "Gingiva",
+                    "Bilateral Hand",
+                    "Left Hand",
+                    "Right Hand",
+                    "Head",
+                    "Bilateral Heel",
+                    "Left Heel",
+                    "Right Heel",
+                    "Left Hemimantle",
+                    "Right Hemimantle",
+                    "Heart",
+                    "Bilateral Hip",
+                    "Left Hip",
+                    "Right Hip",
+                    "Left Humerus",
+                    "Right Humerus",
+                    "Hypopharynx",
+                    "Bilateral Internal Mammary Chain",
+                    "Bilateral Inguinal Nodes",
+                    "Left Inguinal Nodes",
+                    "Right Inguinal Nodes",
+                    "Inverted 'Y' (Dog-Leg,Hockey-Stick)",
+                    "Left Kidney",
+                    "Right Kidney",
+                    "Bilateral Knee",
+                    "Left Knee",
+                    "Right Knee",
+                    "Bilateral Lacrimal Gland",
+                    "Left Lacrimal Gland",
+                    "Right Lacrimal Gland",
+                    "Larygopharynx",
+                    "Larynx",
+                    "Bilateral Leg",
+                    "Left Leg",
+                    "Right Leg",
+                    "Lower Bilateral Leg",
+                    "Lower Left Leg",
+                    "Lower Right Leg",
+                    "Upper Bilateral Leg",
+                    "Upper Left Leg",
+                    "Upper Right Leg",
+                    "Both Eyelid(s)",
+                    "Left Eyelid",
+                    "Right Eyelid",
+                    "Both Lip(s)",
+                    "Lower Lip",
+                    "Upper Lip",
+                    "Liver",
+                    "Bilateral Lung",
+                    "Left Lung",
+                    "Right Lung",
+                    "Bilateral Mandible",
+                    "Left Mandible",
+                    "Right Mandible",
+                    "Mantle",
+                    "Bilateral Maxilla",
+                    "Left Maxilla",
+                    "Right Maxilla",
+                    "Mediastinum",
+                    "Multiple Skin",
+                    "Nasal Fossa",
+                    "Nasopharynx",
+                    "Bilateral Neck Includes Nodes",
+                    "Left Neck Includes Nodes",
+                    "Right Neck Includes Nodes",
+                    "Neck - Skin",
+                    "Nose",
+                    "Oral Cavity / Buccal Mucosa",
+                    "Bilateral Orbit",
+                    "Left Orbit",
+                    "Right Orbit",
+                    "Oropharynx",
+                    "Bilateral Ovary",
+                    "Left Ovary",
+                    "Right Ovary",
+                    "Hard Palate",
+                    "Soft Palate",
+                    "Palate Unspecified",
+                    "Pancreas",
+                    "Para-Aortic Nodes",
+                    "Left Parotid",
+                    "Right Parotid",
+                    "Bilateral Pelvis",
+                    "Left Pelvis",
+                    "Right Pelvis",
+                    "Penis",
+                    "Perineum",
+                    "Pituitary",
+                    "Left Pleura (As in Mesothelioma)",
+                    "Right Pleura",
+                    "Prostate",
+                    "Pubis",
+                    "Pyriform Fossa (Sinuses)",
+                    "Left Radius",
+                    "Right Radius",
+                    "Rectum (Includes Sigmoid)",
+                    "Left Ribs",
+                    "Right Ribs",
+                    "Sacrum",
+                    "Left Salivary Gland",
+                    "Right Salivary Gland",
+                    "Bilateral Scapula",
+                    "Left Scapula",
+                    "Right Scapula",
+                    "Bilateral Supraclavicular Nodes",
+                    "Left Supraclavicular Nodes",
+                    "Right Supraclavicular Nodes",
+                    "Bilateral Scalp",
+                    "Left Scalp",
+                    "Right Scalp",
+                    "Scrotum",
+                    "Bilateral Shoulder",
+                    "Left Shoulder",
+                    "Right Shoulder",
+                    "Whole Body - Skin",
+                    "Skull",
+                    "Cervical & Thoracic Spine",
+                    "Sphenoid Sinus",
+                    "Cervical Spine",
+                    "Lumbar Spine",
+                    "Thoracic Spine",
+                    "Whole Spine",
+                    "Spleen",
+                    "Lumbo-Sacral Spine",
+                    "Thoracic & Lumbar Spine",
+                    "Sternum",
+                    "Stomach",
+                    "Submandibular Glands",
+                    "Left Temple",
+                    "Right Temple",
+                    "Bilateral Testis",
+                    "Left Testis",
+                    "Right Testis",
+                    "Thyroid",
+                    "Left Tibia",
+                    "Right Tibia",
+                    "Left Toes",
+                    "Right Toes",
+                    "Tongue",
+                    "Tonsil",
+                    "Trachea",
+                    "Left Ulna",
+                    "Right Ulna",
+                    "Left Ureter",
+                    "Right Ureter",
+                    "Urethra",
+                    "Uterus",
+                    "Uvula",
+                    "Vagina",
+                    "Vulva",
+                    "Abdomen",
+                    "Body",
+                    "Chest",
+                    "Lower Limb",
+                    "Neck",
+                    "Other",
+                    "Pelvis",
+                    "Skin",
+                    "Spine",
+                    "Upper Limb"
+                ],
+                "title": "RadiationAnatomicalSiteEnum",
+                "type": "string"
+            },
+            "RadiationIngestSchema": {
+                "properties": {
+                    "radiation_therapy_modality": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/RadiationTherapyModalityEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "radiation_therapy_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TherapyTypeEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "radiation_therapy_fractions": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Radiation Therapy Fractions"
+                    },
+                    "radiation_therapy_dosage": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Radiation Therapy Dosage"
+                    },
+                    "anatomical_site_irradiated": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/RadiationAnatomicalSiteEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "radiation_boost": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Radiation Boost"
+                    },
+                    "reference_radiation_treatment_id": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Reference Radiation Treatment Id"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_treatment_id": {
+                        "title": "Submitter Treatment Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "submitter_donor_id",
+                    "submitter_treatment_id"
+                ],
+                "title": "RadiationIngestSchema",
+                "type": "object"
+            },
+            "RadiationTherapyModalityEnum": {
+                "enum": [
+                    "Megavoltage radiation therapy using photons (procedure)",
+                    "Radiopharmaceutical",
+                    "Teleradiotherapy using electrons (procedure)",
+                    "Teleradiotherapy protons (procedure)",
+                    "Teleradiotherapy neutrons (procedure)",
+                    "Brachytherapy (procedure)",
+                    "Other"
+                ],
+                "title": "RadiationTherapyModalityEnum",
+                "type": "string"
+            },
+            "TherapyTypeEnum": {
+                "enum": [
+                    "External",
+                    "Internal"
+                ],
+                "title": "TherapyTypeEnum",
+                "type": "string"
+            },
+            "SampleRegistrationIngestSchema": {
+                "properties": {
+                    "submitter_sample_id": {
+                        "maxLength": 64,
+                        "pattern": "^[A-Za-z0-9\\-\\._]{1,64}",
+                        "title": "Submitter Sample Id",
+                        "type": "string"
+                    },
+                    "specimen_tissue_source": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SpecimenTissueSourceEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "tumour_normal_designation": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TumourDesginationEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "specimen_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SpecimenTypeEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "sample_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SampleTypeEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_specimen_id": {
+                        "title": "Submitter Specimen Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "submitter_sample_id",
+                    "program_id",
+                    "submitter_donor_id",
+                    "submitter_specimen_id"
+                ],
+                "title": "SampleRegistrationIngestSchema",
+                "type": "object"
+            },
+            "SampleTypeEnum": {
+                "enum": [
+                    "Amplified DNA",
+                    "ctDNA",
+                    "Other DNA enrichments",
+                    "Other RNA fractions",
+                    "polyA+ RNA",
+                    "Protein",
+                    "rRNA-depleted RNA",
+                    "Total DNA",
+                    "Total RNA"
+                ],
+                "title": "SampleTypeEnum",
+                "type": "string"
+            },
+            "SpecimenTissueSourceEnum": {
+                "enum": [
+                    "Abdominal fluid",
+                    "Amniotic fluid",
+                    "Arterial blood",
+                    "Bile",
+                    "Blood derived - bone marrow",
+                    "Blood derived - peripheral blood",
+                    "Bone marrow fluid",
+                    "Bone marrow derived mononuclear cells",
+                    "Buccal cell",
+                    "Buffy coat",
+                    "Cerebrospinal fluid",
+                    "Cervical mucus",
+                    "Convalescent plasma",
+                    "Cord blood",
+                    "Duodenal fluid",
+                    "Female genital fluid",
+                    "Fetal blood",
+                    "Hydrocele fluid",
+                    "Male genital fluid",
+                    "Pancreatic fluid",
+                    "Pericardial effusion",
+                    "Pleural fluid",
+                    "Renal cyst fluid",
+                    "Saliva",
+                    "Seminal fluid",
+                    "Serum",
+                    "Solid tissue",
+                    "Sputum",
+                    "Synovial fluid",
+                    "Urine",
+                    "Venous blood",
+                    "Vitreous fluid",
+                    "Whole blood",
+                    "Wound"
+                ],
+                "title": "SpecimenTissueSourceEnum",
+                "type": "string"
+            },
+            "SpecimenTypeEnum": {
+                "enum": [
+                    "Cell line - derived from normal",
+                    "Cell line - derived from primary tumour",
+                    "Cell line - derived from metastatic tumour",
+                    "Cell line - derived from xenograft tumour",
+                    "Metastatic tumour - additional metastatic",
+                    "Metastatic tumour - metastasis local to lymph node",
+                    "Metastatic tumour - metastasis to distant location",
+                    "Metastatic tumour",
+                    "Normal - tissue adjacent to primary tumour",
+                    "Normal",
+                    "Primary tumour - additional new primary",
+                    "Primary tumour - adjacent to normal",
+                    "Primary tumour",
+                    "Recurrent tumour",
+                    "Tumour - unknown if derived from primary or metastatic tumour",
+                    "Xenograft - derived from primary tumour",
+                    "Xenograft - derived from metastatic tumour",
+                    "Xenograft - derived from tumour cell line"
+                ],
+                "title": "SpecimenTypeEnum",
+                "type": "string"
+            },
+            "TumourDesginationEnum": {
+                "enum": [
+                    "Normal",
+                    "Tumour"
+                ],
+                "title": "TumourDesginationEnum",
+                "type": "string"
+            },
+            "CellsMeasureMethodEnum": {
+                "enum": [
+                    "Genomics",
+                    "Image analysis",
+                    "Pathology estimate by percent nuclei",
+                    "Unknown"
+                ],
+                "title": "CellsMeasureMethodEnum",
+                "type": "string"
+            },
+            "ConfirmedDiagnosisTumourEnum": {
+                "enum": [
+                    "Yes",
+                    "No",
+                    "Not done",
+                    "Unknown"
+                ],
+                "title": "ConfirmedDiagnosisTumourEnum",
+                "type": "string"
+            },
+            "PercentCellsRangeEnum": {
+                "enum": [
+                    "0-19%",
+                    "20-50%",
+                    "51-100%"
+                ],
+                "title": "PercentCellsRangeEnum",
+                "type": "string"
+            },
+            "SpecimenIngestSchema": {
+                "properties": {
+                    "submitter_specimen_id": {
+                        "maxLength": 64,
+                        "pattern": "^[A-Za-z0-9\\-\\._]{1,64}",
+                        "title": "Submitter Specimen Id",
+                        "type": "string"
+                    },
+                    "pathological_tumour_staging_system": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TumourStagingSystemEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "pathological_t_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "pathological_n_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/NCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "pathological_m_category": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/MCategoryEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "pathological_stage_group": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StageGroupEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "specimen_collection_date": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Specimen Collection Date"
+                    },
+                    "specimen_storage": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StorageEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "specimen_processing": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SpecimenProcessingEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "tumour_histological_type": {
+                        "anyOf": [
+                            {
+                                "maxLength": 128,
+                                "pattern": "^[8,9]{1}[0-9]{3}/[0,1,2,3,6,9]{1}[1-9]{0,1}$",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tumour Histological Type"
+                    },
+                    "specimen_anatomic_location": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^[C][0-9]{2}(.[0-9]{1})?$",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Specimen Anatomic Location"
+                    },
+                    "specimen_laterality": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SpecimenLateralityEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "reference_pathology_confirmed_diagnosis": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ConfirmedDiagnosisTumourEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "reference_pathology_confirmed_tumour_presence": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ConfirmedDiagnosisTumourEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "tumour_grading_system": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TumourGradingSystemEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "tumour_grade": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TumourGradeEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "percent_tumour_cells_range": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/PercentCellsRangeEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "percent_tumour_cells_measurement_method": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/CellsMeasureMethodEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_primary_diagnosis_id": {
+                        "title": "Submitter Primary Diagnosis Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "submitter_specimen_id",
+                    "program_id",
+                    "submitter_donor_id",
+                    "submitter_primary_diagnosis_id"
+                ],
+                "title": "SpecimenIngestSchema",
+                "type": "object"
+            },
+            "SpecimenLateralityEnum": {
+                "enum": [
+                    "Left",
+                    "Not applicable",
+                    "Right",
+                    "Unknown"
+                ],
+                "title": "SpecimenLateralityEnum",
+                "type": "string"
+            },
+            "SpecimenProcessingEnum": {
+                "enum": [
+                    "Cryopreservation in liquid nitrogen (dead tissue)",
+                    "Cryopreservation in dry ice (dead tissue)",
+                    "Cryopreservation of live cells in liquid nitrogen",
+                    "Cryopreservation - other",
+                    "Formalin fixed & paraffin embedded",
+                    "Formalin fixed - buffered",
+                    "Formalin fixed - unbuffered",
+                    "Fresh",
+                    "Other",
+                    "Unknown"
+                ],
+                "title": "SpecimenProcessingEnum",
+                "type": "string"
+            },
+            "StorageEnum": {
+                "enum": [
+                    "Cut slide",
+                    "Frozen in -70 freezer",
+                    "Frozen in liquid nitrogen",
+                    "Frozen in vapour phase",
+                    "Not Applicable",
+                    "Other",
+                    "Paraffin block",
+                    "RNA later frozen",
+                    "Unknown"
+                ],
+                "title": "StorageEnum",
+                "type": "string"
+            },
+            "TumourGradeEnum": {
+                "enum": [
+                    "Low grade",
+                    "High grade",
+                    "GX",
+                    "G1",
+                    "G2",
+                    "G3",
+                    "G4",
+                    "Low",
+                    "High",
+                    "Grade 1",
+                    "Grade 2",
+                    "Grade 3",
+                    "Grade 4",
+                    "Grade I",
+                    "Grade II",
+                    "Grade III",
+                    "Grade IV",
+                    "Grade Group 1",
+                    "Grade Group 2",
+                    "Grade Group 3",
+                    "Grade Group 4",
+                    "Grade Group 5"
+                ],
+                "title": "TumourGradeEnum",
+                "type": "string"
+            },
+            "TumourGradingSystemEnum": {
+                "enum": [
+                    "FNCLCC grading system",
+                    "Four-tier grading system",
+                    "Gleason grade group system",
+                    "Grading system for GISTs",
+                    "Grading system for GNETs",
+                    "IASLC grading system",
+                    "ISUP grading system",
+                    "Nottingham grading system",
+                    "Nuclear grading system for DCIS",
+                    "Scarff-Bloom-Richardson grading system",
+                    "Three-tier grading system",
+                    "Two-tier grading system",
+                    "WHO grading system for CNS tumours"
+                ],
+                "title": "TumourGradingSystemEnum",
+                "type": "string"
+            },
+            "LymphovascularInvasionEnum": {
+                "enum": [
+                    "Absent",
+                    "Both lymphatic and small vessel and venous (large vessel) invasion",
+                    "Lymphatic and small vessel invasion only",
+                    "Not applicable",
+                    "Present",
+                    "Venous (large vessel) invasion only",
+                    "Unknown"
+                ],
+                "title": "LymphovascularInvasionEnum",
+                "type": "string"
+            },
+            "MarginTypesEnum": {
+                "enum": [
+                    "Circumferential resection margin",
+                    "Common bile duct margin",
+                    "Distal margin",
+                    "Not applicable",
+                    "Proximal margin",
+                    "Unknown"
+                ],
+                "title": "MarginTypesEnum",
+                "type": "string"
+            },
+            "PerineuralInvasionEnum": {
+                "enum": [
+                    "Absent",
+                    "Cannot be assessed",
+                    "Not applicable",
+                    "Present",
+                    "Unknown"
+                ],
+                "title": "PerineuralInvasionEnum",
+                "type": "string"
+            },
+            "SurgeryIngestSchema": {
+                "properties": {
+                    "submitter_specimen_id": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Submitter Specimen Id"
+                    },
+                    "surgery_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SurgeryTypeEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "surgery_site": {
+                        "anyOf": [
+                            {
+                                "maxLength": 255,
+                                "pattern": "^[C][0-9]{2}(.[0-9]{1})?$",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Surgery Site"
+                    },
+                    "surgery_location": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SurgeryLocationEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "tumour_length": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tumour Length"
+                    },
+                    "tumour_width": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tumour Width"
+                    },
+                    "greatest_dimension_tumour": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Greatest Dimension Tumour"
+                    },
+                    "tumour_focality": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TumourFocalityEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "residual_tumour_classification": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TumourClassificationEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "margin_types_involved": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/MarginTypesEnum"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Margin Types Involved"
+                    },
+                    "margin_types_not_involved": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/MarginTypesEnum"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Margin Types Not Involved"
+                    },
+                    "margin_types_not_assessed": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/MarginTypesEnum"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Margin Types Not Assessed"
+                    },
+                    "lymphovascular_invasion": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/LymphovascularInvasionEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "perineural_invasion": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/PerineuralInvasionEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_treatment_id": {
+                        "title": "Submitter Treatment Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "submitter_donor_id",
+                    "submitter_treatment_id"
+                ],
+                "title": "SurgeryIngestSchema",
+                "type": "object"
+            },
+            "SurgeryLocationEnum": {
+                "enum": [
+                    "Local recurrence",
+                    "Metastatic",
+                    "Primary"
+                ],
+                "title": "SurgeryLocationEnum",
+                "type": "string"
+            },
+            "SurgeryTypeEnum": {
+                "enum": [
+                    "Ablation",
+                    "Axillary Clearance",
+                    "Axillary lymph nodes sampling",
+                    "Bilateral complete salpingo-oophorectomy",
+                    "Biopsy",
+                    "Bypass Gastrojejunostomy",
+                    "Cholecystectomy",
+                    "Cholecystojejunostomy",
+                    "Completion Gastrectomy",
+                    "Debridement of pancreatic and peripancreatic necrosis",
+                    "Distal subtotal pancreatectomy",
+                    "Drainage of abscess",
+                    "Duodenal preserving pancreatic head resection",
+                    "Endoscopic biopsy",
+                    "Endoscopic brushings of gastrointestinal tract",
+                    "Enucleation",
+                    "Esophageal bypass surgery/jejunostomy only",
+                    "Exploratory laparotomy",
+                    "Fine needle aspiration biopsy",
+                    "Gastric Antrectomy",
+                    "Glossectomy",
+                    "Hepatojejunostomy",
+                    "Hysterectomy",
+                    "Incision of thorax",
+                    "Ivor Lewis subtotal esophagectomy",
+                    "Laparotomy",
+                    "Left thoracoabdominal incision",
+                    "Lobectomy",
+                    "Mammoplasty",
+                    "Mastectomy",
+                    "McKeown esophagectomy",
+                    "Merendino procedure",
+                    "Minimally invasive esophagectomy",
+                    "Omentectomy",
+                    "Ovariectomy",
+                    "Pancreaticoduodenectomy (Whipple procedure)",
+                    "Pancreaticojejunostomy, side-to-side anastomosis",
+                    "Partial pancreatectomy",
+                    "Pneumonectomy",
+                    "Prostatectomy",
+                    "Proximal subtotal gastrectomy",
+                    "Pylorus-sparing Whipple operation",
+                    "Radical pancreaticoduodenectomy",
+                    "Radical prostatectomy",
+                    "Reexcision",
+                    "Segmentectomy",
+                    "Sentinal Lymph Node Biopsy",
+                    "Spleen preserving distal pancreatectomy",
+                    "Splenectomy",
+                    "Total gastrectomy",
+                    "Total gastrectomy with extended lymphadenectomy",
+                    "Total pancreatectomy",
+                    "Transhiatal esophagectomy",
+                    "Triple bypass of pancreas",
+                    "Tumor Debulking",
+                    "Wedge/localised gastric resection",
+                    "Wide Local Excision"
+                ],
+                "title": "SurgeryTypeEnum",
+                "type": "string"
+            },
+            "TumourClassificationEnum": {
+                "enum": [
+                    "Not applicable",
+                    "RX",
+                    "R0",
+                    "R1",
+                    "R2",
+                    "Unknown"
+                ],
+                "title": "TumourClassificationEnum",
+                "type": "string"
+            },
+            "TumourFocalityEnum": {
+                "enum": [
+                    "Cannot be assessed",
+                    "Multifocal",
+                    "Not applicable",
+                    "Unifocal",
+                    "Unknown"
+                ],
+                "title": "TumourFocalityEnum",
+                "type": "string"
+            },
+            "TreatmentIngestSchema": {
+                "properties": {
+                    "submitter_treatment_id": {
+                        "maxLength": 64,
+                        "pattern": "^[A-Za-z0-9\\-\\._]{1,64}",
+                        "title": "Submitter Treatment Id",
+                        "type": "string"
+                    },
+                    "treatment_type": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/TreatmentTypeEnum"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Treatment Type"
+                    },
+                    "is_primary_treatment": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uBooleanEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "line_of_treatment": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Line Of Treatment"
+                    },
+                    "treatment_start_date": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Treatment Start Date"
+                    },
+                    "treatment_end_date": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Treatment End Date"
+                    },
+                    "treatment_setting": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TreatmentSettingEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "treatment_intent": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TreatmentIntentEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "days_per_cycle": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Days Per Cycle"
+                    },
+                    "number_of_cycles": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Number Of Cycles"
+                    },
+                    "response_to_treatment_criteria_method": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TreatmentResponseMethodEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "response_to_treatment": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TreatmentResponseEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "status_of_treatment": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TreatmentStatusEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "submitter_donor_id": {
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "submitter_primary_diagnosis_id": {
+                        "title": "Submitter Primary Diagnosis Id",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uuid"
+                    }
+                },
+                "required": [
+                    "submitter_treatment_id",
+                    "program_id",
+                    "submitter_donor_id",
+                    "submitter_primary_diagnosis_id"
+                ],
+                "title": "TreatmentIngestSchema",
+                "type": "object"
+            },
+            "TreatmentIntentEnum": {
+                "enum": [
+                    "Curative",
+                    "Palliative",
+                    "Supportive",
+                    "Diagnostic",
+                    "Preventive",
+                    "Guidance",
+                    "Screening",
+                    "Forensic"
+                ],
+                "title": "TreatmentIntentEnum",
+                "type": "string"
+            },
+            "TreatmentResponseEnum": {
+                "enum": [
+                    "Complete response",
+                    "Partial response",
+                    "Progressive disease",
+                    "Stable disease",
+                    "Immune complete response (iCR)",
+                    "Immune partial response (iPR)",
+                    "Immune uncomfirmed progressive disease (iUPD)",
+                    "Immune confirmed progressive disease (iCPD)",
+                    "Immune stable disease (iSD)",
+                    "Complete remission",
+                    "Partial remission",
+                    "Minor response",
+                    "Complete remission without measurable residual disease (CR MRD-)",
+                    "Complete remission with incomplete hematologic recovery (CRi)",
+                    "Morphologic leukemia-free state",
+                    "Primary refractory disease",
+                    "Hematologic relapse (after CR MRD-, CR, CRi)",
+                    "Molecular relapse (after CR MRD-)",
+                    "Physician assessed complete response",
+                    "Physician assessed partial response",
+                    "Physician assessed stable disease",
+                    "No evidence of disease (NED)",
+                    "Major response"
+                ],
+                "title": "TreatmentResponseEnum",
+                "type": "string"
+            },
+            "TreatmentResponseMethodEnum": {
+                "enum": [
+                    "RECIST 1.1",
+                    "iRECIST",
+                    "Cheson CLL 2012 Oncology Response Criteria",
+                    "Response Assessment in Neuro-Oncology (RANO)",
+                    "AML Response Criteria",
+                    "Physician Assessed Response Criteria",
+                    "Blazer score"
+                ],
+                "title": "TreatmentResponseMethodEnum",
+                "type": "string"
+            },
+            "TreatmentSettingEnum": {
+                "enum": [
+                    "Adjuvant",
+                    "Advanced/Metastatic",
+                    "Neoadjuvant",
+                    "Conditioning",
+                    "Induction",
+                    "Locally advanced",
+                    "Maintenance",
+                    "Mobilization",
+                    "Preventative",
+                    "Radiosensitization",
+                    "Salvage"
+                ],
+                "title": "TreatmentSettingEnum",
+                "type": "string"
+            },
+            "TreatmentStatusEnum": {
+                "enum": [
+                    "Treatment completed as prescribed",
+                    "Treatment incomplete due to technical or organizational problems",
+                    "Treatment incomplete because patient died",
+                    "Patient choice (stopped or interrupted treatment)",
+                    "Physician decision (stopped or interrupted treatment)",
+                    "Treatment stopped due to lack of efficacy (disease progression)",
+                    "Treatment stopped due to acute toxicity",
+                    "Other",
+                    "Not applicable",
+                    "Unknown"
+                ],
+                "title": "TreatmentStatusEnum",
+                "type": "string"
+            },
+            "TreatmentTypeEnum": {
+                "enum": [
+                    "Bone marrow transplant",
+                    "Chemotherapy",
+                    "Hormonal therapy",
+                    "Immunotherapy",
+                    "No treatment",
+                    "Other targeting molecular therapy",
+                    "Photodynamic therapy",
+                    "Radiation therapy",
+                    "Stem cell transplant",
+                    "Surgery"
+                ],
+                "title": "TreatmentTypeEnum",
+                "type": "string"
+            },
+            "DonorWithClinicalDataSchema": {
+                "properties": {
+                    "submitter_donor_id": {
+                        "maxLength": 64,
+                        "pattern": "^[A-Za-z0-9\\-\\._]{1,64}",
+                        "title": "Submitter Donor Id",
+                        "type": "string"
+                    },
+                    "gender": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GenderEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "sex_at_birth": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SexAtBirthEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "is_deceased": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Is Deceased"
+                    },
+                    "lost_to_followup_after_clinical_event_identifier": {
+                        "anyOf": [
+                            {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Lost To Followup After Clinical Event Identifier"
+                    },
+                    "lost_to_followup_reason": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/LostToFollowupReasonEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "date_alive_after_lost_to_followup": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Date Alive After Lost To Followup"
+                    },
+                    "cause_of_death": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/CauseOfDeathEnum"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "date_of_birth": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Date Of Birth"
+                    },
+                    "date_of_death": {
+                        "anyOf": [
+                            {
+                                "maxLength": 32,
+                                "pattern": "^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Date Of Death"
+                    },
+                    "primary_site": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/PrimarySiteEnum"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Primary Site"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
                     "primary_diagnoses": {
                         "items": {
                             "$ref": "#/components/schemas/NestedPrimaryDiagnosisSchema"
@@ -7203,216 +8269,6 @@
                 ],
                 "title": "DonorWithClinicalDataSchema",
                 "type": "object"
-            },
-            "DosageUnitsEnum": {
-                "enum": [
-                    "mg/m2",
-                    "IU/m2",
-                    "IU/kg",
-                    "ug/m2",
-                    "g/m2",
-                    "mg/kg",
-                    "cells/kg"
-                ],
-                "title": "DosageUnitsEnum",
-                "type": "string"
-            },
-            "DrugReferenceDbEnum": {
-                "enum": [
-                    "RxNorm",
-                    "PubChem",
-                    "NCI Thesaurus"
-                ],
-                "title": "DrugReferenceDbEnum",
-                "type": "string"
-            },
-            "ErPrHpvStatusEnum": {
-                "enum": [
-                    "Cannot be determined",
-                    "Negative",
-                    "Not applicable",
-                    "Positive",
-                    "Unknown"
-                ],
-                "title": "ErPrHpvStatusEnum",
-                "type": "string"
-            },
-            "GenderEnum": {
-                "enum": [
-                    "Man",
-                    "Woman",
-                    "Non-binary"
-                ],
-                "title": "GenderEnum",
-                "type": "string"
-            },
-            "Her2StatusEnum": {
-                "enum": [
-                    "Cannot be determined",
-                    "Equivocal",
-                    "Positive",
-                    "Negative",
-                    "Not applicable",
-                    "Unknown"
-                ],
-                "title": "Her2StatusEnum",
-                "type": "string"
-            },
-            "HpvStrainEnum": {
-                "enum": [
-                    "HPV16",
-                    "HPV18",
-                    "HPV31",
-                    "HPV33",
-                    "HPV35",
-                    "HPV39",
-                    "HPV45",
-                    "HPV51",
-                    "HPV52",
-                    "HPV56",
-                    "HPV58",
-                    "HPV59",
-                    "HPV66",
-                    "HPV68",
-                    "HPV73"
-                ],
-                "title": "HpvStrainEnum",
-                "type": "string"
-            },
-            "ImmunotherapyTypeEnum": {
-                "enum": [
-                    "Cell-based",
-                    "Immune checkpoint inhibitors",
-                    "Monoclonal antibodies other than immune checkpoint inhibitors",
-                    "Other immunomodulatory substances"
-                ],
-                "title": "ImmunotherapyTypeEnum",
-                "type": "string"
-            },
-            "LostToFollowupReasonEnum": {
-                "enum": [
-                    "Completed study",
-                    "Discharged to palliative care",
-                    "Lost contact",
-                    "Not applicable",
-                    "Unknown",
-                    "Withdrew from study"
-                ],
-                "title": "LostToFollowupReasonEnum",
-                "type": "string"
-            },
-            "LymphNodeMethodEnum": {
-                "enum": [
-                    "Imaging",
-                    "Lymph node dissection/pathological exam",
-                    "Physical palpation of patient"
-                ],
-                "title": "LymphNodeMethodEnum",
-                "type": "string"
-            },
-            "LymphNodeStatusEnum": {
-                "enum": [
-                    "Cannot be determined",
-                    "No",
-                    "No lymph nodes found in resected specimen",
-                    "Not applicable",
-                    "Yes"
-                ],
-                "title": "LymphNodeStatusEnum",
-                "type": "string"
-            },
-            "LymphovascularInvasionEnum": {
-                "enum": [
-                    "Absent",
-                    "Both lymphatic and small vessel and venous (large vessel) invasion",
-                    "Lymphatic and small vessel invasion only",
-                    "Not applicable",
-                    "Present",
-                    "Venous (large vessel) invasion only",
-                    "Unknown"
-                ],
-                "title": "LymphovascularInvasionEnum",
-                "type": "string"
-            },
-            "MCategoryEnum": {
-                "enum": [
-                    "M0",
-                    "M0(i+)",
-                    "M1",
-                    "M1a",
-                    "M1a(0)",
-                    "M1a(1)",
-                    "M1b",
-                    "M1b(0)",
-                    "M1b(1)",
-                    "M1c",
-                    "M1c(0)",
-                    "M1c(1)",
-                    "M1d",
-                    "M1d(0)",
-                    "M1d(1)",
-                    "M1e",
-                    "MX"
-                ],
-                "title": "MCategoryEnum",
-                "type": "string"
-            },
-            "MalignancyLateralityEnum": {
-                "enum": [
-                    "Bilateral",
-                    "Left",
-                    "Midline",
-                    "Not applicable",
-                    "Right",
-                    "Unilateral, Side not specified",
-                    "Unknown"
-                ],
-                "title": "MalignancyLateralityEnum",
-                "type": "string"
-            },
-            "MarginTypesEnum": {
-                "enum": [
-                    "Circumferential resection margin",
-                    "Common bile duct margin",
-                    "Distal margin",
-                    "Not applicable",
-                    "Proximal margin",
-                    "Unknown"
-                ],
-                "title": "MarginTypesEnum",
-                "type": "string"
-            },
-            "NCategoryEnum": {
-                "enum": [
-                    "N0",
-                    "N0a",
-                    "N0a (biopsy)",
-                    "N0b",
-                    "N0b (no biopsy)",
-                    "N0(i+)",
-                    "N0(i-)",
-                    "N0(mol+)",
-                    "N0(mol-)",
-                    "N1",
-                    "N1a",
-                    "N1a(sn)",
-                    "N1b",
-                    "N1c",
-                    "N1mi",
-                    "N2",
-                    "N2a",
-                    "N2b",
-                    "N2c",
-                    "N2mi",
-                    "N3",
-                    "N3a",
-                    "N3b",
-                    "N3c",
-                    "N4",
-                    "NX"
-                ],
-                "title": "NCategoryEnum",
-                "type": "string"
             },
             "NestedBiomarkerSchema": {
                 "properties": {
@@ -8942,1027 +9798,6 @@
                 "title": "NestedTreatmentSchema",
                 "type": "object"
             },
-            "PercentCellsRangeEnum": {
-                "enum": [
-                    "0-19%",
-                    "20-50%",
-                    "51-100%"
-                ],
-                "title": "PercentCellsRangeEnum",
-                "type": "string"
-            },
-            "PerineuralInvasionEnum": {
-                "enum": [
-                    "Absent",
-                    "Cannot be assessed",
-                    "Not applicable",
-                    "Present",
-                    "Unknown"
-                ],
-                "title": "PerineuralInvasionEnum",
-                "type": "string"
-            },
-            "PrimaryDiagnosisLateralityEnum": {
-                "enum": [
-                    "Bilateral",
-                    "Left",
-                    "Midline",
-                    "Not a paired site",
-                    "Right",
-                    "Unilateral, side not specified",
-                    "Unknown"
-                ],
-                "title": "PrimaryDiagnosisLateralityEnum",
-                "type": "string"
-            },
-            "PrimarySiteEnum": {
-                "enum": [
-                    "Accessory sinuses",
-                    "Adrenal gland",
-                    "Anus and anal canal",
-                    "Base of tongue",
-                    "Bladder",
-                    "Bones, joints and articular cartilage of limbs",
-                    "Bones, joints and articular cartilage of other and unspecified sites",
-                    "Brain",
-                    "Breast",
-                    "Bronchus and lung",
-                    "Cervix uteri",
-                    "Colon",
-                    "Connective, subcutaneous and other soft tissues",
-                    "Corpus uteri",
-                    "Esophagus",
-                    "Eye and adnexa",
-                    "Floor of mouth",
-                    "Gallbladder",
-                    "Gum",
-                    "Heart, mediastinum, and pleura",
-                    "Hematopoietic and reticuloendothelial systems",
-                    "Hypopharynx",
-                    "Kidney",
-                    "Larynx",
-                    "Lip",
-                    "Liver and intrahepatic bile ducts",
-                    "Lymph nodes",
-                    "Meninges",
-                    "Nasal cavity and middle ear",
-                    "Nasopharynx",
-                    "Oropharynx",
-                    "Other and ill-defined digestive organs",
-                    "Other and ill-defined sites",
-                    "Other and ill-defined sites in lip, oral cavity and pharynx",
-                    "Other and ill-defined sites within respiratory system and intrathoracic organs",
-                    "Other and unspecified female genital organs",
-                    "Other and unspecified major salivary glands",
-                    "Other and unspecified male genital organs",
-                    "Other and unspecified parts of biliary tract",
-                    "Other and unspecified parts of mouth",
-                    "Other and unspecified parts of tongue",
-                    "Other and unspecified urinary organs",
-                    "Other endocrine glands and related structures",
-                    "Ovary",
-                    "Palate",
-                    "Pancreas",
-                    "Parotid gland",
-                    "Penis",
-                    "Peripheral nerves and autonomic nervous system",
-                    "Placenta",
-                    "Prostate gland",
-                    "Pyriform sinus",
-                    "Rectosigmoid junction",
-                    "Rectum",
-                    "Renal pelvis",
-                    "Retroperitoneum and peritoneum",
-                    "Skin",
-                    "Small intestine",
-                    "Spinal cord, cranial nerves, and other parts of central nervous system",
-                    "Stomach",
-                    "Testis",
-                    "Thymus",
-                    "Thyroid gland",
-                    "Tonsil",
-                    "Trachea",
-                    "Ureter",
-                    "Uterus, NOS",
-                    "Vagina",
-                    "Vulva",
-                    "Unknown primary site"
-                ],
-                "title": "PrimarySiteEnum",
-                "type": "string"
-            },
-            "ProgressionStatusMethodEnum": {
-                "enum": [
-                    "Imaging (procedure)",
-                    "Histopathology test (procedure)",
-                    "Assessment of symptom control (procedure)",
-                    "Physical examination procedure (procedure)",
-                    "Tumor marker measurement (procedure)",
-                    "Laboratory data interpretation (procedure)"
-                ],
-                "title": "ProgressionStatusMethodEnum",
-                "type": "string"
-            },
-            "RadiationAnatomicalSiteEnum": {
-                "enum": [
-                    "Left Abdomen",
-                    "Whole Abdomen",
-                    "Right Abdomen",
-                    "Lower Abdomen",
-                    "Left Lower Abdomen",
-                    "Right Lower Abdomen",
-                    "Upper Abdomen",
-                    "Left Upper Abdomen",
-                    "Right Upper Abdomen",
-                    "Left Adrenal",
-                    "Right Adrenal",
-                    "Bilateral Ankle",
-                    "Left Ankle",
-                    "Right Ankle",
-                    "Bilateral Antrum (Bull's Eye)",
-                    "Left Antrum",
-                    "Right Antrum",
-                    "Anus",
-                    "Lower Left Arm",
-                    "Lower Right Arm",
-                    "Bilateral Arms",
-                    "Left Arm",
-                    "Right Arm",
-                    "Upper Left Arm",
-                    "Upper Right Arm",
-                    "Left Axilla",
-                    "Right Axilla",
-                    "Skin or Soft Tissue of Back",
-                    "Bile Duct",
-                    "Bladder",
-                    "Lower Body",
-                    "Middle Body",
-                    "Upper Body",
-                    "Whole Body",
-                    "Boost - Area Previously Treated",
-                    "Brain",
-                    "Left Breast Boost",
-                    "Right Breast Boost",
-                    "Bilateral Breast",
-                    "Left Breast",
-                    "Right Breast",
-                    "Bilateral Breasts with Nodes",
-                    "Left Breast with Nodes",
-                    "Right Breast with Nodes",
-                    "Bilateral Buttocks",
-                    "Left Buttock",
-                    "Right Buttock",
-                    "Inner Canthus",
-                    "Outer Canthus",
-                    "Cervix",
-                    "Bilateral Chest Lung & Area Involve",
-                    "Left Chest",
-                    "Right Chest",
-                    "Chin",
-                    "Left Cheek",
-                    "Right Cheek",
-                    "Bilateral Chest Wall (W/o Breast)",
-                    "Left Chest Wall",
-                    "Right Chest Wall",
-                    "Bilateral Clavicle",
-                    "Left Clavicle",
-                    "Right Clavicle",
-                    "Coccyx",
-                    "Colon",
-                    "Whole C.N.S. (Medulla Techinque)",
-                    "Csf Spine (Medull Tech 2 Diff Machi",
-                    "Left Chestwall Boost",
-                    "Right Chestwall Boost",
-                    "Bilateral Chestwall with Nodes",
-                    "Left Chestwall with Nodes",
-                    "Right Chestwall with Nodes",
-                    "Left Ear",
-                    "Right Ear",
-                    "Epigastrium",
-                    "Lower Esophagus",
-                    "Middle Esophagus",
-                    "Upper Esophagus",
-                    "Entire Esophagus",
-                    "Ethmoid Sinus",
-                    "Bilateral Eyes",
-                    "Left Eye",
-                    "Right Eye",
-                    "Bilateral Face",
-                    "Left Face",
-                    "Right Face",
-                    "Left Fallopian Tubes",
-                    "Right Fallopian Tubes",
-                    "Bilateral Femur",
-                    "Left Femur",
-                    "Right Femur",
-                    "Left Fibula",
-                    "Right Fibula",
-                    "Finger (Including Thumbs)",
-                    "Floor of Mouth (Boosts)",
-                    "Bilateral Feet",
-                    "Left Foot",
-                    "Right Foot",
-                    "Forehead",
-                    "Posterior Fossa",
-                    "Gall Bladder",
-                    "Gingiva",
-                    "Bilateral Hand",
-                    "Left Hand",
-                    "Right Hand",
-                    "Head",
-                    "Bilateral Heel",
-                    "Left Heel",
-                    "Right Heel",
-                    "Left Hemimantle",
-                    "Right Hemimantle",
-                    "Heart",
-                    "Bilateral Hip",
-                    "Left Hip",
-                    "Right Hip",
-                    "Left Humerus",
-                    "Right Humerus",
-                    "Hypopharynx",
-                    "Bilateral Internal Mammary Chain",
-                    "Bilateral Inguinal Nodes",
-                    "Left Inguinal Nodes",
-                    "Right Inguinal Nodes",
-                    "Inverted 'Y' (Dog-Leg,Hockey-Stick)",
-                    "Left Kidney",
-                    "Right Kidney",
-                    "Bilateral Knee",
-                    "Left Knee",
-                    "Right Knee",
-                    "Bilateral Lacrimal Gland",
-                    "Left Lacrimal Gland",
-                    "Right Lacrimal Gland",
-                    "Larygopharynx",
-                    "Larynx",
-                    "Bilateral Leg",
-                    "Left Leg",
-                    "Right Leg",
-                    "Lower Bilateral Leg",
-                    "Lower Left Leg",
-                    "Lower Right Leg",
-                    "Upper Bilateral Leg",
-                    "Upper Left Leg",
-                    "Upper Right Leg",
-                    "Both Eyelid(s)",
-                    "Left Eyelid",
-                    "Right Eyelid",
-                    "Both Lip(s)",
-                    "Lower Lip",
-                    "Upper Lip",
-                    "Liver",
-                    "Bilateral Lung",
-                    "Left Lung",
-                    "Right Lung",
-                    "Bilateral Mandible",
-                    "Left Mandible",
-                    "Right Mandible",
-                    "Mantle",
-                    "Bilateral Maxilla",
-                    "Left Maxilla",
-                    "Right Maxilla",
-                    "Mediastinum",
-                    "Multiple Skin",
-                    "Nasal Fossa",
-                    "Nasopharynx",
-                    "Bilateral Neck Includes Nodes",
-                    "Left Neck Includes Nodes",
-                    "Right Neck Includes Nodes",
-                    "Neck - Skin",
-                    "Nose",
-                    "Oral Cavity / Buccal Mucosa",
-                    "Bilateral Orbit",
-                    "Left Orbit",
-                    "Right Orbit",
-                    "Oropharynx",
-                    "Bilateral Ovary",
-                    "Left Ovary",
-                    "Right Ovary",
-                    "Hard Palate",
-                    "Soft Palate",
-                    "Palate Unspecified",
-                    "Pancreas",
-                    "Para-Aortic Nodes",
-                    "Left Parotid",
-                    "Right Parotid",
-                    "Bilateral Pelvis",
-                    "Left Pelvis",
-                    "Right Pelvis",
-                    "Penis",
-                    "Perineum",
-                    "Pituitary",
-                    "Left Pleura (As in Mesothelioma)",
-                    "Right Pleura",
-                    "Prostate",
-                    "Pubis",
-                    "Pyriform Fossa (Sinuses)",
-                    "Left Radius",
-                    "Right Radius",
-                    "Rectum (Includes Sigmoid)",
-                    "Left Ribs",
-                    "Right Ribs",
-                    "Sacrum",
-                    "Left Salivary Gland",
-                    "Right Salivary Gland",
-                    "Bilateral Scapula",
-                    "Left Scapula",
-                    "Right Scapula",
-                    "Bilateral Supraclavicular Nodes",
-                    "Left Supraclavicular Nodes",
-                    "Right Supraclavicular Nodes",
-                    "Bilateral Scalp",
-                    "Left Scalp",
-                    "Right Scalp",
-                    "Scrotum",
-                    "Bilateral Shoulder",
-                    "Left Shoulder",
-                    "Right Shoulder",
-                    "Whole Body - Skin",
-                    "Skull",
-                    "Cervical & Thoracic Spine",
-                    "Sphenoid Sinus",
-                    "Cervical Spine",
-                    "Lumbar Spine",
-                    "Thoracic Spine",
-                    "Whole Spine",
-                    "Spleen",
-                    "Lumbo-Sacral Spine",
-                    "Thoracic & Lumbar Spine",
-                    "Sternum",
-                    "Stomach",
-                    "Submandibular Glands",
-                    "Left Temple",
-                    "Right Temple",
-                    "Bilateral Testis",
-                    "Left Testis",
-                    "Right Testis",
-                    "Thyroid",
-                    "Left Tibia",
-                    "Right Tibia",
-                    "Left Toes",
-                    "Right Toes",
-                    "Tongue",
-                    "Tonsil",
-                    "Trachea",
-                    "Left Ulna",
-                    "Right Ulna",
-                    "Left Ureter",
-                    "Right Ureter",
-                    "Urethra",
-                    "Uterus",
-                    "Uvula",
-                    "Vagina",
-                    "Vulva",
-                    "Abdomen",
-                    "Body",
-                    "Chest",
-                    "Lower Limb",
-                    "Neck",
-                    "Other",
-                    "Pelvis",
-                    "Skin",
-                    "Spine",
-                    "Upper Limb"
-                ],
-                "title": "RadiationAnatomicalSiteEnum",
-                "type": "string"
-            },
-            "RadiationTherapyModalityEnum": {
-                "enum": [
-                    "Megavoltage radiation therapy using photons (procedure)",
-                    "Radiopharmaceutical",
-                    "Teleradiotherapy using electrons (procedure)",
-                    "Teleradiotherapy protons (procedure)",
-                    "Teleradiotherapy neutrons (procedure)",
-                    "Brachytherapy (procedure)",
-                    "Other"
-                ],
-                "title": "RadiationTherapyModalityEnum",
-                "type": "string"
-            },
-            "RelapseTypeEnum": {
-                "enum": [
-                    "Distant recurrence/metastasis",
-                    "Local recurrence",
-                    "Local recurrence and distant metastasis",
-                    "Progression (liquid tumours)",
-                    "Biochemical progression"
-                ],
-                "title": "RelapseTypeEnum",
-                "type": "string"
-            },
-            "SampleTypeEnum": {
-                "enum": [
-                    "Amplified DNA",
-                    "ctDNA",
-                    "Other DNA enrichments",
-                    "Other RNA fractions",
-                    "polyA+ RNA",
-                    "Protein",
-                    "rRNA-depleted RNA",
-                    "Total DNA",
-                    "Total RNA"
-                ],
-                "title": "SampleTypeEnum",
-                "type": "string"
-            },
-            "SexAtBirthEnum": {
-                "enum": [
-                    "Male",
-                    "Female",
-                    "Other",
-                    "Unknown"
-                ],
-                "title": "SexAtBirthEnum",
-                "type": "string"
-            },
-            "SmokingStatusEnum": {
-                "enum": [
-                    "Current reformed smoker for <= 15 years",
-                    "Current reformed smoker for > 15 years",
-                    "Current reformed smoker, duration not specified",
-                    "Current smoker",
-                    "Lifelong non-smoker (<100 cigarettes smoked in lifetime)",
-                    "Not applicable",
-                    "Smoking history not documented"
-                ],
-                "title": "SmokingStatusEnum",
-                "type": "string"
-            },
-            "SpecimenLateralityEnum": {
-                "enum": [
-                    "Left",
-                    "Not applicable",
-                    "Right",
-                    "Unknown"
-                ],
-                "title": "SpecimenLateralityEnum",
-                "type": "string"
-            },
-            "SpecimenProcessingEnum": {
-                "enum": [
-                    "Cryopreservation in liquid nitrogen (dead tissue)",
-                    "Cryopreservation in dry ice (dead tissue)",
-                    "Cryopreservation of live cells in liquid nitrogen",
-                    "Cryopreservation - other",
-                    "Formalin fixed & paraffin embedded",
-                    "Formalin fixed - buffered",
-                    "Formalin fixed - unbuffered",
-                    "Fresh",
-                    "Other",
-                    "Unknown"
-                ],
-                "title": "SpecimenProcessingEnum",
-                "type": "string"
-            },
-            "SpecimenTissueSourceEnum": {
-                "enum": [
-                    "Abdominal fluid",
-                    "Amniotic fluid",
-                    "Arterial blood",
-                    "Bile",
-                    "Blood derived - bone marrow",
-                    "Blood derived - peripheral blood",
-                    "Bone marrow fluid",
-                    "Bone marrow derived mononuclear cells",
-                    "Buccal cell",
-                    "Buffy coat",
-                    "Cerebrospinal fluid",
-                    "Cervical mucus",
-                    "Convalescent plasma",
-                    "Cord blood",
-                    "Duodenal fluid",
-                    "Female genital fluid",
-                    "Fetal blood",
-                    "Hydrocele fluid",
-                    "Male genital fluid",
-                    "Pancreatic fluid",
-                    "Pericardial effusion",
-                    "Pleural fluid",
-                    "Renal cyst fluid",
-                    "Saliva",
-                    "Seminal fluid",
-                    "Serum",
-                    "Solid tissue",
-                    "Sputum",
-                    "Synovial fluid",
-                    "Urine",
-                    "Venous blood",
-                    "Vitreous fluid",
-                    "Whole blood",
-                    "Wound"
-                ],
-                "title": "SpecimenTissueSourceEnum",
-                "type": "string"
-            },
-            "SpecimenTypeEnum": {
-                "enum": [
-                    "Cell line - derived from normal",
-                    "Cell line - derived from primary tumour",
-                    "Cell line - derived from metastatic tumour",
-                    "Cell line - derived from xenograft tumour",
-                    "Metastatic tumour - additional metastatic",
-                    "Metastatic tumour - metastasis local to lymph node",
-                    "Metastatic tumour - metastasis to distant location",
-                    "Metastatic tumour",
-                    "Normal - tissue adjacent to primary tumour",
-                    "Normal",
-                    "Primary tumour - additional new primary",
-                    "Primary tumour - adjacent to normal",
-                    "Primary tumour",
-                    "Recurrent tumour",
-                    "Tumour - unknown if derived from primary or metastatic tumour",
-                    "Xenograft - derived from primary tumour",
-                    "Xenograft - derived from metastatic tumour",
-                    "Xenograft - derived from tumour cell line"
-                ],
-                "title": "SpecimenTypeEnum",
-                "type": "string"
-            },
-            "StageGroupEnum": {
-                "enum": [
-                    "Stage 0",
-                    "Stage 0a",
-                    "Stage 0is",
-                    "Stage 1",
-                    "Stage 1A",
-                    "Stage 1B",
-                    "Stage A",
-                    "Stage B",
-                    "Stage C",
-                    "Stage I",
-                    "Stage IA",
-                    "Stage IA1",
-                    "Stage IA2",
-                    "Stage IA3",
-                    "Stage IAB",
-                    "Stage IAE",
-                    "Stage IAES",
-                    "Stage IAS",
-                    "Stage IB",
-                    "Stage IB1",
-                    "Stage IB2",
-                    "Stage IBE",
-                    "Stage IBES",
-                    "Stage IBS",
-                    "Stage IC",
-                    "Stage IE",
-                    "Stage IEA",
-                    "Stage IEB",
-                    "Stage IES",
-                    "Stage II",
-                    "Stage II bulky",
-                    "Stage IIA",
-                    "Stage IIA1",
-                    "Stage IIA2",
-                    "Stage IIAE",
-                    "Stage IIAES",
-                    "Stage IIAS",
-                    "Stage IIB",
-                    "Stage IIBE",
-                    "Stage IIBES",
-                    "Stage IIBS",
-                    "Stage IIC",
-                    "Stage IIE",
-                    "Stage IIEA",
-                    "Stage IIEB",
-                    "Stage IIES",
-                    "Stage III",
-                    "Stage IIIA",
-                    "Stage IIIA1",
-                    "Stage IIIA2",
-                    "Stage IIIAE",
-                    "Stage IIIAES",
-                    "Stage IIIAS",
-                    "Stage IIIB",
-                    "Stage IIIBE",
-                    "Stage IIIBES",
-                    "Stage IIIBS",
-                    "Stage IIIC",
-                    "Stage IIIC1",
-                    "Stage IIIC2",
-                    "Stage IIID",
-                    "Stage IIIE",
-                    "Stage IIIES",
-                    "Stage IIIS",
-                    "Stage IIS",
-                    "Stage IS",
-                    "Stage IV",
-                    "Stage IVA",
-                    "Stage IVA1",
-                    "Stage IVA2",
-                    "Stage IVAE",
-                    "Stage IVAES",
-                    "Stage IVAS",
-                    "Stage IVB",
-                    "Stage IVBE",
-                    "Stage IVBES",
-                    "Stage IVBS",
-                    "Stage IVC",
-                    "Stage IVE",
-                    "Stage IVES",
-                    "Stage IVS",
-                    "In situ",
-                    "Localized",
-                    "Regionalized",
-                    "Distant",
-                    "Stage L1",
-                    "Stage L2",
-                    "Stage M",
-                    "Stage Ms",
-                    "Stage 2A",
-                    "Stage 2B",
-                    "Stage 3",
-                    "Stage 4",
-                    "Stage 4S",
-                    "Occult Carcinoma"
-                ],
-                "title": "StageGroupEnum",
-                "type": "string"
-            },
-            "StorageEnum": {
-                "enum": [
-                    "Cut slide",
-                    "Frozen in -70 freezer",
-                    "Frozen in liquid nitrogen",
-                    "Frozen in vapour phase",
-                    "Not Applicable",
-                    "Other",
-                    "Paraffin block",
-                    "RNA later frozen",
-                    "Unknown"
-                ],
-                "title": "StorageEnum",
-                "type": "string"
-            },
-            "SurgeryLocationEnum": {
-                "enum": [
-                    "Local recurrence",
-                    "Metastatic",
-                    "Primary"
-                ],
-                "title": "SurgeryLocationEnum",
-                "type": "string"
-            },
-            "SurgeryTypeEnum": {
-                "enum": [
-                    "Ablation",
-                    "Axillary Clearance",
-                    "Axillary lymph nodes sampling",
-                    "Bilateral complete salpingo-oophorectomy",
-                    "Biopsy",
-                    "Bypass Gastrojejunostomy",
-                    "Cholecystectomy",
-                    "Cholecystojejunostomy",
-                    "Completion Gastrectomy",
-                    "Debridement of pancreatic and peripancreatic necrosis",
-                    "Distal subtotal pancreatectomy",
-                    "Drainage of abscess",
-                    "Duodenal preserving pancreatic head resection",
-                    "Endoscopic biopsy",
-                    "Endoscopic brushings of gastrointestinal tract",
-                    "Enucleation",
-                    "Esophageal bypass surgery/jejunostomy only",
-                    "Exploratory laparotomy",
-                    "Fine needle aspiration biopsy",
-                    "Gastric Antrectomy",
-                    "Glossectomy",
-                    "Hepatojejunostomy",
-                    "Hysterectomy",
-                    "Incision of thorax",
-                    "Ivor Lewis subtotal esophagectomy",
-                    "Laparotomy",
-                    "Left thoracoabdominal incision",
-                    "Lobectomy",
-                    "Mammoplasty",
-                    "Mastectomy",
-                    "McKeown esophagectomy",
-                    "Merendino procedure",
-                    "Minimally invasive esophagectomy",
-                    "Omentectomy",
-                    "Ovariectomy",
-                    "Pancreaticoduodenectomy (Whipple procedure)",
-                    "Pancreaticojejunostomy, side-to-side anastomosis",
-                    "Partial pancreatectomy",
-                    "Pneumonectomy",
-                    "Prostatectomy",
-                    "Proximal subtotal gastrectomy",
-                    "Pylorus-sparing Whipple operation",
-                    "Radical pancreaticoduodenectomy",
-                    "Radical prostatectomy",
-                    "Reexcision",
-                    "Segmentectomy",
-                    "Sentinal Lymph Node Biopsy",
-                    "Spleen preserving distal pancreatectomy",
-                    "Splenectomy",
-                    "Total gastrectomy",
-                    "Total gastrectomy with extended lymphadenectomy",
-                    "Total pancreatectomy",
-                    "Transhiatal esophagectomy",
-                    "Triple bypass of pancreas",
-                    "Tumor Debulking",
-                    "Wedge/localised gastric resection",
-                    "Wide Local Excision"
-                ],
-                "title": "SurgeryTypeEnum",
-                "type": "string"
-            },
-            "TCategoryEnum": {
-                "enum": [
-                    "T0",
-                    "T1",
-                    "T1a",
-                    "T1a1",
-                    "T1a2",
-                    "T1a(s)",
-                    "T1a(m)",
-                    "T1b",
-                    "T1b1",
-                    "T1b2",
-                    "T1b(s)",
-                    "T1b(m)",
-                    "T1c",
-                    "T1d",
-                    "T1mi",
-                    "T2",
-                    "T2(s)",
-                    "T2(m)",
-                    "T2a",
-                    "T2a1",
-                    "T2a2",
-                    "T2b",
-                    "T2c",
-                    "T2d",
-                    "T3",
-                    "T3(s)",
-                    "T3(m)",
-                    "T3a",
-                    "T3b",
-                    "T3c",
-                    "T3d",
-                    "T3e",
-                    "T4",
-                    "T4a",
-                    "T4a(s)",
-                    "T4a(m)",
-                    "T4b",
-                    "T4b(s)",
-                    "T4b(m)",
-                    "T4c",
-                    "T4d",
-                    "T4e",
-                    "Ta",
-                    "Tis",
-                    "Tis(DCIS)",
-                    "Tis(LAMN)",
-                    "Tis(LCIS)",
-                    "Tis(Paget)",
-                    "Tis(Paget's)",
-                    "Tis pu",
-                    "Tis pd",
-                    "TX"
-                ],
-                "title": "TCategoryEnum",
-                "type": "string"
-            },
-            "TherapyTypeEnum": {
-                "enum": [
-                    "External",
-                    "Internal"
-                ],
-                "title": "TherapyTypeEnum",
-                "type": "string"
-            },
-            "TobaccoTypeEnum": {
-                "enum": [
-                    "Chewing Tobacco",
-                    "Cigar",
-                    "Cigarettes",
-                    "Electronic cigarettes",
-                    "Not applicable",
-                    "Pipe",
-                    "Roll-ups",
-                    "Snuff",
-                    "Unknown",
-                    "Waterpipe"
-                ],
-                "title": "TobaccoTypeEnum",
-                "type": "string"
-            },
-            "TreatmentIntentEnum": {
-                "enum": [
-                    "Curative",
-                    "Palliative",
-                    "Supportive",
-                    "Diagnostic",
-                    "Preventive",
-                    "Guidance",
-                    "Screening",
-                    "Forensic"
-                ],
-                "title": "TreatmentIntentEnum",
-                "type": "string"
-            },
-            "TreatmentResponseEnum": {
-                "enum": [
-                    "Complete response",
-                    "Partial response",
-                    "Progressive disease",
-                    "Stable disease",
-                    "Immune complete response (iCR)",
-                    "Immune partial response (iPR)",
-                    "Immune uncomfirmed progressive disease (iUPD)",
-                    "Immune confirmed progressive disease (iCPD)",
-                    "Immune stable disease (iSD)",
-                    "Complete remission",
-                    "Partial remission",
-                    "Minor response",
-                    "Complete remission without measurable residual disease (CR MRD-)",
-                    "Complete remission with incomplete hematologic recovery (CRi)",
-                    "Morphologic leukemia-free state",
-                    "Primary refractory disease",
-                    "Hematologic relapse (after CR MRD-, CR, CRi)",
-                    "Molecular relapse (after CR MRD-)",
-                    "Physician assessed complete response",
-                    "Physician assessed partial response",
-                    "Physician assessed stable disease",
-                    "No evidence of disease (NED)",
-                    "Major response"
-                ],
-                "title": "TreatmentResponseEnum",
-                "type": "string"
-            },
-            "TreatmentResponseMethodEnum": {
-                "enum": [
-                    "RECIST 1.1",
-                    "iRECIST",
-                    "Cheson CLL 2012 Oncology Response Criteria",
-                    "Response Assessment in Neuro-Oncology (RANO)",
-                    "AML Response Criteria",
-                    "Physician Assessed Response Criteria",
-                    "Blazer score"
-                ],
-                "title": "TreatmentResponseMethodEnum",
-                "type": "string"
-            },
-            "TreatmentSettingEnum": {
-                "enum": [
-                    "Adjuvant",
-                    "Advanced/Metastatic",
-                    "Neoadjuvant",
-                    "Conditioning",
-                    "Induction",
-                    "Locally advanced",
-                    "Maintenance",
-                    "Mobilization",
-                    "Preventative",
-                    "Radiosensitization",
-                    "Salvage"
-                ],
-                "title": "TreatmentSettingEnum",
-                "type": "string"
-            },
-            "TreatmentStatusEnum": {
-                "enum": [
-                    "Treatment completed as prescribed",
-                    "Treatment incomplete due to technical or organizational problems",
-                    "Treatment incomplete because patient died",
-                    "Patient choice (stopped or interrupted treatment)",
-                    "Physician decision (stopped or interrupted treatment)",
-                    "Treatment stopped due to lack of efficacy (disease progression)",
-                    "Treatment stopped due to acute toxicity",
-                    "Other",
-                    "Not applicable",
-                    "Unknown"
-                ],
-                "title": "TreatmentStatusEnum",
-                "type": "string"
-            },
-            "TreatmentTypeEnum": {
-                "enum": [
-                    "Bone marrow transplant",
-                    "Chemotherapy",
-                    "Hormonal therapy",
-                    "Immunotherapy",
-                    "No treatment",
-                    "Other targeting molecular therapy",
-                    "Photodynamic therapy",
-                    "Radiation therapy",
-                    "Stem cell transplant",
-                    "Surgery"
-                ],
-                "title": "TreatmentTypeEnum",
-                "type": "string"
-            },
-            "TumourClassificationEnum": {
-                "enum": [
-                    "Not applicable",
-                    "RX",
-                    "R0",
-                    "R1",
-                    "R2",
-                    "Unknown"
-                ],
-                "title": "TumourClassificationEnum",
-                "type": "string"
-            },
-            "TumourDesginationEnum": {
-                "enum": [
-                    "Normal",
-                    "Tumour"
-                ],
-                "title": "TumourDesginationEnum",
-                "type": "string"
-            },
-            "TumourFocalityEnum": {
-                "enum": [
-                    "Cannot be assessed",
-                    "Multifocal",
-                    "Not applicable",
-                    "Unifocal",
-                    "Unknown"
-                ],
-                "title": "TumourFocalityEnum",
-                "type": "string"
-            },
-            "TumourGradeEnum": {
-                "enum": [
-                    "Low grade",
-                    "High grade",
-                    "GX",
-                    "G1",
-                    "G2",
-                    "G3",
-                    "G4",
-                    "Low",
-                    "High",
-                    "Grade 1",
-                    "Grade 2",
-                    "Grade 3",
-                    "Grade 4",
-                    "Grade I",
-                    "Grade II",
-                    "Grade III",
-                    "Grade IV",
-                    "Grade Group 1",
-                    "Grade Group 2",
-                    "Grade Group 3",
-                    "Grade Group 4",
-                    "Grade Group 5"
-                ],
-                "title": "TumourGradeEnum",
-                "type": "string"
-            },
-            "TumourGradingSystemEnum": {
-                "enum": [
-                    "FNCLCC grading system",
-                    "Four-tier grading system",
-                    "Gleason grade group system",
-                    "Grading system for GISTs",
-                    "Grading system for GNETs",
-                    "IASLC grading system",
-                    "ISUP grading system",
-                    "Nottingham grading system",
-                    "Nuclear grading system for DCIS",
-                    "Scarff-Bloom-Richardson grading system",
-                    "Three-tier grading system",
-                    "Two-tier grading system",
-                    "WHO grading system for CNS tumours"
-                ],
-                "title": "TumourGradingSystemEnum",
-                "type": "string"
-            },
-            "TumourStagingSystemEnum": {
-                "enum": [
-                    "AJCC 8th edition",
-                    "AJCC 7th edition",
-                    "AJCC 6th edition",
-                    "Ann Arbor staging system",
-                    "Binet staging system",
-                    "Durie-Salmon staging system",
-                    "FIGO staging system",
-                    "International Neuroblastoma Risk Group Staging System",
-                    "International Neuroblastoma Staging System",
-                    "Lugano staging system",
-                    "Rai staging system",
-                    "Revised International staging system (RISS)",
-                    "SEER staging system",
-                    "St Jude staging system"
-                ],
-                "title": "TumourStagingSystemEnum",
-                "type": "string"
-            },
-            "uBooleanEnum": {
-                "enum": [
-                    "Yes",
-                    "No",
-                    "Unknown"
-                ],
-                "title": "uBooleanEnum",
-                "type": "string"
-            },
             "Input": {
                 "properties": {
                     "page": {
@@ -10228,10 +10063,6 @@
                         "title": "Submitter Donor Id",
                         "type": "string"
                     },
-                    "program_id": {
-                        "title": "Program Id",
-                        "type": "string"
-                    },
                     "gender": {
                         "anyOf": [
                             {
@@ -10347,6 +10178,10 @@
                             }
                         ],
                         "title": "Primary Site"
+                    },
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/chord_metadata_service/mohpackets/docs/schema.json
+++ b/chord_metadata_service/mohpackets/docs/schema.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "MoH Service API",
         "version": "3.0.0",
-        "description": "This is the RESTful API for the MoH Service."
+        "description": "This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/a6cdc8842cb086d3065578080032e148e5a3fdf7/chord_metadata_service/mohpackets/docs/schema.json"
     },
     "paths": {
         "/v2/service-info": {

--- a/chord_metadata_service/mohpackets/docs/schema.md
+++ b/chord_metadata_service/mohpackets/docs/schema.md
@@ -1,7 +1,7 @@
 
 <h1 id="moh-service-api">MoH Service API v3.0.0</h1>
 
-This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/5c640ce73d080b89ec2bdd80857bf826213dab04/chord_metadata_service/mohpackets/docs/schema.json
+This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/a6cdc8842cb086d3065578080032e148e5a3fdf7/chord_metadata_service/mohpackets/docs/schema.json
 
 Base URLs:
 
@@ -280,7 +280,6 @@ Base URLs:
 ```json
 {
   "submitter_donor_id": "string",
-  "program_id": "string",
   "gender": "Man",
   "sex_at_birth": "Male",
   "is_deceased": true,
@@ -293,6 +292,7 @@ Base URLs:
   "primary_site": [
     "Accessory sinuses"
   ],
+  "program_id": "string",
   "primary_diagnoses": [
     {
       "submitter_primary_diagnosis_id": "string",
@@ -603,7 +603,6 @@ Base URLs:
   "items": [
     {
       "submitter_donor_id": "string",
-      "program_id": "string",
       "gender": "Man",
       "sex_at_birth": "Male",
       "is_deceased": true,
@@ -615,7 +614,8 @@ Base URLs:
       "date_of_death": "string",
       "primary_site": [
         "Accessory sinuses"
-      ]
+      ],
+      "program_id": "string"
     }
   ],
   "count": 0,
@@ -1896,24 +1896,7 @@ ProgramIngestSchema
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|program_id|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
+|program_id|string|true|none|none|
 |metadata|any|false|none|none|
 
 anyOf
@@ -1935,6 +1918,34 @@ continued
 |created|string(date-time)|false|none|none|
 |updated|string(date-time)|false|none|none|
 
+<h2 id="tocS_CauseOfDeathEnum">CauseOfDeathEnum</h2>
+
+<a id="schemacauseofdeathenum"></a>
+<a id="schema_CauseOfDeathEnum"></a>
+<a id="tocScauseofdeathenum"></a>
+<a id="tocscauseofdeathenum"></a>
+
+```json
+"Died of cancer"
+
+```
+
+CauseOfDeathEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|CauseOfDeathEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|CauseOfDeathEnum|Died of cancer|
+|CauseOfDeathEnum|Died of other reasons|
+|CauseOfDeathEnum|Unknown|
+
 <h2 id="tocS_DonorIngestSchema">DonorIngestSchema</h2>
 
 <a id="schemadonoringestschema"></a>
@@ -1944,21 +1955,21 @@ continued
 
 ```json
 {
-  "program_id": "string",
-  "uuid": "string",
   "submitter_donor_id": "string",
-  "gender": "string",
-  "sex_at_birth": "string",
+  "gender": "Man",
+  "sex_at_birth": "Male",
   "is_deceased": true,
   "lost_to_followup_after_clinical_event_identifier": "string",
-  "lost_to_followup_reason": "string",
+  "lost_to_followup_reason": "Completed study",
   "date_alive_after_lost_to_followup": "string",
-  "cause_of_death": "string",
+  "cause_of_death": "Died of cancer",
   "date_of_birth": "string",
   "date_of_death": "string",
   "primary_site": [
-    null
-  ]
+    "Accessory sinuses"
+  ],
+  "program_id": "string",
+  "uuid": "string"
 }
 
 ```
@@ -1969,25 +1980,6 @@ DonorIngestSchema
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|program_id|string|true|none|none|
-|uuid|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
 |submitter_donor_id|string|true|none|none|
 |gender|any|false|none|none|
 
@@ -1995,7 +1987,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[GenderEnum](#schemagenderenum)|false|none|none|
 
 or
 
@@ -2013,7 +2005,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SexAtBirthEnum](#schemasexatbirthenum)|false|none|none|
 
 or
 
@@ -2067,7 +2059,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[LostToFollowupReasonEnum](#schemalosttofollowupreasonenum)|false|none|none|
 
 or
 
@@ -2103,7 +2095,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[CauseOfDeathEnum](#schemacauseofdeathenum)|false|none|none|
 
 or
 
@@ -2157,7 +2149,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
+|» *anonymous*|[[PrimarySiteEnum](#schemaprimarysiteenum)]|false|none|none|
 
 or
 
@@ -2165,44 +2157,7 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_BiomarkerIngestSchema">BiomarkerIngestSchema</h2>
-
-<a id="schemabiomarkeringestschema"></a>
-<a id="schema_BiomarkerIngestSchema"></a>
-<a id="tocSbiomarkeringestschema"></a>
-<a id="tocsbiomarkeringestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_donor_id": "string",
-  "submitter_specimen_id": "string",
-  "submitter_primary_diagnosis_id": "string",
-  "submitter_treatment_id": "string",
-  "submitter_follow_up_id": "string",
-  "test_date": "string",
-  "psa_level": 0,
-  "ca125": 0,
-  "cea": 0,
-  "er_status": "string",
-  "er_percent_positive": 0,
-  "pr_status": "string",
-  "pr_percent_positive": 0,
-  "her2_ihc_status": "string",
-  "her2_ish_status": "string",
-  "hpv_ihc_status": "string",
-  "hpv_pcr_status": "string",
-  "hpv_strain": [
-    null
-  ]
-}
-
-```
-
-BiomarkerIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
@@ -2221,11 +2176,230 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_GenderEnum">GenderEnum</h2>
+
+<a id="schemagenderenum"></a>
+<a id="schema_GenderEnum"></a>
+<a id="tocSgenderenum"></a>
+<a id="tocsgenderenum"></a>
+
+```json
+"Man"
+
+```
+
+GenderEnum
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_donor_id|string|true|none|none|
+|GenderEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|GenderEnum|Man|
+|GenderEnum|Woman|
+|GenderEnum|Non-binary|
+
+<h2 id="tocS_LostToFollowupReasonEnum">LostToFollowupReasonEnum</h2>
+
+<a id="schemalosttofollowupreasonenum"></a>
+<a id="schema_LostToFollowupReasonEnum"></a>
+<a id="tocSlosttofollowupreasonenum"></a>
+<a id="tocslosttofollowupreasonenum"></a>
+
+```json
+"Completed study"
+
+```
+
+LostToFollowupReasonEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|LostToFollowupReasonEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|LostToFollowupReasonEnum|Completed study|
+|LostToFollowupReasonEnum|Discharged to palliative care|
+|LostToFollowupReasonEnum|Lost contact|
+|LostToFollowupReasonEnum|Not applicable|
+|LostToFollowupReasonEnum|Unknown|
+|LostToFollowupReasonEnum|Withdrew from study|
+
+<h2 id="tocS_PrimarySiteEnum">PrimarySiteEnum</h2>
+
+<a id="schemaprimarysiteenum"></a>
+<a id="schema_PrimarySiteEnum"></a>
+<a id="tocSprimarysiteenum"></a>
+<a id="tocsprimarysiteenum"></a>
+
+```json
+"Accessory sinuses"
+
+```
+
+PrimarySiteEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|PrimarySiteEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|PrimarySiteEnum|Accessory sinuses|
+|PrimarySiteEnum|Adrenal gland|
+|PrimarySiteEnum|Anus and anal canal|
+|PrimarySiteEnum|Base of tongue|
+|PrimarySiteEnum|Bladder|
+|PrimarySiteEnum|Bones, joints and articular cartilage of limbs|
+|PrimarySiteEnum|Bones, joints and articular cartilage of other and unspecified sites|
+|PrimarySiteEnum|Brain|
+|PrimarySiteEnum|Breast|
+|PrimarySiteEnum|Bronchus and lung|
+|PrimarySiteEnum|Cervix uteri|
+|PrimarySiteEnum|Colon|
+|PrimarySiteEnum|Connective, subcutaneous and other soft tissues|
+|PrimarySiteEnum|Corpus uteri|
+|PrimarySiteEnum|Esophagus|
+|PrimarySiteEnum|Eye and adnexa|
+|PrimarySiteEnum|Floor of mouth|
+|PrimarySiteEnum|Gallbladder|
+|PrimarySiteEnum|Gum|
+|PrimarySiteEnum|Heart, mediastinum, and pleura|
+|PrimarySiteEnum|Hematopoietic and reticuloendothelial systems|
+|PrimarySiteEnum|Hypopharynx|
+|PrimarySiteEnum|Kidney|
+|PrimarySiteEnum|Larynx|
+|PrimarySiteEnum|Lip|
+|PrimarySiteEnum|Liver and intrahepatic bile ducts|
+|PrimarySiteEnum|Lymph nodes|
+|PrimarySiteEnum|Meninges|
+|PrimarySiteEnum|Nasal cavity and middle ear|
+|PrimarySiteEnum|Nasopharynx|
+|PrimarySiteEnum|Oropharynx|
+|PrimarySiteEnum|Other and ill-defined digestive organs|
+|PrimarySiteEnum|Other and ill-defined sites|
+|PrimarySiteEnum|Other and ill-defined sites in lip, oral cavity and pharynx|
+|PrimarySiteEnum|Other and ill-defined sites within respiratory system and intrathoracic organs|
+|PrimarySiteEnum|Other and unspecified female genital organs|
+|PrimarySiteEnum|Other and unspecified major salivary glands|
+|PrimarySiteEnum|Other and unspecified male genital organs|
+|PrimarySiteEnum|Other and unspecified parts of biliary tract|
+|PrimarySiteEnum|Other and unspecified parts of mouth|
+|PrimarySiteEnum|Other and unspecified parts of tongue|
+|PrimarySiteEnum|Other and unspecified urinary organs|
+|PrimarySiteEnum|Other endocrine glands and related structures|
+|PrimarySiteEnum|Ovary|
+|PrimarySiteEnum|Palate|
+|PrimarySiteEnum|Pancreas|
+|PrimarySiteEnum|Parotid gland|
+|PrimarySiteEnum|Penis|
+|PrimarySiteEnum|Peripheral nerves and autonomic nervous system|
+|PrimarySiteEnum|Placenta|
+|PrimarySiteEnum|Prostate gland|
+|PrimarySiteEnum|Pyriform sinus|
+|PrimarySiteEnum|Rectosigmoid junction|
+|PrimarySiteEnum|Rectum|
+|PrimarySiteEnum|Renal pelvis|
+|PrimarySiteEnum|Retroperitoneum and peritoneum|
+|PrimarySiteEnum|Skin|
+|PrimarySiteEnum|Small intestine|
+|PrimarySiteEnum|Spinal cord, cranial nerves, and other parts of central nervous system|
+|PrimarySiteEnum|Stomach|
+|PrimarySiteEnum|Testis|
+|PrimarySiteEnum|Thymus|
+|PrimarySiteEnum|Thyroid gland|
+|PrimarySiteEnum|Tonsil|
+|PrimarySiteEnum|Trachea|
+|PrimarySiteEnum|Ureter|
+|PrimarySiteEnum|Uterus, NOS|
+|PrimarySiteEnum|Vagina|
+|PrimarySiteEnum|Vulva|
+|PrimarySiteEnum|Unknown primary site|
+
+<h2 id="tocS_SexAtBirthEnum">SexAtBirthEnum</h2>
+
+<a id="schemasexatbirthenum"></a>
+<a id="schema_SexAtBirthEnum"></a>
+<a id="tocSsexatbirthenum"></a>
+<a id="tocssexatbirthenum"></a>
+
+```json
+"Male"
+
+```
+
+SexAtBirthEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|SexAtBirthEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SexAtBirthEnum|Male|
+|SexAtBirthEnum|Female|
+|SexAtBirthEnum|Other|
+|SexAtBirthEnum|Unknown|
+
+<h2 id="tocS_BiomarkerIngestSchema">BiomarkerIngestSchema</h2>
+
+<a id="schemabiomarkeringestschema"></a>
+<a id="schema_BiomarkerIngestSchema"></a>
+<a id="tocSbiomarkeringestschema"></a>
+<a id="tocsbiomarkeringestschema"></a>
+
+```json
+{
+  "submitter_specimen_id": "string",
+  "submitter_primary_diagnosis_id": "string",
+  "submitter_treatment_id": "string",
+  "submitter_follow_up_id": "string",
+  "test_date": "string",
+  "psa_level": 0,
+  "ca125": 0,
+  "cea": 0,
+  "er_status": "Cannot be determined",
+  "er_percent_positive": 0,
+  "pr_status": "Cannot be determined",
+  "pr_percent_positive": 0,
+  "her2_ihc_status": "Cannot be determined",
+  "her2_ish_status": "Cannot be determined",
+  "hpv_ihc_status": "Cannot be determined",
+  "hpv_pcr_status": "Cannot be determined",
+  "hpv_strain": [
+    "HPV16"
+  ],
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "uuid": "string"
+}
+
+```
+
+BiomarkerIngestSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |submitter_specimen_id|any|false|none|none|
 
 anyOf
@@ -2376,7 +2550,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[ErPrHpvStatusEnum](#schemaerprhpvstatusenum)|false|none|none|
 
 or
 
@@ -2412,7 +2586,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[ErPrHpvStatusEnum](#schemaerprhpvstatusenum)|false|none|none|
 
 or
 
@@ -2448,7 +2622,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[Her2StatusEnum](#schemaher2statusenum)|false|none|none|
 
 or
 
@@ -2466,7 +2640,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[Her2StatusEnum](#schemaher2statusenum)|false|none|none|
 
 or
 
@@ -2484,7 +2658,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[ErPrHpvStatusEnum](#schemaerprhpvstatusenum)|false|none|none|
 
 or
 
@@ -2502,7 +2676,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[ErPrHpvStatusEnum](#schemaerprhpvstatusenum)|false|none|none|
 
 or
 
@@ -2520,7 +2694,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
+|» *anonymous*|[[HpvStrainEnum](#schemahpvstrainenum)]|false|none|none|
 
 or
 
@@ -2528,36 +2702,12 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_ChemotherapyIngestSchema">ChemotherapyIngestSchema</h2>
-
-<a id="schemachemotherapyingestschema"></a>
-<a id="schema_ChemotherapyIngestSchema"></a>
-<a id="tocSchemotherapyingestschema"></a>
-<a id="tocschemotherapyingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_donor_id": "string",
-  "submitter_treatment_id": "string",
-  "drug_reference_database": "string",
-  "drug_name": "string",
-  "drug_reference_identifier": "string",
-  "chemotherapy_drug_dose_units": "string",
-  "prescribed_cumulative_drug_dose": 0,
-  "actual_cumulative_drug_dose": 0
-}
-
-```
-
-ChemotherapyIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -2572,19 +2722,143 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_ErPrHpvStatusEnum">ErPrHpvStatusEnum</h2>
+
+<a id="schemaerprhpvstatusenum"></a>
+<a id="schema_ErPrHpvStatusEnum"></a>
+<a id="tocSerprhpvstatusenum"></a>
+<a id="tocserprhpvstatusenum"></a>
+
+```json
+"Cannot be determined"
+
+```
+
+ErPrHpvStatusEnum
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_donor_id|string|true|none|none|
-|submitter_treatment_id|string|true|none|none|
+|ErPrHpvStatusEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|ErPrHpvStatusEnum|Cannot be determined|
+|ErPrHpvStatusEnum|Negative|
+|ErPrHpvStatusEnum|Not applicable|
+|ErPrHpvStatusEnum|Positive|
+|ErPrHpvStatusEnum|Unknown|
+
+<h2 id="tocS_Her2StatusEnum">Her2StatusEnum</h2>
+
+<a id="schemaher2statusenum"></a>
+<a id="schema_Her2StatusEnum"></a>
+<a id="tocSher2statusenum"></a>
+<a id="tocsher2statusenum"></a>
+
+```json
+"Cannot be determined"
+
+```
+
+Her2StatusEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|Her2StatusEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|Her2StatusEnum|Cannot be determined|
+|Her2StatusEnum|Equivocal|
+|Her2StatusEnum|Positive|
+|Her2StatusEnum|Negative|
+|Her2StatusEnum|Not applicable|
+|Her2StatusEnum|Unknown|
+
+<h2 id="tocS_HpvStrainEnum">HpvStrainEnum</h2>
+
+<a id="schemahpvstrainenum"></a>
+<a id="schema_HpvStrainEnum"></a>
+<a id="tocShpvstrainenum"></a>
+<a id="tocshpvstrainenum"></a>
+
+```json
+"HPV16"
+
+```
+
+HpvStrainEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|HpvStrainEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|HpvStrainEnum|HPV16|
+|HpvStrainEnum|HPV18|
+|HpvStrainEnum|HPV31|
+|HpvStrainEnum|HPV33|
+|HpvStrainEnum|HPV35|
+|HpvStrainEnum|HPV39|
+|HpvStrainEnum|HPV45|
+|HpvStrainEnum|HPV51|
+|HpvStrainEnum|HPV52|
+|HpvStrainEnum|HPV56|
+|HpvStrainEnum|HPV58|
+|HpvStrainEnum|HPV59|
+|HpvStrainEnum|HPV66|
+|HpvStrainEnum|HPV68|
+|HpvStrainEnum|HPV73|
+
+<h2 id="tocS_ChemotherapyIngestSchema">ChemotherapyIngestSchema</h2>
+
+<a id="schemachemotherapyingestschema"></a>
+<a id="schema_ChemotherapyIngestSchema"></a>
+<a id="tocSchemotherapyingestschema"></a>
+<a id="tocschemotherapyingestschema"></a>
+
+```json
+{
+  "drug_reference_database": "RxNorm",
+  "drug_name": "string",
+  "drug_reference_identifier": "string",
+  "chemotherapy_drug_dose_units": "mg/m2",
+  "prescribed_cumulative_drug_dose": 0,
+  "actual_cumulative_drug_dose": 0,
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "submitter_treatment_id": "string",
+  "uuid": "string"
+}
+
+```
+
+ChemotherapyIngestSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |drug_reference_database|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[DrugReferenceDbEnum](#schemadrugreferencedbenum)|false|none|none|
 
 or
 
@@ -2638,7 +2912,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[DosageUnitsEnum](#schemadosageunitsenum)|false|none|none|
 
 or
 
@@ -2682,35 +2956,13 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_ComorbidityIngestSchema">ComorbidityIngestSchema</h2>
-
-<a id="schemacomorbidityingestschema"></a>
-<a id="schema_ComorbidityIngestSchema"></a>
-<a id="tocScomorbidityingestschema"></a>
-<a id="tocscomorbidityingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_donor_id": "string",
-  "prior_malignancy": "string",
-  "laterality_of_prior_malignancy": "string",
-  "age_at_comorbidity_diagnosis": 0,
-  "comorbidity_type_code": "string",
-  "comorbidity_treatment_status": "string",
-  "comorbidity_treatment": "string"
-}
-
-```
-
-ComorbidityIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|submitter_treatment_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -2725,18 +2977,101 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_DosageUnitsEnum">DosageUnitsEnum</h2>
+
+<a id="schemadosageunitsenum"></a>
+<a id="schema_DosageUnitsEnum"></a>
+<a id="tocSdosageunitsenum"></a>
+<a id="tocsdosageunitsenum"></a>
+
+```json
+"mg/m2"
+
+```
+
+DosageUnitsEnum
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_donor_id|string|true|none|none|
+|DosageUnitsEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|DosageUnitsEnum|mg/m2|
+|DosageUnitsEnum|IU/m2|
+|DosageUnitsEnum|IU/kg|
+|DosageUnitsEnum|ug/m2|
+|DosageUnitsEnum|g/m2|
+|DosageUnitsEnum|mg/kg|
+|DosageUnitsEnum|cells/kg|
+
+<h2 id="tocS_DrugReferenceDbEnum">DrugReferenceDbEnum</h2>
+
+<a id="schemadrugreferencedbenum"></a>
+<a id="schema_DrugReferenceDbEnum"></a>
+<a id="tocSdrugreferencedbenum"></a>
+<a id="tocsdrugreferencedbenum"></a>
+
+```json
+"RxNorm"
+
+```
+
+DrugReferenceDbEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|DrugReferenceDbEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|DrugReferenceDbEnum|RxNorm|
+|DrugReferenceDbEnum|PubChem|
+|DrugReferenceDbEnum|NCI Thesaurus|
+
+<h2 id="tocS_ComorbidityIngestSchema">ComorbidityIngestSchema</h2>
+
+<a id="schemacomorbidityingestschema"></a>
+<a id="schema_ComorbidityIngestSchema"></a>
+<a id="tocScomorbidityingestschema"></a>
+<a id="tocscomorbidityingestschema"></a>
+
+```json
+{
+  "prior_malignancy": "Yes",
+  "laterality_of_prior_malignancy": "Bilateral",
+  "age_at_comorbidity_diagnosis": 0,
+  "comorbidity_type_code": "string",
+  "comorbidity_treatment_status": "Yes",
+  "comorbidity_treatment": "string",
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "uuid": "string"
+}
+
+```
+
+ComorbidityIngestSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |prior_malignancy|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[uBooleanEnum](#schemaubooleanenum)|false|none|none|
 
 or
 
@@ -2754,7 +3089,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[MalignancyLateralityEnum](#schemamalignancylateralityenum)|false|none|none|
 
 or
 
@@ -2808,7 +3143,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[uBooleanEnum](#schemaubooleanenum)|false|none|none|
 
 or
 
@@ -2834,34 +3169,12 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_ExposureIngestSchema">ExposureIngestSchema</h2>
-
-<a id="schemaexposureingestschema"></a>
-<a id="schema_ExposureIngestSchema"></a>
-<a id="tocSexposureingestschema"></a>
-<a id="tocsexposureingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_donor_id": "string",
-  "tobacco_smoking_status": "string",
-  "tobacco_type": [
-    null
-  ],
-  "pack_years_smoked": 0
-}
-
-```
-
-ExposureIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -2876,18 +3189,100 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_MalignancyLateralityEnum">MalignancyLateralityEnum</h2>
+
+<a id="schemamalignancylateralityenum"></a>
+<a id="schema_MalignancyLateralityEnum"></a>
+<a id="tocSmalignancylateralityenum"></a>
+<a id="tocsmalignancylateralityenum"></a>
+
+```json
+"Bilateral"
+
+```
+
+MalignancyLateralityEnum
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_donor_id|string|true|none|none|
+|MalignancyLateralityEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|MalignancyLateralityEnum|Bilateral|
+|MalignancyLateralityEnum|Left|
+|MalignancyLateralityEnum|Midline|
+|MalignancyLateralityEnum|Not applicable|
+|MalignancyLateralityEnum|Right|
+|MalignancyLateralityEnum|Unilateral, Side not specified|
+|MalignancyLateralityEnum|Unknown|
+
+<h2 id="tocS_uBooleanEnum">uBooleanEnum</h2>
+
+<a id="schemaubooleanenum"></a>
+<a id="schema_uBooleanEnum"></a>
+<a id="tocSubooleanenum"></a>
+<a id="tocsubooleanenum"></a>
+
+```json
+"Yes"
+
+```
+
+uBooleanEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|uBooleanEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|uBooleanEnum|Yes|
+|uBooleanEnum|No|
+|uBooleanEnum|Unknown|
+
+<h2 id="tocS_ExposureIngestSchema">ExposureIngestSchema</h2>
+
+<a id="schemaexposureingestschema"></a>
+<a id="schema_ExposureIngestSchema"></a>
+<a id="tocSexposureingestschema"></a>
+<a id="tocsexposureingestschema"></a>
+
+```json
+{
+  "tobacco_smoking_status": "Current reformed smoker for <= 15 years",
+  "tobacco_type": [
+    "Chewing Tobacco"
+  ],
+  "pack_years_smoked": 0,
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "uuid": "string"
+}
+
+```
+
+ExposureIngestSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |tobacco_smoking_status|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SmokingStatusEnum](#schemasmokingstatusenum)|false|none|none|
 
 or
 
@@ -2905,7 +3300,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
+|» *anonymous*|[[TobaccoTypeEnum](#schematobaccotypeenum)]|false|none|none|
 
 or
 
@@ -2931,6 +3326,126 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|uuid|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+<h2 id="tocS_SmokingStatusEnum">SmokingStatusEnum</h2>
+
+<a id="schemasmokingstatusenum"></a>
+<a id="schema_SmokingStatusEnum"></a>
+<a id="tocSsmokingstatusenum"></a>
+<a id="tocssmokingstatusenum"></a>
+
+```json
+"Current reformed smoker for <= 15 years"
+
+```
+
+SmokingStatusEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|SmokingStatusEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SmokingStatusEnum|Current reformed smoker for <= 15 years|
+|SmokingStatusEnum|Current reformed smoker for > 15 years|
+|SmokingStatusEnum|Current reformed smoker, duration not specified|
+|SmokingStatusEnum|Current smoker|
+|SmokingStatusEnum|Lifelong non-smoker (<100 cigarettes smoked in lifetime)|
+|SmokingStatusEnum|Not applicable|
+|SmokingStatusEnum|Smoking history not documented|
+
+<h2 id="tocS_TobaccoTypeEnum">TobaccoTypeEnum</h2>
+
+<a id="schematobaccotypeenum"></a>
+<a id="schema_TobaccoTypeEnum"></a>
+<a id="tocStobaccotypeenum"></a>
+<a id="tocstobaccotypeenum"></a>
+
+```json
+"Chewing Tobacco"
+
+```
+
+TobaccoTypeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TobaccoTypeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TobaccoTypeEnum|Chewing Tobacco|
+|TobaccoTypeEnum|Cigar|
+|TobaccoTypeEnum|Cigarettes|
+|TobaccoTypeEnum|Electronic cigarettes|
+|TobaccoTypeEnum|Not applicable|
+|TobaccoTypeEnum|Pipe|
+|TobaccoTypeEnum|Roll-ups|
+|TobaccoTypeEnum|Snuff|
+|TobaccoTypeEnum|Unknown|
+|TobaccoTypeEnum|Waterpipe|
+
+<h2 id="tocS_DiseaseStatusFollowupEnum">DiseaseStatusFollowupEnum</h2>
+
+<a id="schemadiseasestatusfollowupenum"></a>
+<a id="schema_DiseaseStatusFollowupEnum"></a>
+<a id="tocSdiseasestatusfollowupenum"></a>
+<a id="tocsdiseasestatusfollowupenum"></a>
+
+```json
+"Complete remission"
+
+```
+
+DiseaseStatusFollowupEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|DiseaseStatusFollowupEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|DiseaseStatusFollowupEnum|Complete remission|
+|DiseaseStatusFollowupEnum|Distant progression|
+|DiseaseStatusFollowupEnum|Loco-regional progression|
+|DiseaseStatusFollowupEnum|No evidence of disease|
+|DiseaseStatusFollowupEnum|Partial remission|
+|DiseaseStatusFollowupEnum|Progression not otherwise specified|
+|DiseaseStatusFollowupEnum|Relapse or recurrence|
+|DiseaseStatusFollowupEnum|Stable|
+
 <h2 id="tocS_FollowUpIngestSchema">FollowUpIngestSchema</h2>
 
 <a id="schemafollowupingestschema"></a>
@@ -2940,29 +3455,27 @@ or
 
 ```json
 {
-  "program_id": "string",
-  "uuid": "string",
-  "treatment_uuid_id": "4bc59108-57b8-4a2c-8af7-388e0b2e5e0b",
-  "primary_diagnosis_uuid_id": "ba89c3f7-52e0-44a8-83f8-a180c68404f8",
   "submitter_follow_up_id": "string",
+  "date_of_followup": "string",
+  "disease_status_at_followup": "Complete remission",
+  "relapse_type": "Distant recurrence/metastasis",
+  "date_of_relapse": "string",
+  "method_of_progression_status": [
+    "Imaging (procedure)"
+  ],
+  "anatomic_site_progression_or_recurrence": [
+    "string"
+  ],
+  "recurrence_tumour_staging_system": "AJCC 8th edition",
+  "recurrence_t_category": "T0",
+  "recurrence_n_category": "N0",
+  "recurrence_m_category": "M0",
+  "recurrence_stage_group": "Stage 0",
+  "program_id": "string",
   "submitter_donor_id": "string",
   "submitter_primary_diagnosis_id": "string",
   "submitter_treatment_id": "string",
-  "date_of_followup": "string",
-  "disease_status_at_followup": "string",
-  "relapse_type": "string",
-  "date_of_relapse": "string",
-  "method_of_progression_status": [
-    null
-  ],
-  "anatomic_site_progression_or_recurrence": [
-    null
-  ],
-  "recurrence_tumour_staging_system": "string",
-  "recurrence_t_category": "string",
-  "recurrence_n_category": "string",
-  "recurrence_m_category": "string",
-  "recurrence_stage_group": "string"
+  "uuid": "string"
 }
 
 ```
@@ -2973,8 +3486,8 @@ FollowUpIngestSchema
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|program_id|string|true|none|none|
-|uuid|any|false|none|none|
+|submitter_follow_up_id|string|true|none|none|
+|date_of_followup|any|false|none|none|
 
 anyOf
 
@@ -2992,13 +3505,13 @@ continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|treatment_uuid_id|any|false|none|none|
+|disease_status_at_followup|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string(uuid)|false|none|none|
+|» *anonymous*|[DiseaseStatusFollowupEnum](#schemadiseasestatusfollowupenum)|false|none|none|
 
 or
 
@@ -3010,13 +3523,13 @@ continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|primary_diagnosis_uuid_id|any|false|none|none|
+|relapse_type|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string(uuid)|false|none|none|
+|» *anonymous*|[RelapseTypeEnum](#schemarelapsetypeenum)|false|none|none|
 
 or
 
@@ -3028,7 +3541,151 @@ continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_follow_up_id|string|true|none|none|
+|date_of_relapse|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|method_of_progression_status|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[[ProgressionStatusMethodEnum](#schemaprogressionstatusmethodenum)]|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|anatomic_site_progression_or_recurrence|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[string]|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|recurrence_tumour_staging_system|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[TumourStagingSystemEnum](#schematumourstagingsystemenum)|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|recurrence_t_category|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[TCategoryEnum](#schematcategoryenum)|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|recurrence_n_category|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[NCategoryEnum](#schemancategoryenum)|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|recurrence_m_category|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[MCategoryEnum](#schemamcategoryenum)|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|recurrence_stage_group|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[StageGroupEnum](#schemastagegroupenum)|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|program_id|string|true|none|none|
 |submitter_donor_id|string|true|none|none|
 |submitter_primary_diagnosis_id|any|false|none|none|
 
@@ -3066,230 +3723,6 @@ continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|date_of_followup|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|disease_status_at_followup|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|relapse_type|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|date_of_relapse|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|method_of_progression_status|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|anatomic_site_progression_or_recurrence|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|recurrence_tumour_staging_system|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|recurrence_t_category|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|recurrence_n_category|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|recurrence_m_category|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|recurrence_stage_group|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-<h2 id="tocS_HormoneTherapyIngestSchema">HormoneTherapyIngestSchema</h2>
-
-<a id="schemahormonetherapyingestschema"></a>
-<a id="schema_HormoneTherapyIngestSchema"></a>
-<a id="tocShormonetherapyingestschema"></a>
-<a id="tocshormonetherapyingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_donor_id": "string",
-  "submitter_treatment_id": "string",
-  "drug_reference_database": "string",
-  "drug_name": "string",
-  "drug_reference_identifier": "string",
-  "hormone_drug_dose_units": "string",
-  "prescribed_cumulative_drug_dose": 0,
-  "actual_cumulative_drug_dose": 0
-}
-
-```
-
-HormoneTherapyIngestSchema
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|program_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -3304,19 +3737,432 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_MCategoryEnum">MCategoryEnum</h2>
+
+<a id="schemamcategoryenum"></a>
+<a id="schema_MCategoryEnum"></a>
+<a id="tocSmcategoryenum"></a>
+<a id="tocsmcategoryenum"></a>
+
+```json
+"M0"
+
+```
+
+MCategoryEnum
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_donor_id|string|true|none|none|
-|submitter_treatment_id|string|true|none|none|
+|MCategoryEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|MCategoryEnum|M0|
+|MCategoryEnum|M0(i+)|
+|MCategoryEnum|M1|
+|MCategoryEnum|M1a|
+|MCategoryEnum|M1a(0)|
+|MCategoryEnum|M1a(1)|
+|MCategoryEnum|M1b|
+|MCategoryEnum|M1b(0)|
+|MCategoryEnum|M1b(1)|
+|MCategoryEnum|M1c|
+|MCategoryEnum|M1c(0)|
+|MCategoryEnum|M1c(1)|
+|MCategoryEnum|M1d|
+|MCategoryEnum|M1d(0)|
+|MCategoryEnum|M1d(1)|
+|MCategoryEnum|M1e|
+|MCategoryEnum|MX|
+
+<h2 id="tocS_NCategoryEnum">NCategoryEnum</h2>
+
+<a id="schemancategoryenum"></a>
+<a id="schema_NCategoryEnum"></a>
+<a id="tocSncategoryenum"></a>
+<a id="tocsncategoryenum"></a>
+
+```json
+"N0"
+
+```
+
+NCategoryEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|NCategoryEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|NCategoryEnum|N0|
+|NCategoryEnum|N0a|
+|NCategoryEnum|N0a (biopsy)|
+|NCategoryEnum|N0b|
+|NCategoryEnum|N0b (no biopsy)|
+|NCategoryEnum|N0(i+)|
+|NCategoryEnum|N0(i-)|
+|NCategoryEnum|N0(mol+)|
+|NCategoryEnum|N0(mol-)|
+|NCategoryEnum|N1|
+|NCategoryEnum|N1a|
+|NCategoryEnum|N1a(sn)|
+|NCategoryEnum|N1b|
+|NCategoryEnum|N1c|
+|NCategoryEnum|N1mi|
+|NCategoryEnum|N2|
+|NCategoryEnum|N2a|
+|NCategoryEnum|N2b|
+|NCategoryEnum|N2c|
+|NCategoryEnum|N2mi|
+|NCategoryEnum|N3|
+|NCategoryEnum|N3a|
+|NCategoryEnum|N3b|
+|NCategoryEnum|N3c|
+|NCategoryEnum|N4|
+|NCategoryEnum|NX|
+
+<h2 id="tocS_ProgressionStatusMethodEnum">ProgressionStatusMethodEnum</h2>
+
+<a id="schemaprogressionstatusmethodenum"></a>
+<a id="schema_ProgressionStatusMethodEnum"></a>
+<a id="tocSprogressionstatusmethodenum"></a>
+<a id="tocsprogressionstatusmethodenum"></a>
+
+```json
+"Imaging (procedure)"
+
+```
+
+ProgressionStatusMethodEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|ProgressionStatusMethodEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|ProgressionStatusMethodEnum|Imaging (procedure)|
+|ProgressionStatusMethodEnum|Histopathology test (procedure)|
+|ProgressionStatusMethodEnum|Assessment of symptom control (procedure)|
+|ProgressionStatusMethodEnum|Physical examination procedure (procedure)|
+|ProgressionStatusMethodEnum|Tumor marker measurement (procedure)|
+|ProgressionStatusMethodEnum|Laboratory data interpretation (procedure)|
+
+<h2 id="tocS_RelapseTypeEnum">RelapseTypeEnum</h2>
+
+<a id="schemarelapsetypeenum"></a>
+<a id="schema_RelapseTypeEnum"></a>
+<a id="tocSrelapsetypeenum"></a>
+<a id="tocsrelapsetypeenum"></a>
+
+```json
+"Distant recurrence/metastasis"
+
+```
+
+RelapseTypeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|RelapseTypeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|RelapseTypeEnum|Distant recurrence/metastasis|
+|RelapseTypeEnum|Local recurrence|
+|RelapseTypeEnum|Local recurrence and distant metastasis|
+|RelapseTypeEnum|Progression (liquid tumours)|
+|RelapseTypeEnum|Biochemical progression|
+
+<h2 id="tocS_StageGroupEnum">StageGroupEnum</h2>
+
+<a id="schemastagegroupenum"></a>
+<a id="schema_StageGroupEnum"></a>
+<a id="tocSstagegroupenum"></a>
+<a id="tocsstagegroupenum"></a>
+
+```json
+"Stage 0"
+
+```
+
+StageGroupEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|StageGroupEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|StageGroupEnum|Stage 0|
+|StageGroupEnum|Stage 0a|
+|StageGroupEnum|Stage 0is|
+|StageGroupEnum|Stage 1|
+|StageGroupEnum|Stage 1A|
+|StageGroupEnum|Stage 1B|
+|StageGroupEnum|Stage A|
+|StageGroupEnum|Stage B|
+|StageGroupEnum|Stage C|
+|StageGroupEnum|Stage I|
+|StageGroupEnum|Stage IA|
+|StageGroupEnum|Stage IA1|
+|StageGroupEnum|Stage IA2|
+|StageGroupEnum|Stage IA3|
+|StageGroupEnum|Stage IAB|
+|StageGroupEnum|Stage IAE|
+|StageGroupEnum|Stage IAES|
+|StageGroupEnum|Stage IAS|
+|StageGroupEnum|Stage IB|
+|StageGroupEnum|Stage IB1|
+|StageGroupEnum|Stage IB2|
+|StageGroupEnum|Stage IBE|
+|StageGroupEnum|Stage IBES|
+|StageGroupEnum|Stage IBS|
+|StageGroupEnum|Stage IC|
+|StageGroupEnum|Stage IE|
+|StageGroupEnum|Stage IEA|
+|StageGroupEnum|Stage IEB|
+|StageGroupEnum|Stage IES|
+|StageGroupEnum|Stage II|
+|StageGroupEnum|Stage II bulky|
+|StageGroupEnum|Stage IIA|
+|StageGroupEnum|Stage IIA1|
+|StageGroupEnum|Stage IIA2|
+|StageGroupEnum|Stage IIAE|
+|StageGroupEnum|Stage IIAES|
+|StageGroupEnum|Stage IIAS|
+|StageGroupEnum|Stage IIB|
+|StageGroupEnum|Stage IIBE|
+|StageGroupEnum|Stage IIBES|
+|StageGroupEnum|Stage IIBS|
+|StageGroupEnum|Stage IIC|
+|StageGroupEnum|Stage IIE|
+|StageGroupEnum|Stage IIEA|
+|StageGroupEnum|Stage IIEB|
+|StageGroupEnum|Stage IIES|
+|StageGroupEnum|Stage III|
+|StageGroupEnum|Stage IIIA|
+|StageGroupEnum|Stage IIIA1|
+|StageGroupEnum|Stage IIIA2|
+|StageGroupEnum|Stage IIIAE|
+|StageGroupEnum|Stage IIIAES|
+|StageGroupEnum|Stage IIIAS|
+|StageGroupEnum|Stage IIIB|
+|StageGroupEnum|Stage IIIBE|
+|StageGroupEnum|Stage IIIBES|
+|StageGroupEnum|Stage IIIBS|
+|StageGroupEnum|Stage IIIC|
+|StageGroupEnum|Stage IIIC1|
+|StageGroupEnum|Stage IIIC2|
+|StageGroupEnum|Stage IIID|
+|StageGroupEnum|Stage IIIE|
+|StageGroupEnum|Stage IIIES|
+|StageGroupEnum|Stage IIIS|
+|StageGroupEnum|Stage IIS|
+|StageGroupEnum|Stage IS|
+|StageGroupEnum|Stage IV|
+|StageGroupEnum|Stage IVA|
+|StageGroupEnum|Stage IVA1|
+|StageGroupEnum|Stage IVA2|
+|StageGroupEnum|Stage IVAE|
+|StageGroupEnum|Stage IVAES|
+|StageGroupEnum|Stage IVAS|
+|StageGroupEnum|Stage IVB|
+|StageGroupEnum|Stage IVBE|
+|StageGroupEnum|Stage IVBES|
+|StageGroupEnum|Stage IVBS|
+|StageGroupEnum|Stage IVC|
+|StageGroupEnum|Stage IVE|
+|StageGroupEnum|Stage IVES|
+|StageGroupEnum|Stage IVS|
+|StageGroupEnum|In situ|
+|StageGroupEnum|Localized|
+|StageGroupEnum|Regionalized|
+|StageGroupEnum|Distant|
+|StageGroupEnum|Stage L1|
+|StageGroupEnum|Stage L2|
+|StageGroupEnum|Stage M|
+|StageGroupEnum|Stage Ms|
+|StageGroupEnum|Stage 2A|
+|StageGroupEnum|Stage 2B|
+|StageGroupEnum|Stage 3|
+|StageGroupEnum|Stage 4|
+|StageGroupEnum|Stage 4S|
+|StageGroupEnum|Occult Carcinoma|
+
+<h2 id="tocS_TCategoryEnum">TCategoryEnum</h2>
+
+<a id="schematcategoryenum"></a>
+<a id="schema_TCategoryEnum"></a>
+<a id="tocStcategoryenum"></a>
+<a id="tocstcategoryenum"></a>
+
+```json
+"T0"
+
+```
+
+TCategoryEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TCategoryEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TCategoryEnum|T0|
+|TCategoryEnum|T1|
+|TCategoryEnum|T1a|
+|TCategoryEnum|T1a1|
+|TCategoryEnum|T1a2|
+|TCategoryEnum|T1a(s)|
+|TCategoryEnum|T1a(m)|
+|TCategoryEnum|T1b|
+|TCategoryEnum|T1b1|
+|TCategoryEnum|T1b2|
+|TCategoryEnum|T1b(s)|
+|TCategoryEnum|T1b(m)|
+|TCategoryEnum|T1c|
+|TCategoryEnum|T1d|
+|TCategoryEnum|T1mi|
+|TCategoryEnum|T2|
+|TCategoryEnum|T2(s)|
+|TCategoryEnum|T2(m)|
+|TCategoryEnum|T2a|
+|TCategoryEnum|T2a1|
+|TCategoryEnum|T2a2|
+|TCategoryEnum|T2b|
+|TCategoryEnum|T2c|
+|TCategoryEnum|T2d|
+|TCategoryEnum|T3|
+|TCategoryEnum|T3(s)|
+|TCategoryEnum|T3(m)|
+|TCategoryEnum|T3a|
+|TCategoryEnum|T3b|
+|TCategoryEnum|T3c|
+|TCategoryEnum|T3d|
+|TCategoryEnum|T3e|
+|TCategoryEnum|T4|
+|TCategoryEnum|T4a|
+|TCategoryEnum|T4a(s)|
+|TCategoryEnum|T4a(m)|
+|TCategoryEnum|T4b|
+|TCategoryEnum|T4b(s)|
+|TCategoryEnum|T4b(m)|
+|TCategoryEnum|T4c|
+|TCategoryEnum|T4d|
+|TCategoryEnum|T4e|
+|TCategoryEnum|Ta|
+|TCategoryEnum|Tis|
+|TCategoryEnum|Tis(DCIS)|
+|TCategoryEnum|Tis(LAMN)|
+|TCategoryEnum|Tis(LCIS)|
+|TCategoryEnum|Tis(Paget)|
+|TCategoryEnum|Tis(Paget's)|
+|TCategoryEnum|Tis pu|
+|TCategoryEnum|Tis pd|
+|TCategoryEnum|TX|
+
+<h2 id="tocS_TumourStagingSystemEnum">TumourStagingSystemEnum</h2>
+
+<a id="schematumourstagingsystemenum"></a>
+<a id="schema_TumourStagingSystemEnum"></a>
+<a id="tocStumourstagingsystemenum"></a>
+<a id="tocstumourstagingsystemenum"></a>
+
+```json
+"AJCC 8th edition"
+
+```
+
+TumourStagingSystemEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TumourStagingSystemEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TumourStagingSystemEnum|AJCC 8th edition|
+|TumourStagingSystemEnum|AJCC 7th edition|
+|TumourStagingSystemEnum|AJCC 6th edition|
+|TumourStagingSystemEnum|Ann Arbor staging system|
+|TumourStagingSystemEnum|Binet staging system|
+|TumourStagingSystemEnum|Durie-Salmon staging system|
+|TumourStagingSystemEnum|FIGO staging system|
+|TumourStagingSystemEnum|International Neuroblastoma Risk Group Staging System|
+|TumourStagingSystemEnum|International Neuroblastoma Staging System|
+|TumourStagingSystemEnum|Lugano staging system|
+|TumourStagingSystemEnum|Rai staging system|
+|TumourStagingSystemEnum|Revised International staging system (RISS)|
+|TumourStagingSystemEnum|SEER staging system|
+|TumourStagingSystemEnum|St Jude staging system|
+
+<h2 id="tocS_HormoneTherapyIngestSchema">HormoneTherapyIngestSchema</h2>
+
+<a id="schemahormonetherapyingestschema"></a>
+<a id="schema_HormoneTherapyIngestSchema"></a>
+<a id="tocShormonetherapyingestschema"></a>
+<a id="tocshormonetherapyingestschema"></a>
+
+```json
+{
+  "drug_reference_database": "RxNorm",
+  "drug_name": "string",
+  "drug_reference_identifier": "string",
+  "hormone_drug_dose_units": "mg/m2",
+  "prescribed_cumulative_drug_dose": 0,
+  "actual_cumulative_drug_dose": 0,
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "submitter_treatment_id": "string",
+  "uuid": "string"
+}
+
+```
+
+HormoneTherapyIngestSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |drug_reference_database|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[DrugReferenceDbEnum](#schemadrugreferencedbenum)|false|none|none|
 
 or
 
@@ -3370,7 +4216,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[DosageUnitsEnum](#schemadosageunitsenum)|false|none|none|
 
 or
 
@@ -3414,37 +4260,13 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_ImmunotherapyIngestSchema">ImmunotherapyIngestSchema</h2>
-
-<a id="schemaimmunotherapyingestschema"></a>
-<a id="schema_ImmunotherapyIngestSchema"></a>
-<a id="tocSimmunotherapyingestschema"></a>
-<a id="tocsimmunotherapyingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_donor_id": "string",
-  "submitter_treatment_id": "string",
-  "drug_reference_database": "string",
-  "immunotherapy_type": "string",
-  "drug_name": "string",
-  "drug_reference_identifier": "string",
-  "immunotherapy_drug_dose_units": "string",
-  "prescribed_cumulative_drug_dose": 0,
-  "actual_cumulative_drug_dose": 0
-}
-
-```
-
-ImmunotherapyIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|submitter_treatment_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -3459,19 +4281,43 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_ImmunotherapyIngestSchema">ImmunotherapyIngestSchema</h2>
+
+<a id="schemaimmunotherapyingestschema"></a>
+<a id="schema_ImmunotherapyIngestSchema"></a>
+<a id="tocSimmunotherapyingestschema"></a>
+<a id="tocsimmunotherapyingestschema"></a>
+
+```json
+{
+  "drug_reference_database": "RxNorm",
+  "immunotherapy_type": "Cell-based",
+  "drug_name": "string",
+  "drug_reference_identifier": "string",
+  "immunotherapy_drug_dose_units": "mg/m2",
+  "prescribed_cumulative_drug_dose": 0,
+  "actual_cumulative_drug_dose": 0,
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "submitter_treatment_id": "string",
+  "uuid": "string"
+}
+
+```
+
+ImmunotherapyIngestSchema
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_donor_id|string|true|none|none|
-|submitter_treatment_id|string|true|none|none|
 |drug_reference_database|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[DrugReferenceDbEnum](#schemadrugreferencedbenum)|false|none|none|
 
 or
 
@@ -3489,7 +4335,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[ImmunotherapyTypeEnum](#schemaimmunotherapytypeenum)|false|none|none|
 
 or
 
@@ -3543,7 +4389,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[DosageUnitsEnum](#schemadosageunitsenum)|false|none|none|
 
 or
 
@@ -3587,42 +4433,13 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_PrimaryDiagnosisIngestSchema">PrimaryDiagnosisIngestSchema</h2>
-
-<a id="schemaprimarydiagnosisingestschema"></a>
-<a id="schema_PrimaryDiagnosisIngestSchema"></a>
-<a id="tocSprimarydiagnosisingestschema"></a>
-<a id="tocsprimarydiagnosisingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_primary_diagnosis_id": "string",
-  "submitter_donor_id": "string",
-  "date_of_diagnosis": "string",
-  "cancer_type_code": "string",
-  "basis_of_diagnosis": "string",
-  "laterality": "string",
-  "lymph_nodes_examined_status": "string",
-  "lymph_nodes_examined_method": "string",
-  "number_lymph_nodes_positive": 0,
-  "clinical_tumour_staging_system": "string",
-  "clinical_t_category": "string",
-  "clinical_n_category": "string",
-  "clinical_m_category": "string",
-  "clinical_stage_group": "string"
-}
-
-```
-
-PrimaryDiagnosisIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|submitter_treatment_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -3637,46 +4454,162 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_ImmunotherapyTypeEnum">ImmunotherapyTypeEnum</h2>
+
+<a id="schemaimmunotherapytypeenum"></a>
+<a id="schema_ImmunotherapyTypeEnum"></a>
+<a id="tocSimmunotherapytypeenum"></a>
+<a id="tocsimmunotherapytypeenum"></a>
+
+```json
+"Cell-based"
+
+```
+
+ImmunotherapyTypeEnum
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_primary_diagnosis_id|any|false|none|none|
+|ImmunotherapyTypeEnum|string|false|none|none|
 
-anyOf
+#### Enumerated Values
 
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|Property|Value|
+|---|---|
+|ImmunotherapyTypeEnum|Cell-based|
+|ImmunotherapyTypeEnum|Immune checkpoint inhibitors|
+|ImmunotherapyTypeEnum|Monoclonal antibodies other than immune checkpoint inhibitors|
+|ImmunotherapyTypeEnum|Other immunomodulatory substances|
 
-or
+<h2 id="tocS_BasisOfDiagnosisEnum">BasisOfDiagnosisEnum</h2>
 
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
+<a id="schemabasisofdiagnosisenum"></a>
+<a id="schema_BasisOfDiagnosisEnum"></a>
+<a id="tocSbasisofdiagnosisenum"></a>
+<a id="tocsbasisofdiagnosisenum"></a>
 
-continued
+```json
+"Clinical investigation"
 
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|submitter_donor_id|any|false|none|none|
+```
 
-anyOf
+BasisOfDiagnosisEnum
 
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|null|false|none|none|
-
-continued
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
+|BasisOfDiagnosisEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|BasisOfDiagnosisEnum|Clinical investigation|
+|BasisOfDiagnosisEnum|Clinical|
+|BasisOfDiagnosisEnum|Cytology|
+|BasisOfDiagnosisEnum|Death certificate only|
+|BasisOfDiagnosisEnum|Histology of a metastasis|
+|BasisOfDiagnosisEnum|Histology of a primary tumour|
+|BasisOfDiagnosisEnum|Specific tumour markers|
+|BasisOfDiagnosisEnum|Unknown|
+
+<h2 id="tocS_LymphNodeMethodEnum">LymphNodeMethodEnum</h2>
+
+<a id="schemalymphnodemethodenum"></a>
+<a id="schema_LymphNodeMethodEnum"></a>
+<a id="tocSlymphnodemethodenum"></a>
+<a id="tocslymphnodemethodenum"></a>
+
+```json
+"Imaging"
+
+```
+
+LymphNodeMethodEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|LymphNodeMethodEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|LymphNodeMethodEnum|Imaging|
+|LymphNodeMethodEnum|Lymph node dissection/pathological exam|
+|LymphNodeMethodEnum|Physical palpation of patient|
+
+<h2 id="tocS_LymphNodeStatusEnum">LymphNodeStatusEnum</h2>
+
+<a id="schemalymphnodestatusenum"></a>
+<a id="schema_LymphNodeStatusEnum"></a>
+<a id="tocSlymphnodestatusenum"></a>
+<a id="tocslymphnodestatusenum"></a>
+
+```json
+"Cannot be determined"
+
+```
+
+LymphNodeStatusEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|LymphNodeStatusEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|LymphNodeStatusEnum|Cannot be determined|
+|LymphNodeStatusEnum|No|
+|LymphNodeStatusEnum|No lymph nodes found in resected specimen|
+|LymphNodeStatusEnum|Not applicable|
+|LymphNodeStatusEnum|Yes|
+
+<h2 id="tocS_PrimaryDiagnosisIngestSchema">PrimaryDiagnosisIngestSchema</h2>
+
+<a id="schemaprimarydiagnosisingestschema"></a>
+<a id="schema_PrimaryDiagnosisIngestSchema"></a>
+<a id="tocSprimarydiagnosisingestschema"></a>
+<a id="tocsprimarydiagnosisingestschema"></a>
+
+```json
+{
+  "submitter_primary_diagnosis_id": "string",
+  "date_of_diagnosis": "string",
+  "cancer_type_code": "string",
+  "basis_of_diagnosis": "Clinical investigation",
+  "laterality": "Bilateral",
+  "lymph_nodes_examined_status": "Cannot be determined",
+  "lymph_nodes_examined_method": "Imaging",
+  "number_lymph_nodes_positive": 0,
+  "clinical_tumour_staging_system": "AJCC 8th edition",
+  "clinical_t_category": "T0",
+  "clinical_n_category": "N0",
+  "clinical_m_category": "M0",
+  "clinical_stage_group": "Stage 0",
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "uuid": "string"
+}
+
+```
+
+PrimaryDiagnosisIngestSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|submitter_primary_diagnosis_id|string|true|none|none|
 |date_of_diagnosis|any|false|none|none|
 
 anyOf
@@ -3719,7 +4652,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[BasisOfDiagnosisEnum](#schemabasisofdiagnosisenum)|false|none|none|
 
 or
 
@@ -3737,7 +4670,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[PrimaryDiagnosisLateralityEnum](#schemaprimarydiagnosislateralityenum)|false|none|none|
 
 or
 
@@ -3755,7 +4688,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[LymphNodeStatusEnum](#schemalymphnodestatusenum)|false|none|none|
 
 or
 
@@ -3773,7 +4706,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[LymphNodeMethodEnum](#schemalymphnodemethodenum)|false|none|none|
 
 or
 
@@ -3809,7 +4742,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TumourStagingSystemEnum](#schematumourstagingsystemenum)|false|none|none|
 
 or
 
@@ -3827,7 +4760,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TCategoryEnum](#schematcategoryenum)|false|none|none|
 
 or
 
@@ -3845,7 +4778,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[NCategoryEnum](#schemancategoryenum)|false|none|none|
 
 or
 
@@ -3863,7 +4796,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[MCategoryEnum](#schemamcategoryenum)|false|none|none|
 
 or
 
@@ -3881,7 +4814,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[StageGroupEnum](#schemastagegroupenum)|false|none|none|
 
 or
 
@@ -3889,37 +4822,12 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_RadiationIngestSchema">RadiationIngestSchema</h2>
-
-<a id="schemaradiationingestschema"></a>
-<a id="schema_RadiationIngestSchema"></a>
-<a id="tocSradiationingestschema"></a>
-<a id="tocsradiationingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_donor_id": "string",
-  "submitter_treatment_id": "string",
-  "radiation_therapy_modality": "string",
-  "radiation_therapy_type": "string",
-  "radiation_therapy_fractions": 0,
-  "radiation_therapy_dosage": 0,
-  "anatomical_site_irradiated": "string",
-  "radiation_boost": true,
-  "reference_radiation_treatment_id": "string"
-}
-
-```
-
-RadiationIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -3934,19 +4842,360 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_PrimaryDiagnosisLateralityEnum">PrimaryDiagnosisLateralityEnum</h2>
+
+<a id="schemaprimarydiagnosislateralityenum"></a>
+<a id="schema_PrimaryDiagnosisLateralityEnum"></a>
+<a id="tocSprimarydiagnosislateralityenum"></a>
+<a id="tocsprimarydiagnosislateralityenum"></a>
+
+```json
+"Bilateral"
+
+```
+
+PrimaryDiagnosisLateralityEnum
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_donor_id|string|true|none|none|
-|submitter_treatment_id|string|true|none|none|
+|PrimaryDiagnosisLateralityEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|PrimaryDiagnosisLateralityEnum|Bilateral|
+|PrimaryDiagnosisLateralityEnum|Left|
+|PrimaryDiagnosisLateralityEnum|Midline|
+|PrimaryDiagnosisLateralityEnum|Not a paired site|
+|PrimaryDiagnosisLateralityEnum|Right|
+|PrimaryDiagnosisLateralityEnum|Unilateral, side not specified|
+|PrimaryDiagnosisLateralityEnum|Unknown|
+
+<h2 id="tocS_RadiationAnatomicalSiteEnum">RadiationAnatomicalSiteEnum</h2>
+
+<a id="schemaradiationanatomicalsiteenum"></a>
+<a id="schema_RadiationAnatomicalSiteEnum"></a>
+<a id="tocSradiationanatomicalsiteenum"></a>
+<a id="tocsradiationanatomicalsiteenum"></a>
+
+```json
+"Left Abdomen"
+
+```
+
+RadiationAnatomicalSiteEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|RadiationAnatomicalSiteEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|RadiationAnatomicalSiteEnum|Left Abdomen|
+|RadiationAnatomicalSiteEnum|Whole Abdomen|
+|RadiationAnatomicalSiteEnum|Right Abdomen|
+|RadiationAnatomicalSiteEnum|Lower Abdomen|
+|RadiationAnatomicalSiteEnum|Left Lower Abdomen|
+|RadiationAnatomicalSiteEnum|Right Lower Abdomen|
+|RadiationAnatomicalSiteEnum|Upper Abdomen|
+|RadiationAnatomicalSiteEnum|Left Upper Abdomen|
+|RadiationAnatomicalSiteEnum|Right Upper Abdomen|
+|RadiationAnatomicalSiteEnum|Left Adrenal|
+|RadiationAnatomicalSiteEnum|Right Adrenal|
+|RadiationAnatomicalSiteEnum|Bilateral Ankle|
+|RadiationAnatomicalSiteEnum|Left Ankle|
+|RadiationAnatomicalSiteEnum|Right Ankle|
+|RadiationAnatomicalSiteEnum|Bilateral Antrum (Bull's Eye)|
+|RadiationAnatomicalSiteEnum|Left Antrum|
+|RadiationAnatomicalSiteEnum|Right Antrum|
+|RadiationAnatomicalSiteEnum|Anus|
+|RadiationAnatomicalSiteEnum|Lower Left Arm|
+|RadiationAnatomicalSiteEnum|Lower Right Arm|
+|RadiationAnatomicalSiteEnum|Bilateral Arms|
+|RadiationAnatomicalSiteEnum|Left Arm|
+|RadiationAnatomicalSiteEnum|Right Arm|
+|RadiationAnatomicalSiteEnum|Upper Left Arm|
+|RadiationAnatomicalSiteEnum|Upper Right Arm|
+|RadiationAnatomicalSiteEnum|Left Axilla|
+|RadiationAnatomicalSiteEnum|Right Axilla|
+|RadiationAnatomicalSiteEnum|Skin or Soft Tissue of Back|
+|RadiationAnatomicalSiteEnum|Bile Duct|
+|RadiationAnatomicalSiteEnum|Bladder|
+|RadiationAnatomicalSiteEnum|Lower Body|
+|RadiationAnatomicalSiteEnum|Middle Body|
+|RadiationAnatomicalSiteEnum|Upper Body|
+|RadiationAnatomicalSiteEnum|Whole Body|
+|RadiationAnatomicalSiteEnum|Boost - Area Previously Treated|
+|RadiationAnatomicalSiteEnum|Brain|
+|RadiationAnatomicalSiteEnum|Left Breast Boost|
+|RadiationAnatomicalSiteEnum|Right Breast Boost|
+|RadiationAnatomicalSiteEnum|Bilateral Breast|
+|RadiationAnatomicalSiteEnum|Left Breast|
+|RadiationAnatomicalSiteEnum|Right Breast|
+|RadiationAnatomicalSiteEnum|Bilateral Breasts with Nodes|
+|RadiationAnatomicalSiteEnum|Left Breast with Nodes|
+|RadiationAnatomicalSiteEnum|Right Breast with Nodes|
+|RadiationAnatomicalSiteEnum|Bilateral Buttocks|
+|RadiationAnatomicalSiteEnum|Left Buttock|
+|RadiationAnatomicalSiteEnum|Right Buttock|
+|RadiationAnatomicalSiteEnum|Inner Canthus|
+|RadiationAnatomicalSiteEnum|Outer Canthus|
+|RadiationAnatomicalSiteEnum|Cervix|
+|RadiationAnatomicalSiteEnum|Bilateral Chest Lung & Area Involve|
+|RadiationAnatomicalSiteEnum|Left Chest|
+|RadiationAnatomicalSiteEnum|Right Chest|
+|RadiationAnatomicalSiteEnum|Chin|
+|RadiationAnatomicalSiteEnum|Left Cheek|
+|RadiationAnatomicalSiteEnum|Right Cheek|
+|RadiationAnatomicalSiteEnum|Bilateral Chest Wall (W/o Breast)|
+|RadiationAnatomicalSiteEnum|Left Chest Wall|
+|RadiationAnatomicalSiteEnum|Right Chest Wall|
+|RadiationAnatomicalSiteEnum|Bilateral Clavicle|
+|RadiationAnatomicalSiteEnum|Left Clavicle|
+|RadiationAnatomicalSiteEnum|Right Clavicle|
+|RadiationAnatomicalSiteEnum|Coccyx|
+|RadiationAnatomicalSiteEnum|Colon|
+|RadiationAnatomicalSiteEnum|Whole C.N.S. (Medulla Techinque)|
+|RadiationAnatomicalSiteEnum|Csf Spine (Medull Tech 2 Diff Machi|
+|RadiationAnatomicalSiteEnum|Left Chestwall Boost|
+|RadiationAnatomicalSiteEnum|Right Chestwall Boost|
+|RadiationAnatomicalSiteEnum|Bilateral Chestwall with Nodes|
+|RadiationAnatomicalSiteEnum|Left Chestwall with Nodes|
+|RadiationAnatomicalSiteEnum|Right Chestwall with Nodes|
+|RadiationAnatomicalSiteEnum|Left Ear|
+|RadiationAnatomicalSiteEnum|Right Ear|
+|RadiationAnatomicalSiteEnum|Epigastrium|
+|RadiationAnatomicalSiteEnum|Lower Esophagus|
+|RadiationAnatomicalSiteEnum|Middle Esophagus|
+|RadiationAnatomicalSiteEnum|Upper Esophagus|
+|RadiationAnatomicalSiteEnum|Entire Esophagus|
+|RadiationAnatomicalSiteEnum|Ethmoid Sinus|
+|RadiationAnatomicalSiteEnum|Bilateral Eyes|
+|RadiationAnatomicalSiteEnum|Left Eye|
+|RadiationAnatomicalSiteEnum|Right Eye|
+|RadiationAnatomicalSiteEnum|Bilateral Face|
+|RadiationAnatomicalSiteEnum|Left Face|
+|RadiationAnatomicalSiteEnum|Right Face|
+|RadiationAnatomicalSiteEnum|Left Fallopian Tubes|
+|RadiationAnatomicalSiteEnum|Right Fallopian Tubes|
+|RadiationAnatomicalSiteEnum|Bilateral Femur|
+|RadiationAnatomicalSiteEnum|Left Femur|
+|RadiationAnatomicalSiteEnum|Right Femur|
+|RadiationAnatomicalSiteEnum|Left Fibula|
+|RadiationAnatomicalSiteEnum|Right Fibula|
+|RadiationAnatomicalSiteEnum|Finger (Including Thumbs)|
+|RadiationAnatomicalSiteEnum|Floor of Mouth (Boosts)|
+|RadiationAnatomicalSiteEnum|Bilateral Feet|
+|RadiationAnatomicalSiteEnum|Left Foot|
+|RadiationAnatomicalSiteEnum|Right Foot|
+|RadiationAnatomicalSiteEnum|Forehead|
+|RadiationAnatomicalSiteEnum|Posterior Fossa|
+|RadiationAnatomicalSiteEnum|Gall Bladder|
+|RadiationAnatomicalSiteEnum|Gingiva|
+|RadiationAnatomicalSiteEnum|Bilateral Hand|
+|RadiationAnatomicalSiteEnum|Left Hand|
+|RadiationAnatomicalSiteEnum|Right Hand|
+|RadiationAnatomicalSiteEnum|Head|
+|RadiationAnatomicalSiteEnum|Bilateral Heel|
+|RadiationAnatomicalSiteEnum|Left Heel|
+|RadiationAnatomicalSiteEnum|Right Heel|
+|RadiationAnatomicalSiteEnum|Left Hemimantle|
+|RadiationAnatomicalSiteEnum|Right Hemimantle|
+|RadiationAnatomicalSiteEnum|Heart|
+|RadiationAnatomicalSiteEnum|Bilateral Hip|
+|RadiationAnatomicalSiteEnum|Left Hip|
+|RadiationAnatomicalSiteEnum|Right Hip|
+|RadiationAnatomicalSiteEnum|Left Humerus|
+|RadiationAnatomicalSiteEnum|Right Humerus|
+|RadiationAnatomicalSiteEnum|Hypopharynx|
+|RadiationAnatomicalSiteEnum|Bilateral Internal Mammary Chain|
+|RadiationAnatomicalSiteEnum|Bilateral Inguinal Nodes|
+|RadiationAnatomicalSiteEnum|Left Inguinal Nodes|
+|RadiationAnatomicalSiteEnum|Right Inguinal Nodes|
+|RadiationAnatomicalSiteEnum|Inverted 'Y' (Dog-Leg,Hockey-Stick)|
+|RadiationAnatomicalSiteEnum|Left Kidney|
+|RadiationAnatomicalSiteEnum|Right Kidney|
+|RadiationAnatomicalSiteEnum|Bilateral Knee|
+|RadiationAnatomicalSiteEnum|Left Knee|
+|RadiationAnatomicalSiteEnum|Right Knee|
+|RadiationAnatomicalSiteEnum|Bilateral Lacrimal Gland|
+|RadiationAnatomicalSiteEnum|Left Lacrimal Gland|
+|RadiationAnatomicalSiteEnum|Right Lacrimal Gland|
+|RadiationAnatomicalSiteEnum|Larygopharynx|
+|RadiationAnatomicalSiteEnum|Larynx|
+|RadiationAnatomicalSiteEnum|Bilateral Leg|
+|RadiationAnatomicalSiteEnum|Left Leg|
+|RadiationAnatomicalSiteEnum|Right Leg|
+|RadiationAnatomicalSiteEnum|Lower Bilateral Leg|
+|RadiationAnatomicalSiteEnum|Lower Left Leg|
+|RadiationAnatomicalSiteEnum|Lower Right Leg|
+|RadiationAnatomicalSiteEnum|Upper Bilateral Leg|
+|RadiationAnatomicalSiteEnum|Upper Left Leg|
+|RadiationAnatomicalSiteEnum|Upper Right Leg|
+|RadiationAnatomicalSiteEnum|Both Eyelid(s)|
+|RadiationAnatomicalSiteEnum|Left Eyelid|
+|RadiationAnatomicalSiteEnum|Right Eyelid|
+|RadiationAnatomicalSiteEnum|Both Lip(s)|
+|RadiationAnatomicalSiteEnum|Lower Lip|
+|RadiationAnatomicalSiteEnum|Upper Lip|
+|RadiationAnatomicalSiteEnum|Liver|
+|RadiationAnatomicalSiteEnum|Bilateral Lung|
+|RadiationAnatomicalSiteEnum|Left Lung|
+|RadiationAnatomicalSiteEnum|Right Lung|
+|RadiationAnatomicalSiteEnum|Bilateral Mandible|
+|RadiationAnatomicalSiteEnum|Left Mandible|
+|RadiationAnatomicalSiteEnum|Right Mandible|
+|RadiationAnatomicalSiteEnum|Mantle|
+|RadiationAnatomicalSiteEnum|Bilateral Maxilla|
+|RadiationAnatomicalSiteEnum|Left Maxilla|
+|RadiationAnatomicalSiteEnum|Right Maxilla|
+|RadiationAnatomicalSiteEnum|Mediastinum|
+|RadiationAnatomicalSiteEnum|Multiple Skin|
+|RadiationAnatomicalSiteEnum|Nasal Fossa|
+|RadiationAnatomicalSiteEnum|Nasopharynx|
+|RadiationAnatomicalSiteEnum|Bilateral Neck Includes Nodes|
+|RadiationAnatomicalSiteEnum|Left Neck Includes Nodes|
+|RadiationAnatomicalSiteEnum|Right Neck Includes Nodes|
+|RadiationAnatomicalSiteEnum|Neck - Skin|
+|RadiationAnatomicalSiteEnum|Nose|
+|RadiationAnatomicalSiteEnum|Oral Cavity / Buccal Mucosa|
+|RadiationAnatomicalSiteEnum|Bilateral Orbit|
+|RadiationAnatomicalSiteEnum|Left Orbit|
+|RadiationAnatomicalSiteEnum|Right Orbit|
+|RadiationAnatomicalSiteEnum|Oropharynx|
+|RadiationAnatomicalSiteEnum|Bilateral Ovary|
+|RadiationAnatomicalSiteEnum|Left Ovary|
+|RadiationAnatomicalSiteEnum|Right Ovary|
+|RadiationAnatomicalSiteEnum|Hard Palate|
+|RadiationAnatomicalSiteEnum|Soft Palate|
+|RadiationAnatomicalSiteEnum|Palate Unspecified|
+|RadiationAnatomicalSiteEnum|Pancreas|
+|RadiationAnatomicalSiteEnum|Para-Aortic Nodes|
+|RadiationAnatomicalSiteEnum|Left Parotid|
+|RadiationAnatomicalSiteEnum|Right Parotid|
+|RadiationAnatomicalSiteEnum|Bilateral Pelvis|
+|RadiationAnatomicalSiteEnum|Left Pelvis|
+|RadiationAnatomicalSiteEnum|Right Pelvis|
+|RadiationAnatomicalSiteEnum|Penis|
+|RadiationAnatomicalSiteEnum|Perineum|
+|RadiationAnatomicalSiteEnum|Pituitary|
+|RadiationAnatomicalSiteEnum|Left Pleura (As in Mesothelioma)|
+|RadiationAnatomicalSiteEnum|Right Pleura|
+|RadiationAnatomicalSiteEnum|Prostate|
+|RadiationAnatomicalSiteEnum|Pubis|
+|RadiationAnatomicalSiteEnum|Pyriform Fossa (Sinuses)|
+|RadiationAnatomicalSiteEnum|Left Radius|
+|RadiationAnatomicalSiteEnum|Right Radius|
+|RadiationAnatomicalSiteEnum|Rectum (Includes Sigmoid)|
+|RadiationAnatomicalSiteEnum|Left Ribs|
+|RadiationAnatomicalSiteEnum|Right Ribs|
+|RadiationAnatomicalSiteEnum|Sacrum|
+|RadiationAnatomicalSiteEnum|Left Salivary Gland|
+|RadiationAnatomicalSiteEnum|Right Salivary Gland|
+|RadiationAnatomicalSiteEnum|Bilateral Scapula|
+|RadiationAnatomicalSiteEnum|Left Scapula|
+|RadiationAnatomicalSiteEnum|Right Scapula|
+|RadiationAnatomicalSiteEnum|Bilateral Supraclavicular Nodes|
+|RadiationAnatomicalSiteEnum|Left Supraclavicular Nodes|
+|RadiationAnatomicalSiteEnum|Right Supraclavicular Nodes|
+|RadiationAnatomicalSiteEnum|Bilateral Scalp|
+|RadiationAnatomicalSiteEnum|Left Scalp|
+|RadiationAnatomicalSiteEnum|Right Scalp|
+|RadiationAnatomicalSiteEnum|Scrotum|
+|RadiationAnatomicalSiteEnum|Bilateral Shoulder|
+|RadiationAnatomicalSiteEnum|Left Shoulder|
+|RadiationAnatomicalSiteEnum|Right Shoulder|
+|RadiationAnatomicalSiteEnum|Whole Body - Skin|
+|RadiationAnatomicalSiteEnum|Skull|
+|RadiationAnatomicalSiteEnum|Cervical & Thoracic Spine|
+|RadiationAnatomicalSiteEnum|Sphenoid Sinus|
+|RadiationAnatomicalSiteEnum|Cervical Spine|
+|RadiationAnatomicalSiteEnum|Lumbar Spine|
+|RadiationAnatomicalSiteEnum|Thoracic Spine|
+|RadiationAnatomicalSiteEnum|Whole Spine|
+|RadiationAnatomicalSiteEnum|Spleen|
+|RadiationAnatomicalSiteEnum|Lumbo-Sacral Spine|
+|RadiationAnatomicalSiteEnum|Thoracic & Lumbar Spine|
+|RadiationAnatomicalSiteEnum|Sternum|
+|RadiationAnatomicalSiteEnum|Stomach|
+|RadiationAnatomicalSiteEnum|Submandibular Glands|
+|RadiationAnatomicalSiteEnum|Left Temple|
+|RadiationAnatomicalSiteEnum|Right Temple|
+|RadiationAnatomicalSiteEnum|Bilateral Testis|
+|RadiationAnatomicalSiteEnum|Left Testis|
+|RadiationAnatomicalSiteEnum|Right Testis|
+|RadiationAnatomicalSiteEnum|Thyroid|
+|RadiationAnatomicalSiteEnum|Left Tibia|
+|RadiationAnatomicalSiteEnum|Right Tibia|
+|RadiationAnatomicalSiteEnum|Left Toes|
+|RadiationAnatomicalSiteEnum|Right Toes|
+|RadiationAnatomicalSiteEnum|Tongue|
+|RadiationAnatomicalSiteEnum|Tonsil|
+|RadiationAnatomicalSiteEnum|Trachea|
+|RadiationAnatomicalSiteEnum|Left Ulna|
+|RadiationAnatomicalSiteEnum|Right Ulna|
+|RadiationAnatomicalSiteEnum|Left Ureter|
+|RadiationAnatomicalSiteEnum|Right Ureter|
+|RadiationAnatomicalSiteEnum|Urethra|
+|RadiationAnatomicalSiteEnum|Uterus|
+|RadiationAnatomicalSiteEnum|Uvula|
+|RadiationAnatomicalSiteEnum|Vagina|
+|RadiationAnatomicalSiteEnum|Vulva|
+|RadiationAnatomicalSiteEnum|Abdomen|
+|RadiationAnatomicalSiteEnum|Body|
+|RadiationAnatomicalSiteEnum|Chest|
+|RadiationAnatomicalSiteEnum|Lower Limb|
+|RadiationAnatomicalSiteEnum|Neck|
+|RadiationAnatomicalSiteEnum|Other|
+|RadiationAnatomicalSiteEnum|Pelvis|
+|RadiationAnatomicalSiteEnum|Skin|
+|RadiationAnatomicalSiteEnum|Spine|
+|RadiationAnatomicalSiteEnum|Upper Limb|
+
+<h2 id="tocS_RadiationIngestSchema">RadiationIngestSchema</h2>
+
+<a id="schemaradiationingestschema"></a>
+<a id="schema_RadiationIngestSchema"></a>
+<a id="tocSradiationingestschema"></a>
+<a id="tocsradiationingestschema"></a>
+
+```json
+{
+  "radiation_therapy_modality": "Megavoltage radiation therapy using photons (procedure)",
+  "radiation_therapy_type": "External",
+  "radiation_therapy_fractions": 0,
+  "radiation_therapy_dosage": 0,
+  "anatomical_site_irradiated": "Left Abdomen",
+  "radiation_boost": true,
+  "reference_radiation_treatment_id": "string",
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "submitter_treatment_id": "string",
+  "uuid": "string"
+}
+
+```
+
+RadiationIngestSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |radiation_therapy_modality|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[RadiationTherapyModalityEnum](#schemaradiationtherapymodalityenum)|false|none|none|
 
 or
 
@@ -3964,7 +5213,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TherapyTypeEnum](#schematherapytypeenum)|false|none|none|
 
 or
 
@@ -4018,7 +5267,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[RadiationAnatomicalSiteEnum](#schemaradiationanatomicalsiteenum)|false|none|none|
 
 or
 
@@ -4062,35 +5311,13 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_SampleRegistrationIngestSchema">SampleRegistrationIngestSchema</h2>
-
-<a id="schemasampleregistrationingestschema"></a>
-<a id="schema_SampleRegistrationIngestSchema"></a>
-<a id="tocSsampleregistrationingestschema"></a>
-<a id="tocssampleregistrationingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_sample_id": "string",
-  "submitter_donor_id": "string",
-  "submitter_specimen_id": "string",
-  "specimen_tissue_source": "string",
-  "tumour_normal_designation": "string",
-  "specimen_type": "string",
-  "sample_type": "string"
-}
-
-```
-
-SampleRegistrationIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|submitter_treatment_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -4105,20 +5332,101 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_RadiationTherapyModalityEnum">RadiationTherapyModalityEnum</h2>
+
+<a id="schemaradiationtherapymodalityenum"></a>
+<a id="schema_RadiationTherapyModalityEnum"></a>
+<a id="tocSradiationtherapymodalityenum"></a>
+<a id="tocsradiationtherapymodalityenum"></a>
+
+```json
+"Megavoltage radiation therapy using photons (procedure)"
+
+```
+
+RadiationTherapyModalityEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|RadiationTherapyModalityEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|RadiationTherapyModalityEnum|Megavoltage radiation therapy using photons (procedure)|
+|RadiationTherapyModalityEnum|Radiopharmaceutical|
+|RadiationTherapyModalityEnum|Teleradiotherapy using electrons (procedure)|
+|RadiationTherapyModalityEnum|Teleradiotherapy protons (procedure)|
+|RadiationTherapyModalityEnum|Teleradiotherapy neutrons (procedure)|
+|RadiationTherapyModalityEnum|Brachytherapy (procedure)|
+|RadiationTherapyModalityEnum|Other|
+
+<h2 id="tocS_TherapyTypeEnum">TherapyTypeEnum</h2>
+
+<a id="schematherapytypeenum"></a>
+<a id="schema_TherapyTypeEnum"></a>
+<a id="tocStherapytypeenum"></a>
+<a id="tocstherapytypeenum"></a>
+
+```json
+"External"
+
+```
+
+TherapyTypeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TherapyTypeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TherapyTypeEnum|External|
+|TherapyTypeEnum|Internal|
+
+<h2 id="tocS_SampleRegistrationIngestSchema">SampleRegistrationIngestSchema</h2>
+
+<a id="schemasampleregistrationingestschema"></a>
+<a id="schema_SampleRegistrationIngestSchema"></a>
+<a id="tocSsampleregistrationingestschema"></a>
+<a id="tocssampleregistrationingestschema"></a>
+
+```json
+{
+  "submitter_sample_id": "string",
+  "specimen_tissue_source": "Abdominal fluid",
+  "tumour_normal_designation": "Normal",
+  "specimen_type": "Cell line - derived from normal",
+  "sample_type": "Amplified DNA",
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "submitter_specimen_id": "string",
+  "uuid": "string"
+}
+
+```
+
+SampleRegistrationIngestSchema
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |submitter_sample_id|string|true|none|none|
-|submitter_donor_id|string|true|none|none|
-|submitter_specimen_id|string|true|none|none|
 |specimen_tissue_source|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SpecimenTissueSourceEnum](#schemaspecimentissuesourceenum)|false|none|none|
 
 or
 
@@ -4136,7 +5444,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TumourDesginationEnum](#schematumourdesginationenum)|false|none|none|
 
 or
 
@@ -4154,7 +5462,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SpecimenTypeEnum](#schemaspecimentypeenum)|false|none|none|
 
 or
 
@@ -4172,7 +5480,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SampleTypeEnum](#schemasampletypeenum)|false|none|none|
 
 or
 
@@ -4180,48 +5488,13 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_SpecimenIngestSchema">SpecimenIngestSchema</h2>
-
-<a id="schemaspecimeningestschema"></a>
-<a id="schema_SpecimenIngestSchema"></a>
-<a id="tocSspecimeningestschema"></a>
-<a id="tocsspecimeningestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_specimen_id": "string",
-  "submitter_donor_id": "string",
-  "submitter_primary_diagnosis_id": "string",
-  "pathological_tumour_staging_system": "string",
-  "pathological_t_category": "string",
-  "pathological_n_category": "string",
-  "pathological_m_category": "string",
-  "pathological_stage_group": "string",
-  "specimen_collection_date": "string",
-  "specimen_storage": "string",
-  "specimen_processing": "string",
-  "tumour_histological_type": "string",
-  "specimen_anatomic_location": "string",
-  "specimen_laterality": "string",
-  "reference_pathology_confirmed_diagnosis": "string",
-  "reference_pathology_confirmed_tumour_presence": "string",
-  "tumour_grading_system": "string",
-  "tumour_grade": "string",
-  "percent_tumour_cells_range": "string",
-  "percent_tumour_cells_measurement_method": "string"
-}
-
-```
-
-SpecimenIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|submitter_specimen_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -4236,20 +5509,304 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_SampleTypeEnum">SampleTypeEnum</h2>
+
+<a id="schemasampletypeenum"></a>
+<a id="schema_SampleTypeEnum"></a>
+<a id="tocSsampletypeenum"></a>
+<a id="tocssampletypeenum"></a>
+
+```json
+"Amplified DNA"
+
+```
+
+SampleTypeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|SampleTypeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SampleTypeEnum|Amplified DNA|
+|SampleTypeEnum|ctDNA|
+|SampleTypeEnum|Other DNA enrichments|
+|SampleTypeEnum|Other RNA fractions|
+|SampleTypeEnum|polyA+ RNA|
+|SampleTypeEnum|Protein|
+|SampleTypeEnum|rRNA-depleted RNA|
+|SampleTypeEnum|Total DNA|
+|SampleTypeEnum|Total RNA|
+
+<h2 id="tocS_SpecimenTissueSourceEnum">SpecimenTissueSourceEnum</h2>
+
+<a id="schemaspecimentissuesourceenum"></a>
+<a id="schema_SpecimenTissueSourceEnum"></a>
+<a id="tocSspecimentissuesourceenum"></a>
+<a id="tocsspecimentissuesourceenum"></a>
+
+```json
+"Abdominal fluid"
+
+```
+
+SpecimenTissueSourceEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|SpecimenTissueSourceEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SpecimenTissueSourceEnum|Abdominal fluid|
+|SpecimenTissueSourceEnum|Amniotic fluid|
+|SpecimenTissueSourceEnum|Arterial blood|
+|SpecimenTissueSourceEnum|Bile|
+|SpecimenTissueSourceEnum|Blood derived - bone marrow|
+|SpecimenTissueSourceEnum|Blood derived - peripheral blood|
+|SpecimenTissueSourceEnum|Bone marrow fluid|
+|SpecimenTissueSourceEnum|Bone marrow derived mononuclear cells|
+|SpecimenTissueSourceEnum|Buccal cell|
+|SpecimenTissueSourceEnum|Buffy coat|
+|SpecimenTissueSourceEnum|Cerebrospinal fluid|
+|SpecimenTissueSourceEnum|Cervical mucus|
+|SpecimenTissueSourceEnum|Convalescent plasma|
+|SpecimenTissueSourceEnum|Cord blood|
+|SpecimenTissueSourceEnum|Duodenal fluid|
+|SpecimenTissueSourceEnum|Female genital fluid|
+|SpecimenTissueSourceEnum|Fetal blood|
+|SpecimenTissueSourceEnum|Hydrocele fluid|
+|SpecimenTissueSourceEnum|Male genital fluid|
+|SpecimenTissueSourceEnum|Pancreatic fluid|
+|SpecimenTissueSourceEnum|Pericardial effusion|
+|SpecimenTissueSourceEnum|Pleural fluid|
+|SpecimenTissueSourceEnum|Renal cyst fluid|
+|SpecimenTissueSourceEnum|Saliva|
+|SpecimenTissueSourceEnum|Seminal fluid|
+|SpecimenTissueSourceEnum|Serum|
+|SpecimenTissueSourceEnum|Solid tissue|
+|SpecimenTissueSourceEnum|Sputum|
+|SpecimenTissueSourceEnum|Synovial fluid|
+|SpecimenTissueSourceEnum|Urine|
+|SpecimenTissueSourceEnum|Venous blood|
+|SpecimenTissueSourceEnum|Vitreous fluid|
+|SpecimenTissueSourceEnum|Whole blood|
+|SpecimenTissueSourceEnum|Wound|
+
+<h2 id="tocS_SpecimenTypeEnum">SpecimenTypeEnum</h2>
+
+<a id="schemaspecimentypeenum"></a>
+<a id="schema_SpecimenTypeEnum"></a>
+<a id="tocSspecimentypeenum"></a>
+<a id="tocsspecimentypeenum"></a>
+
+```json
+"Cell line - derived from normal"
+
+```
+
+SpecimenTypeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|SpecimenTypeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SpecimenTypeEnum|Cell line - derived from normal|
+|SpecimenTypeEnum|Cell line - derived from primary tumour|
+|SpecimenTypeEnum|Cell line - derived from metastatic tumour|
+|SpecimenTypeEnum|Cell line - derived from xenograft tumour|
+|SpecimenTypeEnum|Metastatic tumour - additional metastatic|
+|SpecimenTypeEnum|Metastatic tumour - metastasis local to lymph node|
+|SpecimenTypeEnum|Metastatic tumour - metastasis to distant location|
+|SpecimenTypeEnum|Metastatic tumour|
+|SpecimenTypeEnum|Normal - tissue adjacent to primary tumour|
+|SpecimenTypeEnum|Normal|
+|SpecimenTypeEnum|Primary tumour - additional new primary|
+|SpecimenTypeEnum|Primary tumour - adjacent to normal|
+|SpecimenTypeEnum|Primary tumour|
+|SpecimenTypeEnum|Recurrent tumour|
+|SpecimenTypeEnum|Tumour - unknown if derived from primary or metastatic tumour|
+|SpecimenTypeEnum|Xenograft - derived from primary tumour|
+|SpecimenTypeEnum|Xenograft - derived from metastatic tumour|
+|SpecimenTypeEnum|Xenograft - derived from tumour cell line|
+
+<h2 id="tocS_TumourDesginationEnum">TumourDesginationEnum</h2>
+
+<a id="schematumourdesginationenum"></a>
+<a id="schema_TumourDesginationEnum"></a>
+<a id="tocStumourdesginationenum"></a>
+<a id="tocstumourdesginationenum"></a>
+
+```json
+"Normal"
+
+```
+
+TumourDesginationEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TumourDesginationEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TumourDesginationEnum|Normal|
+|TumourDesginationEnum|Tumour|
+
+<h2 id="tocS_CellsMeasureMethodEnum">CellsMeasureMethodEnum</h2>
+
+<a id="schemacellsmeasuremethodenum"></a>
+<a id="schema_CellsMeasureMethodEnum"></a>
+<a id="tocScellsmeasuremethodenum"></a>
+<a id="tocscellsmeasuremethodenum"></a>
+
+```json
+"Genomics"
+
+```
+
+CellsMeasureMethodEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|CellsMeasureMethodEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|CellsMeasureMethodEnum|Genomics|
+|CellsMeasureMethodEnum|Image analysis|
+|CellsMeasureMethodEnum|Pathology estimate by percent nuclei|
+|CellsMeasureMethodEnum|Unknown|
+
+<h2 id="tocS_ConfirmedDiagnosisTumourEnum">ConfirmedDiagnosisTumourEnum</h2>
+
+<a id="schemaconfirmeddiagnosistumourenum"></a>
+<a id="schema_ConfirmedDiagnosisTumourEnum"></a>
+<a id="tocSconfirmeddiagnosistumourenum"></a>
+<a id="tocsconfirmeddiagnosistumourenum"></a>
+
+```json
+"Yes"
+
+```
+
+ConfirmedDiagnosisTumourEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|ConfirmedDiagnosisTumourEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|ConfirmedDiagnosisTumourEnum|Yes|
+|ConfirmedDiagnosisTumourEnum|No|
+|ConfirmedDiagnosisTumourEnum|Not done|
+|ConfirmedDiagnosisTumourEnum|Unknown|
+
+<h2 id="tocS_PercentCellsRangeEnum">PercentCellsRangeEnum</h2>
+
+<a id="schemapercentcellsrangeenum"></a>
+<a id="schema_PercentCellsRangeEnum"></a>
+<a id="tocSpercentcellsrangeenum"></a>
+<a id="tocspercentcellsrangeenum"></a>
+
+```json
+"0-19%"
+
+```
+
+PercentCellsRangeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|PercentCellsRangeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|PercentCellsRangeEnum|0-19%|
+|PercentCellsRangeEnum|20-50%|
+|PercentCellsRangeEnum|51-100%|
+
+<h2 id="tocS_SpecimenIngestSchema">SpecimenIngestSchema</h2>
+
+<a id="schemaspecimeningestschema"></a>
+<a id="schema_SpecimenIngestSchema"></a>
+<a id="tocSspecimeningestschema"></a>
+<a id="tocsspecimeningestschema"></a>
+
+```json
+{
+  "submitter_specimen_id": "string",
+  "pathological_tumour_staging_system": "AJCC 8th edition",
+  "pathological_t_category": "T0",
+  "pathological_n_category": "N0",
+  "pathological_m_category": "M0",
+  "pathological_stage_group": "Stage 0",
+  "specimen_collection_date": "string",
+  "specimen_storage": "Cut slide",
+  "specimen_processing": "Cryopreservation in liquid nitrogen (dead tissue)",
+  "tumour_histological_type": "string",
+  "specimen_anatomic_location": "string",
+  "specimen_laterality": "Left",
+  "reference_pathology_confirmed_diagnosis": "Yes",
+  "reference_pathology_confirmed_tumour_presence": "Yes",
+  "tumour_grading_system": "FNCLCC grading system",
+  "tumour_grade": "Low grade",
+  "percent_tumour_cells_range": "0-19%",
+  "percent_tumour_cells_measurement_method": "Genomics",
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "submitter_primary_diagnosis_id": "string",
+  "uuid": "string"
+}
+
+```
+
+SpecimenIngestSchema
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |submitter_specimen_id|string|true|none|none|
-|submitter_donor_id|string|true|none|none|
-|submitter_primary_diagnosis_id|string|true|none|none|
 |pathological_tumour_staging_system|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TumourStagingSystemEnum](#schematumourstagingsystemenum)|false|none|none|
 
 or
 
@@ -4267,7 +5824,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TCategoryEnum](#schematcategoryenum)|false|none|none|
 
 or
 
@@ -4285,7 +5842,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[NCategoryEnum](#schemancategoryenum)|false|none|none|
 
 or
 
@@ -4303,7 +5860,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[MCategoryEnum](#schemamcategoryenum)|false|none|none|
 
 or
 
@@ -4321,7 +5878,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[StageGroupEnum](#schemastagegroupenum)|false|none|none|
 
 or
 
@@ -4357,7 +5914,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[StorageEnum](#schemastorageenum)|false|none|none|
 
 or
 
@@ -4375,7 +5932,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SpecimenProcessingEnum](#schemaspecimenprocessingenum)|false|none|none|
 
 or
 
@@ -4429,7 +5986,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SpecimenLateralityEnum](#schemaspecimenlateralityenum)|false|none|none|
 
 or
 
@@ -4447,7 +6004,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[ConfirmedDiagnosisTumourEnum](#schemaconfirmeddiagnosistumourenum)|false|none|none|
 
 or
 
@@ -4465,7 +6022,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[ConfirmedDiagnosisTumourEnum](#schemaconfirmeddiagnosistumourenum)|false|none|none|
 
 or
 
@@ -4483,7 +6040,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TumourGradingSystemEnum](#schematumourgradingsystemenum)|false|none|none|
 
 or
 
@@ -4501,7 +6058,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TumourGradeEnum](#schematumourgradeenum)|false|none|none|
 
 or
 
@@ -4519,7 +6076,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[PercentCellsRangeEnum](#schemapercentcellsrangeenum)|false|none|none|
 
 or
 
@@ -4537,7 +6094,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[CellsMeasureMethodEnum](#schemacellsmeasuremethodenum)|false|none|none|
 
 or
 
@@ -4545,50 +6102,13 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_SurgeryIngestSchema">SurgeryIngestSchema</h2>
-
-<a id="schemasurgeryingestschema"></a>
-<a id="schema_SurgeryIngestSchema"></a>
-<a id="tocSsurgeryingestschema"></a>
-<a id="tocssurgeryingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_donor_id": "string",
-  "submitter_treatment_id": "string",
-  "submitter_specimen_id": "string",
-  "surgery_type": "string",
-  "surgery_site": "string",
-  "surgery_location": "string",
-  "tumour_length": 0,
-  "tumour_width": 0,
-  "greatest_dimension_tumour": 0,
-  "tumour_focality": "string",
-  "residual_tumour_classification": "string",
-  "margin_types_involved": [
-    null
-  ],
-  "margin_types_not_involved": [
-    null
-  ],
-  "margin_types_not_assessed": [
-    null
-  ],
-  "lymphovascular_invasion": "string",
-  "perineural_invasion": "string"
-}
-
-```
-
-SurgeryIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|submitter_primary_diagnosis_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -4603,12 +6123,325 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_SpecimenLateralityEnum">SpecimenLateralityEnum</h2>
+
+<a id="schemaspecimenlateralityenum"></a>
+<a id="schema_SpecimenLateralityEnum"></a>
+<a id="tocSspecimenlateralityenum"></a>
+<a id="tocsspecimenlateralityenum"></a>
+
+```json
+"Left"
+
+```
+
+SpecimenLateralityEnum
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|submitter_donor_id|string|true|none|none|
-|submitter_treatment_id|string|true|none|none|
+|SpecimenLateralityEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SpecimenLateralityEnum|Left|
+|SpecimenLateralityEnum|Not applicable|
+|SpecimenLateralityEnum|Right|
+|SpecimenLateralityEnum|Unknown|
+
+<h2 id="tocS_SpecimenProcessingEnum">SpecimenProcessingEnum</h2>
+
+<a id="schemaspecimenprocessingenum"></a>
+<a id="schema_SpecimenProcessingEnum"></a>
+<a id="tocSspecimenprocessingenum"></a>
+<a id="tocsspecimenprocessingenum"></a>
+
+```json
+"Cryopreservation in liquid nitrogen (dead tissue)"
+
+```
+
+SpecimenProcessingEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|SpecimenProcessingEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SpecimenProcessingEnum|Cryopreservation in liquid nitrogen (dead tissue)|
+|SpecimenProcessingEnum|Cryopreservation in dry ice (dead tissue)|
+|SpecimenProcessingEnum|Cryopreservation of live cells in liquid nitrogen|
+|SpecimenProcessingEnum|Cryopreservation - other|
+|SpecimenProcessingEnum|Formalin fixed & paraffin embedded|
+|SpecimenProcessingEnum|Formalin fixed - buffered|
+|SpecimenProcessingEnum|Formalin fixed - unbuffered|
+|SpecimenProcessingEnum|Fresh|
+|SpecimenProcessingEnum|Other|
+|SpecimenProcessingEnum|Unknown|
+
+<h2 id="tocS_StorageEnum">StorageEnum</h2>
+
+<a id="schemastorageenum"></a>
+<a id="schema_StorageEnum"></a>
+<a id="tocSstorageenum"></a>
+<a id="tocsstorageenum"></a>
+
+```json
+"Cut slide"
+
+```
+
+StorageEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|StorageEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|StorageEnum|Cut slide|
+|StorageEnum|Frozen in -70 freezer|
+|StorageEnum|Frozen in liquid nitrogen|
+|StorageEnum|Frozen in vapour phase|
+|StorageEnum|Not Applicable|
+|StorageEnum|Other|
+|StorageEnum|Paraffin block|
+|StorageEnum|RNA later frozen|
+|StorageEnum|Unknown|
+
+<h2 id="tocS_TumourGradeEnum">TumourGradeEnum</h2>
+
+<a id="schematumourgradeenum"></a>
+<a id="schema_TumourGradeEnum"></a>
+<a id="tocStumourgradeenum"></a>
+<a id="tocstumourgradeenum"></a>
+
+```json
+"Low grade"
+
+```
+
+TumourGradeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TumourGradeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TumourGradeEnum|Low grade|
+|TumourGradeEnum|High grade|
+|TumourGradeEnum|GX|
+|TumourGradeEnum|G1|
+|TumourGradeEnum|G2|
+|TumourGradeEnum|G3|
+|TumourGradeEnum|G4|
+|TumourGradeEnum|Low|
+|TumourGradeEnum|High|
+|TumourGradeEnum|Grade 1|
+|TumourGradeEnum|Grade 2|
+|TumourGradeEnum|Grade 3|
+|TumourGradeEnum|Grade 4|
+|TumourGradeEnum|Grade I|
+|TumourGradeEnum|Grade II|
+|TumourGradeEnum|Grade III|
+|TumourGradeEnum|Grade IV|
+|TumourGradeEnum|Grade Group 1|
+|TumourGradeEnum|Grade Group 2|
+|TumourGradeEnum|Grade Group 3|
+|TumourGradeEnum|Grade Group 4|
+|TumourGradeEnum|Grade Group 5|
+
+<h2 id="tocS_TumourGradingSystemEnum">TumourGradingSystemEnum</h2>
+
+<a id="schematumourgradingsystemenum"></a>
+<a id="schema_TumourGradingSystemEnum"></a>
+<a id="tocStumourgradingsystemenum"></a>
+<a id="tocstumourgradingsystemenum"></a>
+
+```json
+"FNCLCC grading system"
+
+```
+
+TumourGradingSystemEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TumourGradingSystemEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TumourGradingSystemEnum|FNCLCC grading system|
+|TumourGradingSystemEnum|Four-tier grading system|
+|TumourGradingSystemEnum|Gleason grade group system|
+|TumourGradingSystemEnum|Grading system for GISTs|
+|TumourGradingSystemEnum|Grading system for GNETs|
+|TumourGradingSystemEnum|IASLC grading system|
+|TumourGradingSystemEnum|ISUP grading system|
+|TumourGradingSystemEnum|Nottingham grading system|
+|TumourGradingSystemEnum|Nuclear grading system for DCIS|
+|TumourGradingSystemEnum|Scarff-Bloom-Richardson grading system|
+|TumourGradingSystemEnum|Three-tier grading system|
+|TumourGradingSystemEnum|Two-tier grading system|
+|TumourGradingSystemEnum|WHO grading system for CNS tumours|
+
+<h2 id="tocS_LymphovascularInvasionEnum">LymphovascularInvasionEnum</h2>
+
+<a id="schemalymphovascularinvasionenum"></a>
+<a id="schema_LymphovascularInvasionEnum"></a>
+<a id="tocSlymphovascularinvasionenum"></a>
+<a id="tocslymphovascularinvasionenum"></a>
+
+```json
+"Absent"
+
+```
+
+LymphovascularInvasionEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|LymphovascularInvasionEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|LymphovascularInvasionEnum|Absent|
+|LymphovascularInvasionEnum|Both lymphatic and small vessel and venous (large vessel) invasion|
+|LymphovascularInvasionEnum|Lymphatic and small vessel invasion only|
+|LymphovascularInvasionEnum|Not applicable|
+|LymphovascularInvasionEnum|Present|
+|LymphovascularInvasionEnum|Venous (large vessel) invasion only|
+|LymphovascularInvasionEnum|Unknown|
+
+<h2 id="tocS_MarginTypesEnum">MarginTypesEnum</h2>
+
+<a id="schemamargintypesenum"></a>
+<a id="schema_MarginTypesEnum"></a>
+<a id="tocSmargintypesenum"></a>
+<a id="tocsmargintypesenum"></a>
+
+```json
+"Circumferential resection margin"
+
+```
+
+MarginTypesEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|MarginTypesEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|MarginTypesEnum|Circumferential resection margin|
+|MarginTypesEnum|Common bile duct margin|
+|MarginTypesEnum|Distal margin|
+|MarginTypesEnum|Not applicable|
+|MarginTypesEnum|Proximal margin|
+|MarginTypesEnum|Unknown|
+
+<h2 id="tocS_PerineuralInvasionEnum">PerineuralInvasionEnum</h2>
+
+<a id="schemaperineuralinvasionenum"></a>
+<a id="schema_PerineuralInvasionEnum"></a>
+<a id="tocSperineuralinvasionenum"></a>
+<a id="tocsperineuralinvasionenum"></a>
+
+```json
+"Absent"
+
+```
+
+PerineuralInvasionEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|PerineuralInvasionEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|PerineuralInvasionEnum|Absent|
+|PerineuralInvasionEnum|Cannot be assessed|
+|PerineuralInvasionEnum|Not applicable|
+|PerineuralInvasionEnum|Present|
+|PerineuralInvasionEnum|Unknown|
+
+<h2 id="tocS_SurgeryIngestSchema">SurgeryIngestSchema</h2>
+
+<a id="schemasurgeryingestschema"></a>
+<a id="schema_SurgeryIngestSchema"></a>
+<a id="tocSsurgeryingestschema"></a>
+<a id="tocssurgeryingestschema"></a>
+
+```json
+{
+  "submitter_specimen_id": "string",
+  "surgery_type": "Ablation",
+  "surgery_site": "string",
+  "surgery_location": "Local recurrence",
+  "tumour_length": 0,
+  "tumour_width": 0,
+  "greatest_dimension_tumour": 0,
+  "tumour_focality": "Cannot be assessed",
+  "residual_tumour_classification": "Not applicable",
+  "margin_types_involved": [
+    "Circumferential resection margin"
+  ],
+  "margin_types_not_involved": [
+    "Circumferential resection margin"
+  ],
+  "margin_types_not_assessed": [
+    "Circumferential resection margin"
+  ],
+  "lymphovascular_invasion": "Absent",
+  "perineural_invasion": "Absent",
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "submitter_treatment_id": "string",
+  "uuid": "string"
+}
+
+```
+
+SurgeryIngestSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |submitter_specimen_id|any|false|none|none|
 
 anyOf
@@ -4633,7 +6466,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SurgeryTypeEnum](#schemasurgerytypeenum)|false|none|none|
 
 or
 
@@ -4669,7 +6502,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[SurgeryLocationEnum](#schemasurgerylocationenum)|false|none|none|
 
 or
 
@@ -4741,7 +6574,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TumourFocalityEnum](#schematumourfocalityenum)|false|none|none|
 
 or
 
@@ -4759,7 +6592,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TumourClassificationEnum](#schematumourclassificationenum)|false|none|none|
 
 or
 
@@ -4777,7 +6610,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
+|» *anonymous*|[[MarginTypesEnum](#schemamargintypesenum)]|false|none|none|
 
 or
 
@@ -4795,7 +6628,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
+|» *anonymous*|[[MarginTypesEnum](#schemamargintypesenum)]|false|none|none|
 
 or
 
@@ -4813,7 +6646,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
+|» *anonymous*|[[MarginTypesEnum](#schemamargintypesenum)]|false|none|none|
 
 or
 
@@ -4831,7 +6664,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[LymphovascularInvasionEnum](#schemalymphovascularinvasionenum)|false|none|none|
 
 or
 
@@ -4849,7 +6682,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[PerineuralInvasionEnum](#schemaperineuralinvasionenum)|false|none|none|
 
 or
 
@@ -4857,45 +6690,13 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_TreatmentIngestSchema">TreatmentIngestSchema</h2>
-
-<a id="schematreatmentingestschema"></a>
-<a id="schema_TreatmentIngestSchema"></a>
-<a id="tocStreatmentingestschema"></a>
-<a id="tocstreatmentingestschema"></a>
-
-```json
-{
-  "program_id": "string",
-  "uuid": "string",
-  "submitter_treatment_id": "string",
-  "submitter_donor_id": "string",
-  "submitter_primary_diagnosis_id": "string",
-  "treatment_type": [
-    null
-  ],
-  "is_primary_treatment": "string",
-  "line_of_treatment": 0,
-  "treatment_start_date": "string",
-  "treatment_end_date": "string",
-  "treatment_setting": "string",
-  "treatment_intent": "string",
-  "days_per_cycle": 0,
-  "number_of_cycles": 0,
-  "response_to_treatment_criteria_method": "string",
-  "response_to_treatment": "string",
-  "status_of_treatment": "string"
-}
-
-```
-
-TreatmentIngestSchema
-
-### Properties
+continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|submitter_treatment_id|string|true|none|none|
 |uuid|any|false|none|none|
 
 anyOf
@@ -4910,20 +6711,223 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-continued
+<h2 id="tocS_SurgeryLocationEnum">SurgeryLocationEnum</h2>
+
+<a id="schemasurgerylocationenum"></a>
+<a id="schema_SurgeryLocationEnum"></a>
+<a id="tocSsurgerylocationenum"></a>
+<a id="tocssurgerylocationenum"></a>
+
+```json
+"Local recurrence"
+
+```
+
+SurgeryLocationEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|SurgeryLocationEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SurgeryLocationEnum|Local recurrence|
+|SurgeryLocationEnum|Metastatic|
+|SurgeryLocationEnum|Primary|
+
+<h2 id="tocS_SurgeryTypeEnum">SurgeryTypeEnum</h2>
+
+<a id="schemasurgerytypeenum"></a>
+<a id="schema_SurgeryTypeEnum"></a>
+<a id="tocSsurgerytypeenum"></a>
+<a id="tocssurgerytypeenum"></a>
+
+```json
+"Ablation"
+
+```
+
+SurgeryTypeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|SurgeryTypeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|SurgeryTypeEnum|Ablation|
+|SurgeryTypeEnum|Axillary Clearance|
+|SurgeryTypeEnum|Axillary lymph nodes sampling|
+|SurgeryTypeEnum|Bilateral complete salpingo-oophorectomy|
+|SurgeryTypeEnum|Biopsy|
+|SurgeryTypeEnum|Bypass Gastrojejunostomy|
+|SurgeryTypeEnum|Cholecystectomy|
+|SurgeryTypeEnum|Cholecystojejunostomy|
+|SurgeryTypeEnum|Completion Gastrectomy|
+|SurgeryTypeEnum|Debridement of pancreatic and peripancreatic necrosis|
+|SurgeryTypeEnum|Distal subtotal pancreatectomy|
+|SurgeryTypeEnum|Drainage of abscess|
+|SurgeryTypeEnum|Duodenal preserving pancreatic head resection|
+|SurgeryTypeEnum|Endoscopic biopsy|
+|SurgeryTypeEnum|Endoscopic brushings of gastrointestinal tract|
+|SurgeryTypeEnum|Enucleation|
+|SurgeryTypeEnum|Esophageal bypass surgery/jejunostomy only|
+|SurgeryTypeEnum|Exploratory laparotomy|
+|SurgeryTypeEnum|Fine needle aspiration biopsy|
+|SurgeryTypeEnum|Gastric Antrectomy|
+|SurgeryTypeEnum|Glossectomy|
+|SurgeryTypeEnum|Hepatojejunostomy|
+|SurgeryTypeEnum|Hysterectomy|
+|SurgeryTypeEnum|Incision of thorax|
+|SurgeryTypeEnum|Ivor Lewis subtotal esophagectomy|
+|SurgeryTypeEnum|Laparotomy|
+|SurgeryTypeEnum|Left thoracoabdominal incision|
+|SurgeryTypeEnum|Lobectomy|
+|SurgeryTypeEnum|Mammoplasty|
+|SurgeryTypeEnum|Mastectomy|
+|SurgeryTypeEnum|McKeown esophagectomy|
+|SurgeryTypeEnum|Merendino procedure|
+|SurgeryTypeEnum|Minimally invasive esophagectomy|
+|SurgeryTypeEnum|Omentectomy|
+|SurgeryTypeEnum|Ovariectomy|
+|SurgeryTypeEnum|Pancreaticoduodenectomy (Whipple procedure)|
+|SurgeryTypeEnum|Pancreaticojejunostomy, side-to-side anastomosis|
+|SurgeryTypeEnum|Partial pancreatectomy|
+|SurgeryTypeEnum|Pneumonectomy|
+|SurgeryTypeEnum|Prostatectomy|
+|SurgeryTypeEnum|Proximal subtotal gastrectomy|
+|SurgeryTypeEnum|Pylorus-sparing Whipple operation|
+|SurgeryTypeEnum|Radical pancreaticoduodenectomy|
+|SurgeryTypeEnum|Radical prostatectomy|
+|SurgeryTypeEnum|Reexcision|
+|SurgeryTypeEnum|Segmentectomy|
+|SurgeryTypeEnum|Sentinal Lymph Node Biopsy|
+|SurgeryTypeEnum|Spleen preserving distal pancreatectomy|
+|SurgeryTypeEnum|Splenectomy|
+|SurgeryTypeEnum|Total gastrectomy|
+|SurgeryTypeEnum|Total gastrectomy with extended lymphadenectomy|
+|SurgeryTypeEnum|Total pancreatectomy|
+|SurgeryTypeEnum|Transhiatal esophagectomy|
+|SurgeryTypeEnum|Triple bypass of pancreas|
+|SurgeryTypeEnum|Tumor Debulking|
+|SurgeryTypeEnum|Wedge/localised gastric resection|
+|SurgeryTypeEnum|Wide Local Excision|
+
+<h2 id="tocS_TumourClassificationEnum">TumourClassificationEnum</h2>
+
+<a id="schematumourclassificationenum"></a>
+<a id="schema_TumourClassificationEnum"></a>
+<a id="tocStumourclassificationenum"></a>
+<a id="tocstumourclassificationenum"></a>
+
+```json
+"Not applicable"
+
+```
+
+TumourClassificationEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TumourClassificationEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TumourClassificationEnum|Not applicable|
+|TumourClassificationEnum|RX|
+|TumourClassificationEnum|R0|
+|TumourClassificationEnum|R1|
+|TumourClassificationEnum|R2|
+|TumourClassificationEnum|Unknown|
+
+<h2 id="tocS_TumourFocalityEnum">TumourFocalityEnum</h2>
+
+<a id="schematumourfocalityenum"></a>
+<a id="schema_TumourFocalityEnum"></a>
+<a id="tocStumourfocalityenum"></a>
+<a id="tocstumourfocalityenum"></a>
+
+```json
+"Cannot be assessed"
+
+```
+
+TumourFocalityEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TumourFocalityEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TumourFocalityEnum|Cannot be assessed|
+|TumourFocalityEnum|Multifocal|
+|TumourFocalityEnum|Not applicable|
+|TumourFocalityEnum|Unifocal|
+|TumourFocalityEnum|Unknown|
+
+<h2 id="tocS_TreatmentIngestSchema">TreatmentIngestSchema</h2>
+
+<a id="schematreatmentingestschema"></a>
+<a id="schema_TreatmentIngestSchema"></a>
+<a id="tocStreatmentingestschema"></a>
+<a id="tocstreatmentingestschema"></a>
+
+```json
+{
+  "submitter_treatment_id": "string",
+  "treatment_type": [
+    "Bone marrow transplant"
+  ],
+  "is_primary_treatment": "Yes",
+  "line_of_treatment": 0,
+  "treatment_start_date": "string",
+  "treatment_end_date": "string",
+  "treatment_setting": "Adjuvant",
+  "treatment_intent": "Curative",
+  "days_per_cycle": 0,
+  "number_of_cycles": 0,
+  "response_to_treatment_criteria_method": "RECIST 1.1",
+  "response_to_treatment": "Complete response",
+  "status_of_treatment": "Treatment completed as prescribed",
+  "program_id": "string",
+  "submitter_donor_id": "string",
+  "submitter_primary_diagnosis_id": "string",
+  "uuid": "string"
+}
+
+```
+
+TreatmentIngestSchema
+
+### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |submitter_treatment_id|string|true|none|none|
-|submitter_donor_id|string|true|none|none|
-|submitter_primary_diagnosis_id|string|true|none|none|
 |treatment_type|any|false|none|none|
 
 anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|[any]|false|none|none|
+|» *anonymous*|[[TreatmentTypeEnum](#schematreatmenttypeenum)]|false|none|none|
 
 or
 
@@ -4941,7 +6945,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[uBooleanEnum](#schemaubooleanenum)|false|none|none|
 
 or
 
@@ -5013,7 +7017,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TreatmentSettingEnum](#schematreatmentsettingenum)|false|none|none|
 
 or
 
@@ -5031,7 +7035,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TreatmentIntentEnum](#schematreatmentintentenum)|false|none|none|
 
 or
 
@@ -5085,7 +7089,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TreatmentResponseMethodEnum](#schematreatmentresponsemethodenum)|false|none|none|
 
 or
 
@@ -5103,7 +7107,7 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» *anonymous*|string|false|none|none|
+|» *anonymous*|[TreatmentResponseEnum](#schematreatmentresponseenum)|false|none|none|
 
 or
 
@@ -5121,6 +7125,27 @@ anyOf
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
+|» *anonymous*|[TreatmentStatusEnum](#schematreatmentstatusenum)|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|program_id|string|true|none|none|
+|submitter_donor_id|string|true|none|none|
+|submitter_primary_diagnosis_id|string|true|none|none|
+|uuid|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |» *anonymous*|string|false|none|none|
 
 or
@@ -5129,157 +7154,224 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
-<h2 id="tocS_BasisOfDiagnosisEnum">BasisOfDiagnosisEnum</h2>
+<h2 id="tocS_TreatmentIntentEnum">TreatmentIntentEnum</h2>
 
-<a id="schemabasisofdiagnosisenum"></a>
-<a id="schema_BasisOfDiagnosisEnum"></a>
-<a id="tocSbasisofdiagnosisenum"></a>
-<a id="tocsbasisofdiagnosisenum"></a>
+<a id="schematreatmentintentenum"></a>
+<a id="schema_TreatmentIntentEnum"></a>
+<a id="tocStreatmentintentenum"></a>
+<a id="tocstreatmentintentenum"></a>
 
 ```json
-"Clinical investigation"
+"Curative"
 
 ```
 
-BasisOfDiagnosisEnum
+TreatmentIntentEnum
 
 ### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|BasisOfDiagnosisEnum|string|false|none|none|
+|TreatmentIntentEnum|string|false|none|none|
 
 #### Enumerated Values
 
 |Property|Value|
 |---|---|
-|BasisOfDiagnosisEnum|Clinical investigation|
-|BasisOfDiagnosisEnum|Clinical|
-|BasisOfDiagnosisEnum|Cytology|
-|BasisOfDiagnosisEnum|Death certificate only|
-|BasisOfDiagnosisEnum|Histology of a metastasis|
-|BasisOfDiagnosisEnum|Histology of a primary tumour|
-|BasisOfDiagnosisEnum|Specific tumour markers|
-|BasisOfDiagnosisEnum|Unknown|
+|TreatmentIntentEnum|Curative|
+|TreatmentIntentEnum|Palliative|
+|TreatmentIntentEnum|Supportive|
+|TreatmentIntentEnum|Diagnostic|
+|TreatmentIntentEnum|Preventive|
+|TreatmentIntentEnum|Guidance|
+|TreatmentIntentEnum|Screening|
+|TreatmentIntentEnum|Forensic|
 
-<h2 id="tocS_CauseOfDeathEnum">CauseOfDeathEnum</h2>
+<h2 id="tocS_TreatmentResponseEnum">TreatmentResponseEnum</h2>
 
-<a id="schemacauseofdeathenum"></a>
-<a id="schema_CauseOfDeathEnum"></a>
-<a id="tocScauseofdeathenum"></a>
-<a id="tocscauseofdeathenum"></a>
+<a id="schematreatmentresponseenum"></a>
+<a id="schema_TreatmentResponseEnum"></a>
+<a id="tocStreatmentresponseenum"></a>
+<a id="tocstreatmentresponseenum"></a>
 
 ```json
-"Died of cancer"
+"Complete response"
 
 ```
 
-CauseOfDeathEnum
+TreatmentResponseEnum
 
 ### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|CauseOfDeathEnum|string|false|none|none|
+|TreatmentResponseEnum|string|false|none|none|
 
 #### Enumerated Values
 
 |Property|Value|
 |---|---|
-|CauseOfDeathEnum|Died of cancer|
-|CauseOfDeathEnum|Died of other reasons|
-|CauseOfDeathEnum|Unknown|
+|TreatmentResponseEnum|Complete response|
+|TreatmentResponseEnum|Partial response|
+|TreatmentResponseEnum|Progressive disease|
+|TreatmentResponseEnum|Stable disease|
+|TreatmentResponseEnum|Immune complete response (iCR)|
+|TreatmentResponseEnum|Immune partial response (iPR)|
+|TreatmentResponseEnum|Immune uncomfirmed progressive disease (iUPD)|
+|TreatmentResponseEnum|Immune confirmed progressive disease (iCPD)|
+|TreatmentResponseEnum|Immune stable disease (iSD)|
+|TreatmentResponseEnum|Complete remission|
+|TreatmentResponseEnum|Partial remission|
+|TreatmentResponseEnum|Minor response|
+|TreatmentResponseEnum|Complete remission without measurable residual disease (CR MRD-)|
+|TreatmentResponseEnum|Complete remission with incomplete hematologic recovery (CRi)|
+|TreatmentResponseEnum|Morphologic leukemia-free state|
+|TreatmentResponseEnum|Primary refractory disease|
+|TreatmentResponseEnum|Hematologic relapse (after CR MRD-, CR, CRi)|
+|TreatmentResponseEnum|Molecular relapse (after CR MRD-)|
+|TreatmentResponseEnum|Physician assessed complete response|
+|TreatmentResponseEnum|Physician assessed partial response|
+|TreatmentResponseEnum|Physician assessed stable disease|
+|TreatmentResponseEnum|No evidence of disease (NED)|
+|TreatmentResponseEnum|Major response|
 
-<h2 id="tocS_CellsMeasureMethodEnum">CellsMeasureMethodEnum</h2>
+<h2 id="tocS_TreatmentResponseMethodEnum">TreatmentResponseMethodEnum</h2>
 
-<a id="schemacellsmeasuremethodenum"></a>
-<a id="schema_CellsMeasureMethodEnum"></a>
-<a id="tocScellsmeasuremethodenum"></a>
-<a id="tocscellsmeasuremethodenum"></a>
+<a id="schematreatmentresponsemethodenum"></a>
+<a id="schema_TreatmentResponseMethodEnum"></a>
+<a id="tocStreatmentresponsemethodenum"></a>
+<a id="tocstreatmentresponsemethodenum"></a>
 
 ```json
-"Genomics"
+"RECIST 1.1"
 
 ```
 
-CellsMeasureMethodEnum
+TreatmentResponseMethodEnum
 
 ### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|CellsMeasureMethodEnum|string|false|none|none|
+|TreatmentResponseMethodEnum|string|false|none|none|
 
 #### Enumerated Values
 
 |Property|Value|
 |---|---|
-|CellsMeasureMethodEnum|Genomics|
-|CellsMeasureMethodEnum|Image analysis|
-|CellsMeasureMethodEnum|Pathology estimate by percent nuclei|
-|CellsMeasureMethodEnum|Unknown|
+|TreatmentResponseMethodEnum|RECIST 1.1|
+|TreatmentResponseMethodEnum|iRECIST|
+|TreatmentResponseMethodEnum|Cheson CLL 2012 Oncology Response Criteria|
+|TreatmentResponseMethodEnum|Response Assessment in Neuro-Oncology (RANO)|
+|TreatmentResponseMethodEnum|AML Response Criteria|
+|TreatmentResponseMethodEnum|Physician Assessed Response Criteria|
+|TreatmentResponseMethodEnum|Blazer score|
 
-<h2 id="tocS_ConfirmedDiagnosisTumourEnum">ConfirmedDiagnosisTumourEnum</h2>
+<h2 id="tocS_TreatmentSettingEnum">TreatmentSettingEnum</h2>
 
-<a id="schemaconfirmeddiagnosistumourenum"></a>
-<a id="schema_ConfirmedDiagnosisTumourEnum"></a>
-<a id="tocSconfirmeddiagnosistumourenum"></a>
-<a id="tocsconfirmeddiagnosistumourenum"></a>
+<a id="schematreatmentsettingenum"></a>
+<a id="schema_TreatmentSettingEnum"></a>
+<a id="tocStreatmentsettingenum"></a>
+<a id="tocstreatmentsettingenum"></a>
 
 ```json
-"Yes"
+"Adjuvant"
 
 ```
 
-ConfirmedDiagnosisTumourEnum
+TreatmentSettingEnum
 
 ### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|ConfirmedDiagnosisTumourEnum|string|false|none|none|
+|TreatmentSettingEnum|string|false|none|none|
 
 #### Enumerated Values
 
 |Property|Value|
 |---|---|
-|ConfirmedDiagnosisTumourEnum|Yes|
-|ConfirmedDiagnosisTumourEnum|No|
-|ConfirmedDiagnosisTumourEnum|Not done|
-|ConfirmedDiagnosisTumourEnum|Unknown|
+|TreatmentSettingEnum|Adjuvant|
+|TreatmentSettingEnum|Advanced/Metastatic|
+|TreatmentSettingEnum|Neoadjuvant|
+|TreatmentSettingEnum|Conditioning|
+|TreatmentSettingEnum|Induction|
+|TreatmentSettingEnum|Locally advanced|
+|TreatmentSettingEnum|Maintenance|
+|TreatmentSettingEnum|Mobilization|
+|TreatmentSettingEnum|Preventative|
+|TreatmentSettingEnum|Radiosensitization|
+|TreatmentSettingEnum|Salvage|
 
-<h2 id="tocS_DiseaseStatusFollowupEnum">DiseaseStatusFollowupEnum</h2>
+<h2 id="tocS_TreatmentStatusEnum">TreatmentStatusEnum</h2>
 
-<a id="schemadiseasestatusfollowupenum"></a>
-<a id="schema_DiseaseStatusFollowupEnum"></a>
-<a id="tocSdiseasestatusfollowupenum"></a>
-<a id="tocsdiseasestatusfollowupenum"></a>
+<a id="schematreatmentstatusenum"></a>
+<a id="schema_TreatmentStatusEnum"></a>
+<a id="tocStreatmentstatusenum"></a>
+<a id="tocstreatmentstatusenum"></a>
 
 ```json
-"Complete remission"
+"Treatment completed as prescribed"
 
 ```
 
-DiseaseStatusFollowupEnum
+TreatmentStatusEnum
 
 ### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|DiseaseStatusFollowupEnum|string|false|none|none|
+|TreatmentStatusEnum|string|false|none|none|
 
 #### Enumerated Values
 
 |Property|Value|
 |---|---|
-|DiseaseStatusFollowupEnum|Complete remission|
-|DiseaseStatusFollowupEnum|Distant progression|
-|DiseaseStatusFollowupEnum|Loco-regional progression|
-|DiseaseStatusFollowupEnum|No evidence of disease|
-|DiseaseStatusFollowupEnum|Partial remission|
-|DiseaseStatusFollowupEnum|Progression not otherwise specified|
-|DiseaseStatusFollowupEnum|Relapse or recurrence|
-|DiseaseStatusFollowupEnum|Stable|
+|TreatmentStatusEnum|Treatment completed as prescribed|
+|TreatmentStatusEnum|Treatment incomplete due to technical or organizational problems|
+|TreatmentStatusEnum|Treatment incomplete because patient died|
+|TreatmentStatusEnum|Patient choice (stopped or interrupted treatment)|
+|TreatmentStatusEnum|Physician decision (stopped or interrupted treatment)|
+|TreatmentStatusEnum|Treatment stopped due to lack of efficacy (disease progression)|
+|TreatmentStatusEnum|Treatment stopped due to acute toxicity|
+|TreatmentStatusEnum|Other|
+|TreatmentStatusEnum|Not applicable|
+|TreatmentStatusEnum|Unknown|
+
+<h2 id="tocS_TreatmentTypeEnum">TreatmentTypeEnum</h2>
+
+<a id="schematreatmenttypeenum"></a>
+<a id="schema_TreatmentTypeEnum"></a>
+<a id="tocStreatmenttypeenum"></a>
+<a id="tocstreatmenttypeenum"></a>
+
+```json
+"Bone marrow transplant"
+
+```
+
+TreatmentTypeEnum
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|TreatmentTypeEnum|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|TreatmentTypeEnum|Bone marrow transplant|
+|TreatmentTypeEnum|Chemotherapy|
+|TreatmentTypeEnum|Hormonal therapy|
+|TreatmentTypeEnum|Immunotherapy|
+|TreatmentTypeEnum|No treatment|
+|TreatmentTypeEnum|Other targeting molecular therapy|
+|TreatmentTypeEnum|Photodynamic therapy|
+|TreatmentTypeEnum|Radiation therapy|
+|TreatmentTypeEnum|Stem cell transplant|
+|TreatmentTypeEnum|Surgery|
 
 <h2 id="tocS_DonorWithClinicalDataSchema">DonorWithClinicalDataSchema</h2>
 
@@ -5291,7 +7383,6 @@ DiseaseStatusFollowupEnum
 ```json
 {
   "submitter_donor_id": "string",
-  "program_id": "string",
   "gender": "Man",
   "sex_at_birth": "Male",
   "is_deceased": true,
@@ -5304,6 +7395,7 @@ DiseaseStatusFollowupEnum
   "primary_site": [
     "Accessory sinuses"
   ],
+  "program_id": "string",
   "primary_diagnoses": [
     {
       "submitter_primary_diagnosis_id": "string",
@@ -5550,7 +7642,6 @@ DonorWithClinicalDataSchema
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |submitter_donor_id|string|true|none|none|
-|program_id|string|true|none|none|
 |gender|any|false|none|none|
 
 anyOf
@@ -5731,506 +7822,12 @@ continued
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
+|program_id|string|true|none|none|
 |primary_diagnoses|[[NestedPrimaryDiagnosisSchema](#schemanestedprimarydiagnosisschema)]|false|none|none|
 |followups|[[NestedFollowUpSchema](#schemanestedfollowupschema)]|false|none|none|
 |biomarkers|[[NestedBiomarkerSchema](#schemanestedbiomarkerschema)]|false|none|none|
 |exposures|[[NestedExposureSchema](#schemanestedexposureschema)]|false|none|none|
 |comorbidities|[[NestedComorbiditySchema](#schemanestedcomorbidityschema)]|false|none|none|
-
-<h2 id="tocS_DosageUnitsEnum">DosageUnitsEnum</h2>
-
-<a id="schemadosageunitsenum"></a>
-<a id="schema_DosageUnitsEnum"></a>
-<a id="tocSdosageunitsenum"></a>
-<a id="tocsdosageunitsenum"></a>
-
-```json
-"mg/m2"
-
-```
-
-DosageUnitsEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|DosageUnitsEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|DosageUnitsEnum|mg/m2|
-|DosageUnitsEnum|IU/m2|
-|DosageUnitsEnum|IU/kg|
-|DosageUnitsEnum|ug/m2|
-|DosageUnitsEnum|g/m2|
-|DosageUnitsEnum|mg/kg|
-|DosageUnitsEnum|cells/kg|
-
-<h2 id="tocS_DrugReferenceDbEnum">DrugReferenceDbEnum</h2>
-
-<a id="schemadrugreferencedbenum"></a>
-<a id="schema_DrugReferenceDbEnum"></a>
-<a id="tocSdrugreferencedbenum"></a>
-<a id="tocsdrugreferencedbenum"></a>
-
-```json
-"RxNorm"
-
-```
-
-DrugReferenceDbEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|DrugReferenceDbEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|DrugReferenceDbEnum|RxNorm|
-|DrugReferenceDbEnum|PubChem|
-|DrugReferenceDbEnum|NCI Thesaurus|
-
-<h2 id="tocS_ErPrHpvStatusEnum">ErPrHpvStatusEnum</h2>
-
-<a id="schemaerprhpvstatusenum"></a>
-<a id="schema_ErPrHpvStatusEnum"></a>
-<a id="tocSerprhpvstatusenum"></a>
-<a id="tocserprhpvstatusenum"></a>
-
-```json
-"Cannot be determined"
-
-```
-
-ErPrHpvStatusEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|ErPrHpvStatusEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|ErPrHpvStatusEnum|Cannot be determined|
-|ErPrHpvStatusEnum|Negative|
-|ErPrHpvStatusEnum|Not applicable|
-|ErPrHpvStatusEnum|Positive|
-|ErPrHpvStatusEnum|Unknown|
-
-<h2 id="tocS_GenderEnum">GenderEnum</h2>
-
-<a id="schemagenderenum"></a>
-<a id="schema_GenderEnum"></a>
-<a id="tocSgenderenum"></a>
-<a id="tocsgenderenum"></a>
-
-```json
-"Man"
-
-```
-
-GenderEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|GenderEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|GenderEnum|Man|
-|GenderEnum|Woman|
-|GenderEnum|Non-binary|
-
-<h2 id="tocS_Her2StatusEnum">Her2StatusEnum</h2>
-
-<a id="schemaher2statusenum"></a>
-<a id="schema_Her2StatusEnum"></a>
-<a id="tocSher2statusenum"></a>
-<a id="tocsher2statusenum"></a>
-
-```json
-"Cannot be determined"
-
-```
-
-Her2StatusEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|Her2StatusEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|Her2StatusEnum|Cannot be determined|
-|Her2StatusEnum|Equivocal|
-|Her2StatusEnum|Positive|
-|Her2StatusEnum|Negative|
-|Her2StatusEnum|Not applicable|
-|Her2StatusEnum|Unknown|
-
-<h2 id="tocS_HpvStrainEnum">HpvStrainEnum</h2>
-
-<a id="schemahpvstrainenum"></a>
-<a id="schema_HpvStrainEnum"></a>
-<a id="tocShpvstrainenum"></a>
-<a id="tocshpvstrainenum"></a>
-
-```json
-"HPV16"
-
-```
-
-HpvStrainEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|HpvStrainEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|HpvStrainEnum|HPV16|
-|HpvStrainEnum|HPV18|
-|HpvStrainEnum|HPV31|
-|HpvStrainEnum|HPV33|
-|HpvStrainEnum|HPV35|
-|HpvStrainEnum|HPV39|
-|HpvStrainEnum|HPV45|
-|HpvStrainEnum|HPV51|
-|HpvStrainEnum|HPV52|
-|HpvStrainEnum|HPV56|
-|HpvStrainEnum|HPV58|
-|HpvStrainEnum|HPV59|
-|HpvStrainEnum|HPV66|
-|HpvStrainEnum|HPV68|
-|HpvStrainEnum|HPV73|
-
-<h2 id="tocS_ImmunotherapyTypeEnum">ImmunotherapyTypeEnum</h2>
-
-<a id="schemaimmunotherapytypeenum"></a>
-<a id="schema_ImmunotherapyTypeEnum"></a>
-<a id="tocSimmunotherapytypeenum"></a>
-<a id="tocsimmunotherapytypeenum"></a>
-
-```json
-"Cell-based"
-
-```
-
-ImmunotherapyTypeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|ImmunotherapyTypeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|ImmunotherapyTypeEnum|Cell-based|
-|ImmunotherapyTypeEnum|Immune checkpoint inhibitors|
-|ImmunotherapyTypeEnum|Monoclonal antibodies other than immune checkpoint inhibitors|
-|ImmunotherapyTypeEnum|Other immunomodulatory substances|
-
-<h2 id="tocS_LostToFollowupReasonEnum">LostToFollowupReasonEnum</h2>
-
-<a id="schemalosttofollowupreasonenum"></a>
-<a id="schema_LostToFollowupReasonEnum"></a>
-<a id="tocSlosttofollowupreasonenum"></a>
-<a id="tocslosttofollowupreasonenum"></a>
-
-```json
-"Completed study"
-
-```
-
-LostToFollowupReasonEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|LostToFollowupReasonEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|LostToFollowupReasonEnum|Completed study|
-|LostToFollowupReasonEnum|Discharged to palliative care|
-|LostToFollowupReasonEnum|Lost contact|
-|LostToFollowupReasonEnum|Not applicable|
-|LostToFollowupReasonEnum|Unknown|
-|LostToFollowupReasonEnum|Withdrew from study|
-
-<h2 id="tocS_LymphNodeMethodEnum">LymphNodeMethodEnum</h2>
-
-<a id="schemalymphnodemethodenum"></a>
-<a id="schema_LymphNodeMethodEnum"></a>
-<a id="tocSlymphnodemethodenum"></a>
-<a id="tocslymphnodemethodenum"></a>
-
-```json
-"Imaging"
-
-```
-
-LymphNodeMethodEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|LymphNodeMethodEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|LymphNodeMethodEnum|Imaging|
-|LymphNodeMethodEnum|Lymph node dissection/pathological exam|
-|LymphNodeMethodEnum|Physical palpation of patient|
-
-<h2 id="tocS_LymphNodeStatusEnum">LymphNodeStatusEnum</h2>
-
-<a id="schemalymphnodestatusenum"></a>
-<a id="schema_LymphNodeStatusEnum"></a>
-<a id="tocSlymphnodestatusenum"></a>
-<a id="tocslymphnodestatusenum"></a>
-
-```json
-"Cannot be determined"
-
-```
-
-LymphNodeStatusEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|LymphNodeStatusEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|LymphNodeStatusEnum|Cannot be determined|
-|LymphNodeStatusEnum|No|
-|LymphNodeStatusEnum|No lymph nodes found in resected specimen|
-|LymphNodeStatusEnum|Not applicable|
-|LymphNodeStatusEnum|Yes|
-
-<h2 id="tocS_LymphovascularInvasionEnum">LymphovascularInvasionEnum</h2>
-
-<a id="schemalymphovascularinvasionenum"></a>
-<a id="schema_LymphovascularInvasionEnum"></a>
-<a id="tocSlymphovascularinvasionenum"></a>
-<a id="tocslymphovascularinvasionenum"></a>
-
-```json
-"Absent"
-
-```
-
-LymphovascularInvasionEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|LymphovascularInvasionEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|LymphovascularInvasionEnum|Absent|
-|LymphovascularInvasionEnum|Both lymphatic and small vessel and venous (large vessel) invasion|
-|LymphovascularInvasionEnum|Lymphatic and small vessel invasion only|
-|LymphovascularInvasionEnum|Not applicable|
-|LymphovascularInvasionEnum|Present|
-|LymphovascularInvasionEnum|Venous (large vessel) invasion only|
-|LymphovascularInvasionEnum|Unknown|
-
-<h2 id="tocS_MCategoryEnum">MCategoryEnum</h2>
-
-<a id="schemamcategoryenum"></a>
-<a id="schema_MCategoryEnum"></a>
-<a id="tocSmcategoryenum"></a>
-<a id="tocsmcategoryenum"></a>
-
-```json
-"M0"
-
-```
-
-MCategoryEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|MCategoryEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|MCategoryEnum|M0|
-|MCategoryEnum|M0(i+)|
-|MCategoryEnum|M1|
-|MCategoryEnum|M1a|
-|MCategoryEnum|M1a(0)|
-|MCategoryEnum|M1a(1)|
-|MCategoryEnum|M1b|
-|MCategoryEnum|M1b(0)|
-|MCategoryEnum|M1b(1)|
-|MCategoryEnum|M1c|
-|MCategoryEnum|M1c(0)|
-|MCategoryEnum|M1c(1)|
-|MCategoryEnum|M1d|
-|MCategoryEnum|M1d(0)|
-|MCategoryEnum|M1d(1)|
-|MCategoryEnum|M1e|
-|MCategoryEnum|MX|
-
-<h2 id="tocS_MalignancyLateralityEnum">MalignancyLateralityEnum</h2>
-
-<a id="schemamalignancylateralityenum"></a>
-<a id="schema_MalignancyLateralityEnum"></a>
-<a id="tocSmalignancylateralityenum"></a>
-<a id="tocsmalignancylateralityenum"></a>
-
-```json
-"Bilateral"
-
-```
-
-MalignancyLateralityEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|MalignancyLateralityEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|MalignancyLateralityEnum|Bilateral|
-|MalignancyLateralityEnum|Left|
-|MalignancyLateralityEnum|Midline|
-|MalignancyLateralityEnum|Not applicable|
-|MalignancyLateralityEnum|Right|
-|MalignancyLateralityEnum|Unilateral, Side not specified|
-|MalignancyLateralityEnum|Unknown|
-
-<h2 id="tocS_MarginTypesEnum">MarginTypesEnum</h2>
-
-<a id="schemamargintypesenum"></a>
-<a id="schema_MarginTypesEnum"></a>
-<a id="tocSmargintypesenum"></a>
-<a id="tocsmargintypesenum"></a>
-
-```json
-"Circumferential resection margin"
-
-```
-
-MarginTypesEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|MarginTypesEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|MarginTypesEnum|Circumferential resection margin|
-|MarginTypesEnum|Common bile duct margin|
-|MarginTypesEnum|Distal margin|
-|MarginTypesEnum|Not applicable|
-|MarginTypesEnum|Proximal margin|
-|MarginTypesEnum|Unknown|
-
-<h2 id="tocS_NCategoryEnum">NCategoryEnum</h2>
-
-<a id="schemancategoryenum"></a>
-<a id="schema_NCategoryEnum"></a>
-<a id="tocSncategoryenum"></a>
-<a id="tocsncategoryenum"></a>
-
-```json
-"N0"
-
-```
-
-NCategoryEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|NCategoryEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|NCategoryEnum|N0|
-|NCategoryEnum|N0a|
-|NCategoryEnum|N0a (biopsy)|
-|NCategoryEnum|N0b|
-|NCategoryEnum|N0b (no biopsy)|
-|NCategoryEnum|N0(i+)|
-|NCategoryEnum|N0(i-)|
-|NCategoryEnum|N0(mol+)|
-|NCategoryEnum|N0(mol-)|
-|NCategoryEnum|N1|
-|NCategoryEnum|N1a|
-|NCategoryEnum|N1a(sn)|
-|NCategoryEnum|N1b|
-|NCategoryEnum|N1c|
-|NCategoryEnum|N1mi|
-|NCategoryEnum|N2|
-|NCategoryEnum|N2a|
-|NCategoryEnum|N2b|
-|NCategoryEnum|N2c|
-|NCategoryEnum|N2mi|
-|NCategoryEnum|N3|
-|NCategoryEnum|N3a|
-|NCategoryEnum|N3b|
-|NCategoryEnum|N3c|
-|NCategoryEnum|N4|
-|NCategoryEnum|NX|
 
 <h2 id="tocS_NestedBiomarkerSchema">NestedBiomarkerSchema</h2>
 
@@ -9047,1692 +10644,6 @@ continued
 |surgeries|[[NestedSurgerySchema](#schemanestedsurgeryschema)]|false|none|none|
 |followups|[[NestedFollowUpSchema](#schemanestedfollowupschema)]|false|none|none|
 
-<h2 id="tocS_PercentCellsRangeEnum">PercentCellsRangeEnum</h2>
-
-<a id="schemapercentcellsrangeenum"></a>
-<a id="schema_PercentCellsRangeEnum"></a>
-<a id="tocSpercentcellsrangeenum"></a>
-<a id="tocspercentcellsrangeenum"></a>
-
-```json
-"0-19%"
-
-```
-
-PercentCellsRangeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|PercentCellsRangeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|PercentCellsRangeEnum|0-19%|
-|PercentCellsRangeEnum|20-50%|
-|PercentCellsRangeEnum|51-100%|
-
-<h2 id="tocS_PerineuralInvasionEnum">PerineuralInvasionEnum</h2>
-
-<a id="schemaperineuralinvasionenum"></a>
-<a id="schema_PerineuralInvasionEnum"></a>
-<a id="tocSperineuralinvasionenum"></a>
-<a id="tocsperineuralinvasionenum"></a>
-
-```json
-"Absent"
-
-```
-
-PerineuralInvasionEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|PerineuralInvasionEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|PerineuralInvasionEnum|Absent|
-|PerineuralInvasionEnum|Cannot be assessed|
-|PerineuralInvasionEnum|Not applicable|
-|PerineuralInvasionEnum|Present|
-|PerineuralInvasionEnum|Unknown|
-
-<h2 id="tocS_PrimaryDiagnosisLateralityEnum">PrimaryDiagnosisLateralityEnum</h2>
-
-<a id="schemaprimarydiagnosislateralityenum"></a>
-<a id="schema_PrimaryDiagnosisLateralityEnum"></a>
-<a id="tocSprimarydiagnosislateralityenum"></a>
-<a id="tocsprimarydiagnosislateralityenum"></a>
-
-```json
-"Bilateral"
-
-```
-
-PrimaryDiagnosisLateralityEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|PrimaryDiagnosisLateralityEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|PrimaryDiagnosisLateralityEnum|Bilateral|
-|PrimaryDiagnosisLateralityEnum|Left|
-|PrimaryDiagnosisLateralityEnum|Midline|
-|PrimaryDiagnosisLateralityEnum|Not a paired site|
-|PrimaryDiagnosisLateralityEnum|Right|
-|PrimaryDiagnosisLateralityEnum|Unilateral, side not specified|
-|PrimaryDiagnosisLateralityEnum|Unknown|
-
-<h2 id="tocS_PrimarySiteEnum">PrimarySiteEnum</h2>
-
-<a id="schemaprimarysiteenum"></a>
-<a id="schema_PrimarySiteEnum"></a>
-<a id="tocSprimarysiteenum"></a>
-<a id="tocsprimarysiteenum"></a>
-
-```json
-"Accessory sinuses"
-
-```
-
-PrimarySiteEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|PrimarySiteEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|PrimarySiteEnum|Accessory sinuses|
-|PrimarySiteEnum|Adrenal gland|
-|PrimarySiteEnum|Anus and anal canal|
-|PrimarySiteEnum|Base of tongue|
-|PrimarySiteEnum|Bladder|
-|PrimarySiteEnum|Bones, joints and articular cartilage of limbs|
-|PrimarySiteEnum|Bones, joints and articular cartilage of other and unspecified sites|
-|PrimarySiteEnum|Brain|
-|PrimarySiteEnum|Breast|
-|PrimarySiteEnum|Bronchus and lung|
-|PrimarySiteEnum|Cervix uteri|
-|PrimarySiteEnum|Colon|
-|PrimarySiteEnum|Connective, subcutaneous and other soft tissues|
-|PrimarySiteEnum|Corpus uteri|
-|PrimarySiteEnum|Esophagus|
-|PrimarySiteEnum|Eye and adnexa|
-|PrimarySiteEnum|Floor of mouth|
-|PrimarySiteEnum|Gallbladder|
-|PrimarySiteEnum|Gum|
-|PrimarySiteEnum|Heart, mediastinum, and pleura|
-|PrimarySiteEnum|Hematopoietic and reticuloendothelial systems|
-|PrimarySiteEnum|Hypopharynx|
-|PrimarySiteEnum|Kidney|
-|PrimarySiteEnum|Larynx|
-|PrimarySiteEnum|Lip|
-|PrimarySiteEnum|Liver and intrahepatic bile ducts|
-|PrimarySiteEnum|Lymph nodes|
-|PrimarySiteEnum|Meninges|
-|PrimarySiteEnum|Nasal cavity and middle ear|
-|PrimarySiteEnum|Nasopharynx|
-|PrimarySiteEnum|Oropharynx|
-|PrimarySiteEnum|Other and ill-defined digestive organs|
-|PrimarySiteEnum|Other and ill-defined sites|
-|PrimarySiteEnum|Other and ill-defined sites in lip, oral cavity and pharynx|
-|PrimarySiteEnum|Other and ill-defined sites within respiratory system and intrathoracic organs|
-|PrimarySiteEnum|Other and unspecified female genital organs|
-|PrimarySiteEnum|Other and unspecified major salivary glands|
-|PrimarySiteEnum|Other and unspecified male genital organs|
-|PrimarySiteEnum|Other and unspecified parts of biliary tract|
-|PrimarySiteEnum|Other and unspecified parts of mouth|
-|PrimarySiteEnum|Other and unspecified parts of tongue|
-|PrimarySiteEnum|Other and unspecified urinary organs|
-|PrimarySiteEnum|Other endocrine glands and related structures|
-|PrimarySiteEnum|Ovary|
-|PrimarySiteEnum|Palate|
-|PrimarySiteEnum|Pancreas|
-|PrimarySiteEnum|Parotid gland|
-|PrimarySiteEnum|Penis|
-|PrimarySiteEnum|Peripheral nerves and autonomic nervous system|
-|PrimarySiteEnum|Placenta|
-|PrimarySiteEnum|Prostate gland|
-|PrimarySiteEnum|Pyriform sinus|
-|PrimarySiteEnum|Rectosigmoid junction|
-|PrimarySiteEnum|Rectum|
-|PrimarySiteEnum|Renal pelvis|
-|PrimarySiteEnum|Retroperitoneum and peritoneum|
-|PrimarySiteEnum|Skin|
-|PrimarySiteEnum|Small intestine|
-|PrimarySiteEnum|Spinal cord, cranial nerves, and other parts of central nervous system|
-|PrimarySiteEnum|Stomach|
-|PrimarySiteEnum|Testis|
-|PrimarySiteEnum|Thymus|
-|PrimarySiteEnum|Thyroid gland|
-|PrimarySiteEnum|Tonsil|
-|PrimarySiteEnum|Trachea|
-|PrimarySiteEnum|Ureter|
-|PrimarySiteEnum|Uterus, NOS|
-|PrimarySiteEnum|Vagina|
-|PrimarySiteEnum|Vulva|
-|PrimarySiteEnum|Unknown primary site|
-
-<h2 id="tocS_ProgressionStatusMethodEnum">ProgressionStatusMethodEnum</h2>
-
-<a id="schemaprogressionstatusmethodenum"></a>
-<a id="schema_ProgressionStatusMethodEnum"></a>
-<a id="tocSprogressionstatusmethodenum"></a>
-<a id="tocsprogressionstatusmethodenum"></a>
-
-```json
-"Imaging (procedure)"
-
-```
-
-ProgressionStatusMethodEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|ProgressionStatusMethodEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|ProgressionStatusMethodEnum|Imaging (procedure)|
-|ProgressionStatusMethodEnum|Histopathology test (procedure)|
-|ProgressionStatusMethodEnum|Assessment of symptom control (procedure)|
-|ProgressionStatusMethodEnum|Physical examination procedure (procedure)|
-|ProgressionStatusMethodEnum|Tumor marker measurement (procedure)|
-|ProgressionStatusMethodEnum|Laboratory data interpretation (procedure)|
-
-<h2 id="tocS_RadiationAnatomicalSiteEnum">RadiationAnatomicalSiteEnum</h2>
-
-<a id="schemaradiationanatomicalsiteenum"></a>
-<a id="schema_RadiationAnatomicalSiteEnum"></a>
-<a id="tocSradiationanatomicalsiteenum"></a>
-<a id="tocsradiationanatomicalsiteenum"></a>
-
-```json
-"Left Abdomen"
-
-```
-
-RadiationAnatomicalSiteEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|RadiationAnatomicalSiteEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|RadiationAnatomicalSiteEnum|Left Abdomen|
-|RadiationAnatomicalSiteEnum|Whole Abdomen|
-|RadiationAnatomicalSiteEnum|Right Abdomen|
-|RadiationAnatomicalSiteEnum|Lower Abdomen|
-|RadiationAnatomicalSiteEnum|Left Lower Abdomen|
-|RadiationAnatomicalSiteEnum|Right Lower Abdomen|
-|RadiationAnatomicalSiteEnum|Upper Abdomen|
-|RadiationAnatomicalSiteEnum|Left Upper Abdomen|
-|RadiationAnatomicalSiteEnum|Right Upper Abdomen|
-|RadiationAnatomicalSiteEnum|Left Adrenal|
-|RadiationAnatomicalSiteEnum|Right Adrenal|
-|RadiationAnatomicalSiteEnum|Bilateral Ankle|
-|RadiationAnatomicalSiteEnum|Left Ankle|
-|RadiationAnatomicalSiteEnum|Right Ankle|
-|RadiationAnatomicalSiteEnum|Bilateral Antrum (Bull's Eye)|
-|RadiationAnatomicalSiteEnum|Left Antrum|
-|RadiationAnatomicalSiteEnum|Right Antrum|
-|RadiationAnatomicalSiteEnum|Anus|
-|RadiationAnatomicalSiteEnum|Lower Left Arm|
-|RadiationAnatomicalSiteEnum|Lower Right Arm|
-|RadiationAnatomicalSiteEnum|Bilateral Arms|
-|RadiationAnatomicalSiteEnum|Left Arm|
-|RadiationAnatomicalSiteEnum|Right Arm|
-|RadiationAnatomicalSiteEnum|Upper Left Arm|
-|RadiationAnatomicalSiteEnum|Upper Right Arm|
-|RadiationAnatomicalSiteEnum|Left Axilla|
-|RadiationAnatomicalSiteEnum|Right Axilla|
-|RadiationAnatomicalSiteEnum|Skin or Soft Tissue of Back|
-|RadiationAnatomicalSiteEnum|Bile Duct|
-|RadiationAnatomicalSiteEnum|Bladder|
-|RadiationAnatomicalSiteEnum|Lower Body|
-|RadiationAnatomicalSiteEnum|Middle Body|
-|RadiationAnatomicalSiteEnum|Upper Body|
-|RadiationAnatomicalSiteEnum|Whole Body|
-|RadiationAnatomicalSiteEnum|Boost - Area Previously Treated|
-|RadiationAnatomicalSiteEnum|Brain|
-|RadiationAnatomicalSiteEnum|Left Breast Boost|
-|RadiationAnatomicalSiteEnum|Right Breast Boost|
-|RadiationAnatomicalSiteEnum|Bilateral Breast|
-|RadiationAnatomicalSiteEnum|Left Breast|
-|RadiationAnatomicalSiteEnum|Right Breast|
-|RadiationAnatomicalSiteEnum|Bilateral Breasts with Nodes|
-|RadiationAnatomicalSiteEnum|Left Breast with Nodes|
-|RadiationAnatomicalSiteEnum|Right Breast with Nodes|
-|RadiationAnatomicalSiteEnum|Bilateral Buttocks|
-|RadiationAnatomicalSiteEnum|Left Buttock|
-|RadiationAnatomicalSiteEnum|Right Buttock|
-|RadiationAnatomicalSiteEnum|Inner Canthus|
-|RadiationAnatomicalSiteEnum|Outer Canthus|
-|RadiationAnatomicalSiteEnum|Cervix|
-|RadiationAnatomicalSiteEnum|Bilateral Chest Lung & Area Involve|
-|RadiationAnatomicalSiteEnum|Left Chest|
-|RadiationAnatomicalSiteEnum|Right Chest|
-|RadiationAnatomicalSiteEnum|Chin|
-|RadiationAnatomicalSiteEnum|Left Cheek|
-|RadiationAnatomicalSiteEnum|Right Cheek|
-|RadiationAnatomicalSiteEnum|Bilateral Chest Wall (W/o Breast)|
-|RadiationAnatomicalSiteEnum|Left Chest Wall|
-|RadiationAnatomicalSiteEnum|Right Chest Wall|
-|RadiationAnatomicalSiteEnum|Bilateral Clavicle|
-|RadiationAnatomicalSiteEnum|Left Clavicle|
-|RadiationAnatomicalSiteEnum|Right Clavicle|
-|RadiationAnatomicalSiteEnum|Coccyx|
-|RadiationAnatomicalSiteEnum|Colon|
-|RadiationAnatomicalSiteEnum|Whole C.N.S. (Medulla Techinque)|
-|RadiationAnatomicalSiteEnum|Csf Spine (Medull Tech 2 Diff Machi|
-|RadiationAnatomicalSiteEnum|Left Chestwall Boost|
-|RadiationAnatomicalSiteEnum|Right Chestwall Boost|
-|RadiationAnatomicalSiteEnum|Bilateral Chestwall with Nodes|
-|RadiationAnatomicalSiteEnum|Left Chestwall with Nodes|
-|RadiationAnatomicalSiteEnum|Right Chestwall with Nodes|
-|RadiationAnatomicalSiteEnum|Left Ear|
-|RadiationAnatomicalSiteEnum|Right Ear|
-|RadiationAnatomicalSiteEnum|Epigastrium|
-|RadiationAnatomicalSiteEnum|Lower Esophagus|
-|RadiationAnatomicalSiteEnum|Middle Esophagus|
-|RadiationAnatomicalSiteEnum|Upper Esophagus|
-|RadiationAnatomicalSiteEnum|Entire Esophagus|
-|RadiationAnatomicalSiteEnum|Ethmoid Sinus|
-|RadiationAnatomicalSiteEnum|Bilateral Eyes|
-|RadiationAnatomicalSiteEnum|Left Eye|
-|RadiationAnatomicalSiteEnum|Right Eye|
-|RadiationAnatomicalSiteEnum|Bilateral Face|
-|RadiationAnatomicalSiteEnum|Left Face|
-|RadiationAnatomicalSiteEnum|Right Face|
-|RadiationAnatomicalSiteEnum|Left Fallopian Tubes|
-|RadiationAnatomicalSiteEnum|Right Fallopian Tubes|
-|RadiationAnatomicalSiteEnum|Bilateral Femur|
-|RadiationAnatomicalSiteEnum|Left Femur|
-|RadiationAnatomicalSiteEnum|Right Femur|
-|RadiationAnatomicalSiteEnum|Left Fibula|
-|RadiationAnatomicalSiteEnum|Right Fibula|
-|RadiationAnatomicalSiteEnum|Finger (Including Thumbs)|
-|RadiationAnatomicalSiteEnum|Floor of Mouth (Boosts)|
-|RadiationAnatomicalSiteEnum|Bilateral Feet|
-|RadiationAnatomicalSiteEnum|Left Foot|
-|RadiationAnatomicalSiteEnum|Right Foot|
-|RadiationAnatomicalSiteEnum|Forehead|
-|RadiationAnatomicalSiteEnum|Posterior Fossa|
-|RadiationAnatomicalSiteEnum|Gall Bladder|
-|RadiationAnatomicalSiteEnum|Gingiva|
-|RadiationAnatomicalSiteEnum|Bilateral Hand|
-|RadiationAnatomicalSiteEnum|Left Hand|
-|RadiationAnatomicalSiteEnum|Right Hand|
-|RadiationAnatomicalSiteEnum|Head|
-|RadiationAnatomicalSiteEnum|Bilateral Heel|
-|RadiationAnatomicalSiteEnum|Left Heel|
-|RadiationAnatomicalSiteEnum|Right Heel|
-|RadiationAnatomicalSiteEnum|Left Hemimantle|
-|RadiationAnatomicalSiteEnum|Right Hemimantle|
-|RadiationAnatomicalSiteEnum|Heart|
-|RadiationAnatomicalSiteEnum|Bilateral Hip|
-|RadiationAnatomicalSiteEnum|Left Hip|
-|RadiationAnatomicalSiteEnum|Right Hip|
-|RadiationAnatomicalSiteEnum|Left Humerus|
-|RadiationAnatomicalSiteEnum|Right Humerus|
-|RadiationAnatomicalSiteEnum|Hypopharynx|
-|RadiationAnatomicalSiteEnum|Bilateral Internal Mammary Chain|
-|RadiationAnatomicalSiteEnum|Bilateral Inguinal Nodes|
-|RadiationAnatomicalSiteEnum|Left Inguinal Nodes|
-|RadiationAnatomicalSiteEnum|Right Inguinal Nodes|
-|RadiationAnatomicalSiteEnum|Inverted 'Y' (Dog-Leg,Hockey-Stick)|
-|RadiationAnatomicalSiteEnum|Left Kidney|
-|RadiationAnatomicalSiteEnum|Right Kidney|
-|RadiationAnatomicalSiteEnum|Bilateral Knee|
-|RadiationAnatomicalSiteEnum|Left Knee|
-|RadiationAnatomicalSiteEnum|Right Knee|
-|RadiationAnatomicalSiteEnum|Bilateral Lacrimal Gland|
-|RadiationAnatomicalSiteEnum|Left Lacrimal Gland|
-|RadiationAnatomicalSiteEnum|Right Lacrimal Gland|
-|RadiationAnatomicalSiteEnum|Larygopharynx|
-|RadiationAnatomicalSiteEnum|Larynx|
-|RadiationAnatomicalSiteEnum|Bilateral Leg|
-|RadiationAnatomicalSiteEnum|Left Leg|
-|RadiationAnatomicalSiteEnum|Right Leg|
-|RadiationAnatomicalSiteEnum|Lower Bilateral Leg|
-|RadiationAnatomicalSiteEnum|Lower Left Leg|
-|RadiationAnatomicalSiteEnum|Lower Right Leg|
-|RadiationAnatomicalSiteEnum|Upper Bilateral Leg|
-|RadiationAnatomicalSiteEnum|Upper Left Leg|
-|RadiationAnatomicalSiteEnum|Upper Right Leg|
-|RadiationAnatomicalSiteEnum|Both Eyelid(s)|
-|RadiationAnatomicalSiteEnum|Left Eyelid|
-|RadiationAnatomicalSiteEnum|Right Eyelid|
-|RadiationAnatomicalSiteEnum|Both Lip(s)|
-|RadiationAnatomicalSiteEnum|Lower Lip|
-|RadiationAnatomicalSiteEnum|Upper Lip|
-|RadiationAnatomicalSiteEnum|Liver|
-|RadiationAnatomicalSiteEnum|Bilateral Lung|
-|RadiationAnatomicalSiteEnum|Left Lung|
-|RadiationAnatomicalSiteEnum|Right Lung|
-|RadiationAnatomicalSiteEnum|Bilateral Mandible|
-|RadiationAnatomicalSiteEnum|Left Mandible|
-|RadiationAnatomicalSiteEnum|Right Mandible|
-|RadiationAnatomicalSiteEnum|Mantle|
-|RadiationAnatomicalSiteEnum|Bilateral Maxilla|
-|RadiationAnatomicalSiteEnum|Left Maxilla|
-|RadiationAnatomicalSiteEnum|Right Maxilla|
-|RadiationAnatomicalSiteEnum|Mediastinum|
-|RadiationAnatomicalSiteEnum|Multiple Skin|
-|RadiationAnatomicalSiteEnum|Nasal Fossa|
-|RadiationAnatomicalSiteEnum|Nasopharynx|
-|RadiationAnatomicalSiteEnum|Bilateral Neck Includes Nodes|
-|RadiationAnatomicalSiteEnum|Left Neck Includes Nodes|
-|RadiationAnatomicalSiteEnum|Right Neck Includes Nodes|
-|RadiationAnatomicalSiteEnum|Neck - Skin|
-|RadiationAnatomicalSiteEnum|Nose|
-|RadiationAnatomicalSiteEnum|Oral Cavity / Buccal Mucosa|
-|RadiationAnatomicalSiteEnum|Bilateral Orbit|
-|RadiationAnatomicalSiteEnum|Left Orbit|
-|RadiationAnatomicalSiteEnum|Right Orbit|
-|RadiationAnatomicalSiteEnum|Oropharynx|
-|RadiationAnatomicalSiteEnum|Bilateral Ovary|
-|RadiationAnatomicalSiteEnum|Left Ovary|
-|RadiationAnatomicalSiteEnum|Right Ovary|
-|RadiationAnatomicalSiteEnum|Hard Palate|
-|RadiationAnatomicalSiteEnum|Soft Palate|
-|RadiationAnatomicalSiteEnum|Palate Unspecified|
-|RadiationAnatomicalSiteEnum|Pancreas|
-|RadiationAnatomicalSiteEnum|Para-Aortic Nodes|
-|RadiationAnatomicalSiteEnum|Left Parotid|
-|RadiationAnatomicalSiteEnum|Right Parotid|
-|RadiationAnatomicalSiteEnum|Bilateral Pelvis|
-|RadiationAnatomicalSiteEnum|Left Pelvis|
-|RadiationAnatomicalSiteEnum|Right Pelvis|
-|RadiationAnatomicalSiteEnum|Penis|
-|RadiationAnatomicalSiteEnum|Perineum|
-|RadiationAnatomicalSiteEnum|Pituitary|
-|RadiationAnatomicalSiteEnum|Left Pleura (As in Mesothelioma)|
-|RadiationAnatomicalSiteEnum|Right Pleura|
-|RadiationAnatomicalSiteEnum|Prostate|
-|RadiationAnatomicalSiteEnum|Pubis|
-|RadiationAnatomicalSiteEnum|Pyriform Fossa (Sinuses)|
-|RadiationAnatomicalSiteEnum|Left Radius|
-|RadiationAnatomicalSiteEnum|Right Radius|
-|RadiationAnatomicalSiteEnum|Rectum (Includes Sigmoid)|
-|RadiationAnatomicalSiteEnum|Left Ribs|
-|RadiationAnatomicalSiteEnum|Right Ribs|
-|RadiationAnatomicalSiteEnum|Sacrum|
-|RadiationAnatomicalSiteEnum|Left Salivary Gland|
-|RadiationAnatomicalSiteEnum|Right Salivary Gland|
-|RadiationAnatomicalSiteEnum|Bilateral Scapula|
-|RadiationAnatomicalSiteEnum|Left Scapula|
-|RadiationAnatomicalSiteEnum|Right Scapula|
-|RadiationAnatomicalSiteEnum|Bilateral Supraclavicular Nodes|
-|RadiationAnatomicalSiteEnum|Left Supraclavicular Nodes|
-|RadiationAnatomicalSiteEnum|Right Supraclavicular Nodes|
-|RadiationAnatomicalSiteEnum|Bilateral Scalp|
-|RadiationAnatomicalSiteEnum|Left Scalp|
-|RadiationAnatomicalSiteEnum|Right Scalp|
-|RadiationAnatomicalSiteEnum|Scrotum|
-|RadiationAnatomicalSiteEnum|Bilateral Shoulder|
-|RadiationAnatomicalSiteEnum|Left Shoulder|
-|RadiationAnatomicalSiteEnum|Right Shoulder|
-|RadiationAnatomicalSiteEnum|Whole Body - Skin|
-|RadiationAnatomicalSiteEnum|Skull|
-|RadiationAnatomicalSiteEnum|Cervical & Thoracic Spine|
-|RadiationAnatomicalSiteEnum|Sphenoid Sinus|
-|RadiationAnatomicalSiteEnum|Cervical Spine|
-|RadiationAnatomicalSiteEnum|Lumbar Spine|
-|RadiationAnatomicalSiteEnum|Thoracic Spine|
-|RadiationAnatomicalSiteEnum|Whole Spine|
-|RadiationAnatomicalSiteEnum|Spleen|
-|RadiationAnatomicalSiteEnum|Lumbo-Sacral Spine|
-|RadiationAnatomicalSiteEnum|Thoracic & Lumbar Spine|
-|RadiationAnatomicalSiteEnum|Sternum|
-|RadiationAnatomicalSiteEnum|Stomach|
-|RadiationAnatomicalSiteEnum|Submandibular Glands|
-|RadiationAnatomicalSiteEnum|Left Temple|
-|RadiationAnatomicalSiteEnum|Right Temple|
-|RadiationAnatomicalSiteEnum|Bilateral Testis|
-|RadiationAnatomicalSiteEnum|Left Testis|
-|RadiationAnatomicalSiteEnum|Right Testis|
-|RadiationAnatomicalSiteEnum|Thyroid|
-|RadiationAnatomicalSiteEnum|Left Tibia|
-|RadiationAnatomicalSiteEnum|Right Tibia|
-|RadiationAnatomicalSiteEnum|Left Toes|
-|RadiationAnatomicalSiteEnum|Right Toes|
-|RadiationAnatomicalSiteEnum|Tongue|
-|RadiationAnatomicalSiteEnum|Tonsil|
-|RadiationAnatomicalSiteEnum|Trachea|
-|RadiationAnatomicalSiteEnum|Left Ulna|
-|RadiationAnatomicalSiteEnum|Right Ulna|
-|RadiationAnatomicalSiteEnum|Left Ureter|
-|RadiationAnatomicalSiteEnum|Right Ureter|
-|RadiationAnatomicalSiteEnum|Urethra|
-|RadiationAnatomicalSiteEnum|Uterus|
-|RadiationAnatomicalSiteEnum|Uvula|
-|RadiationAnatomicalSiteEnum|Vagina|
-|RadiationAnatomicalSiteEnum|Vulva|
-|RadiationAnatomicalSiteEnum|Abdomen|
-|RadiationAnatomicalSiteEnum|Body|
-|RadiationAnatomicalSiteEnum|Chest|
-|RadiationAnatomicalSiteEnum|Lower Limb|
-|RadiationAnatomicalSiteEnum|Neck|
-|RadiationAnatomicalSiteEnum|Other|
-|RadiationAnatomicalSiteEnum|Pelvis|
-|RadiationAnatomicalSiteEnum|Skin|
-|RadiationAnatomicalSiteEnum|Spine|
-|RadiationAnatomicalSiteEnum|Upper Limb|
-
-<h2 id="tocS_RadiationTherapyModalityEnum">RadiationTherapyModalityEnum</h2>
-
-<a id="schemaradiationtherapymodalityenum"></a>
-<a id="schema_RadiationTherapyModalityEnum"></a>
-<a id="tocSradiationtherapymodalityenum"></a>
-<a id="tocsradiationtherapymodalityenum"></a>
-
-```json
-"Megavoltage radiation therapy using photons (procedure)"
-
-```
-
-RadiationTherapyModalityEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|RadiationTherapyModalityEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|RadiationTherapyModalityEnum|Megavoltage radiation therapy using photons (procedure)|
-|RadiationTherapyModalityEnum|Radiopharmaceutical|
-|RadiationTherapyModalityEnum|Teleradiotherapy using electrons (procedure)|
-|RadiationTherapyModalityEnum|Teleradiotherapy protons (procedure)|
-|RadiationTherapyModalityEnum|Teleradiotherapy neutrons (procedure)|
-|RadiationTherapyModalityEnum|Brachytherapy (procedure)|
-|RadiationTherapyModalityEnum|Other|
-
-<h2 id="tocS_RelapseTypeEnum">RelapseTypeEnum</h2>
-
-<a id="schemarelapsetypeenum"></a>
-<a id="schema_RelapseTypeEnum"></a>
-<a id="tocSrelapsetypeenum"></a>
-<a id="tocsrelapsetypeenum"></a>
-
-```json
-"Distant recurrence/metastasis"
-
-```
-
-RelapseTypeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|RelapseTypeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|RelapseTypeEnum|Distant recurrence/metastasis|
-|RelapseTypeEnum|Local recurrence|
-|RelapseTypeEnum|Local recurrence and distant metastasis|
-|RelapseTypeEnum|Progression (liquid tumours)|
-|RelapseTypeEnum|Biochemical progression|
-
-<h2 id="tocS_SampleTypeEnum">SampleTypeEnum</h2>
-
-<a id="schemasampletypeenum"></a>
-<a id="schema_SampleTypeEnum"></a>
-<a id="tocSsampletypeenum"></a>
-<a id="tocssampletypeenum"></a>
-
-```json
-"Amplified DNA"
-
-```
-
-SampleTypeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SampleTypeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SampleTypeEnum|Amplified DNA|
-|SampleTypeEnum|ctDNA|
-|SampleTypeEnum|Other DNA enrichments|
-|SampleTypeEnum|Other RNA fractions|
-|SampleTypeEnum|polyA+ RNA|
-|SampleTypeEnum|Protein|
-|SampleTypeEnum|rRNA-depleted RNA|
-|SampleTypeEnum|Total DNA|
-|SampleTypeEnum|Total RNA|
-
-<h2 id="tocS_SexAtBirthEnum">SexAtBirthEnum</h2>
-
-<a id="schemasexatbirthenum"></a>
-<a id="schema_SexAtBirthEnum"></a>
-<a id="tocSsexatbirthenum"></a>
-<a id="tocssexatbirthenum"></a>
-
-```json
-"Male"
-
-```
-
-SexAtBirthEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SexAtBirthEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SexAtBirthEnum|Male|
-|SexAtBirthEnum|Female|
-|SexAtBirthEnum|Other|
-|SexAtBirthEnum|Unknown|
-
-<h2 id="tocS_SmokingStatusEnum">SmokingStatusEnum</h2>
-
-<a id="schemasmokingstatusenum"></a>
-<a id="schema_SmokingStatusEnum"></a>
-<a id="tocSsmokingstatusenum"></a>
-<a id="tocssmokingstatusenum"></a>
-
-```json
-"Current reformed smoker for <= 15 years"
-
-```
-
-SmokingStatusEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SmokingStatusEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SmokingStatusEnum|Current reformed smoker for <= 15 years|
-|SmokingStatusEnum|Current reformed smoker for > 15 years|
-|SmokingStatusEnum|Current reformed smoker, duration not specified|
-|SmokingStatusEnum|Current smoker|
-|SmokingStatusEnum|Lifelong non-smoker (<100 cigarettes smoked in lifetime)|
-|SmokingStatusEnum|Not applicable|
-|SmokingStatusEnum|Smoking history not documented|
-
-<h2 id="tocS_SpecimenLateralityEnum">SpecimenLateralityEnum</h2>
-
-<a id="schemaspecimenlateralityenum"></a>
-<a id="schema_SpecimenLateralityEnum"></a>
-<a id="tocSspecimenlateralityenum"></a>
-<a id="tocsspecimenlateralityenum"></a>
-
-```json
-"Left"
-
-```
-
-SpecimenLateralityEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SpecimenLateralityEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SpecimenLateralityEnum|Left|
-|SpecimenLateralityEnum|Not applicable|
-|SpecimenLateralityEnum|Right|
-|SpecimenLateralityEnum|Unknown|
-
-<h2 id="tocS_SpecimenProcessingEnum">SpecimenProcessingEnum</h2>
-
-<a id="schemaspecimenprocessingenum"></a>
-<a id="schema_SpecimenProcessingEnum"></a>
-<a id="tocSspecimenprocessingenum"></a>
-<a id="tocsspecimenprocessingenum"></a>
-
-```json
-"Cryopreservation in liquid nitrogen (dead tissue)"
-
-```
-
-SpecimenProcessingEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SpecimenProcessingEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SpecimenProcessingEnum|Cryopreservation in liquid nitrogen (dead tissue)|
-|SpecimenProcessingEnum|Cryopreservation in dry ice (dead tissue)|
-|SpecimenProcessingEnum|Cryopreservation of live cells in liquid nitrogen|
-|SpecimenProcessingEnum|Cryopreservation - other|
-|SpecimenProcessingEnum|Formalin fixed & paraffin embedded|
-|SpecimenProcessingEnum|Formalin fixed - buffered|
-|SpecimenProcessingEnum|Formalin fixed - unbuffered|
-|SpecimenProcessingEnum|Fresh|
-|SpecimenProcessingEnum|Other|
-|SpecimenProcessingEnum|Unknown|
-
-<h2 id="tocS_SpecimenTissueSourceEnum">SpecimenTissueSourceEnum</h2>
-
-<a id="schemaspecimentissuesourceenum"></a>
-<a id="schema_SpecimenTissueSourceEnum"></a>
-<a id="tocSspecimentissuesourceenum"></a>
-<a id="tocsspecimentissuesourceenum"></a>
-
-```json
-"Abdominal fluid"
-
-```
-
-SpecimenTissueSourceEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SpecimenTissueSourceEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SpecimenTissueSourceEnum|Abdominal fluid|
-|SpecimenTissueSourceEnum|Amniotic fluid|
-|SpecimenTissueSourceEnum|Arterial blood|
-|SpecimenTissueSourceEnum|Bile|
-|SpecimenTissueSourceEnum|Blood derived - bone marrow|
-|SpecimenTissueSourceEnum|Blood derived - peripheral blood|
-|SpecimenTissueSourceEnum|Bone marrow fluid|
-|SpecimenTissueSourceEnum|Bone marrow derived mononuclear cells|
-|SpecimenTissueSourceEnum|Buccal cell|
-|SpecimenTissueSourceEnum|Buffy coat|
-|SpecimenTissueSourceEnum|Cerebrospinal fluid|
-|SpecimenTissueSourceEnum|Cervical mucus|
-|SpecimenTissueSourceEnum|Convalescent plasma|
-|SpecimenTissueSourceEnum|Cord blood|
-|SpecimenTissueSourceEnum|Duodenal fluid|
-|SpecimenTissueSourceEnum|Female genital fluid|
-|SpecimenTissueSourceEnum|Fetal blood|
-|SpecimenTissueSourceEnum|Hydrocele fluid|
-|SpecimenTissueSourceEnum|Male genital fluid|
-|SpecimenTissueSourceEnum|Pancreatic fluid|
-|SpecimenTissueSourceEnum|Pericardial effusion|
-|SpecimenTissueSourceEnum|Pleural fluid|
-|SpecimenTissueSourceEnum|Renal cyst fluid|
-|SpecimenTissueSourceEnum|Saliva|
-|SpecimenTissueSourceEnum|Seminal fluid|
-|SpecimenTissueSourceEnum|Serum|
-|SpecimenTissueSourceEnum|Solid tissue|
-|SpecimenTissueSourceEnum|Sputum|
-|SpecimenTissueSourceEnum|Synovial fluid|
-|SpecimenTissueSourceEnum|Urine|
-|SpecimenTissueSourceEnum|Venous blood|
-|SpecimenTissueSourceEnum|Vitreous fluid|
-|SpecimenTissueSourceEnum|Whole blood|
-|SpecimenTissueSourceEnum|Wound|
-
-<h2 id="tocS_SpecimenTypeEnum">SpecimenTypeEnum</h2>
-
-<a id="schemaspecimentypeenum"></a>
-<a id="schema_SpecimenTypeEnum"></a>
-<a id="tocSspecimentypeenum"></a>
-<a id="tocsspecimentypeenum"></a>
-
-```json
-"Cell line - derived from normal"
-
-```
-
-SpecimenTypeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SpecimenTypeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SpecimenTypeEnum|Cell line - derived from normal|
-|SpecimenTypeEnum|Cell line - derived from primary tumour|
-|SpecimenTypeEnum|Cell line - derived from metastatic tumour|
-|SpecimenTypeEnum|Cell line - derived from xenograft tumour|
-|SpecimenTypeEnum|Metastatic tumour - additional metastatic|
-|SpecimenTypeEnum|Metastatic tumour - metastasis local to lymph node|
-|SpecimenTypeEnum|Metastatic tumour - metastasis to distant location|
-|SpecimenTypeEnum|Metastatic tumour|
-|SpecimenTypeEnum|Normal - tissue adjacent to primary tumour|
-|SpecimenTypeEnum|Normal|
-|SpecimenTypeEnum|Primary tumour - additional new primary|
-|SpecimenTypeEnum|Primary tumour - adjacent to normal|
-|SpecimenTypeEnum|Primary tumour|
-|SpecimenTypeEnum|Recurrent tumour|
-|SpecimenTypeEnum|Tumour - unknown if derived from primary or metastatic tumour|
-|SpecimenTypeEnum|Xenograft - derived from primary tumour|
-|SpecimenTypeEnum|Xenograft - derived from metastatic tumour|
-|SpecimenTypeEnum|Xenograft - derived from tumour cell line|
-
-<h2 id="tocS_StageGroupEnum">StageGroupEnum</h2>
-
-<a id="schemastagegroupenum"></a>
-<a id="schema_StageGroupEnum"></a>
-<a id="tocSstagegroupenum"></a>
-<a id="tocsstagegroupenum"></a>
-
-```json
-"Stage 0"
-
-```
-
-StageGroupEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|StageGroupEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|StageGroupEnum|Stage 0|
-|StageGroupEnum|Stage 0a|
-|StageGroupEnum|Stage 0is|
-|StageGroupEnum|Stage 1|
-|StageGroupEnum|Stage 1A|
-|StageGroupEnum|Stage 1B|
-|StageGroupEnum|Stage A|
-|StageGroupEnum|Stage B|
-|StageGroupEnum|Stage C|
-|StageGroupEnum|Stage I|
-|StageGroupEnum|Stage IA|
-|StageGroupEnum|Stage IA1|
-|StageGroupEnum|Stage IA2|
-|StageGroupEnum|Stage IA3|
-|StageGroupEnum|Stage IAB|
-|StageGroupEnum|Stage IAE|
-|StageGroupEnum|Stage IAES|
-|StageGroupEnum|Stage IAS|
-|StageGroupEnum|Stage IB|
-|StageGroupEnum|Stage IB1|
-|StageGroupEnum|Stage IB2|
-|StageGroupEnum|Stage IBE|
-|StageGroupEnum|Stage IBES|
-|StageGroupEnum|Stage IBS|
-|StageGroupEnum|Stage IC|
-|StageGroupEnum|Stage IE|
-|StageGroupEnum|Stage IEA|
-|StageGroupEnum|Stage IEB|
-|StageGroupEnum|Stage IES|
-|StageGroupEnum|Stage II|
-|StageGroupEnum|Stage II bulky|
-|StageGroupEnum|Stage IIA|
-|StageGroupEnum|Stage IIA1|
-|StageGroupEnum|Stage IIA2|
-|StageGroupEnum|Stage IIAE|
-|StageGroupEnum|Stage IIAES|
-|StageGroupEnum|Stage IIAS|
-|StageGroupEnum|Stage IIB|
-|StageGroupEnum|Stage IIBE|
-|StageGroupEnum|Stage IIBES|
-|StageGroupEnum|Stage IIBS|
-|StageGroupEnum|Stage IIC|
-|StageGroupEnum|Stage IIE|
-|StageGroupEnum|Stage IIEA|
-|StageGroupEnum|Stage IIEB|
-|StageGroupEnum|Stage IIES|
-|StageGroupEnum|Stage III|
-|StageGroupEnum|Stage IIIA|
-|StageGroupEnum|Stage IIIA1|
-|StageGroupEnum|Stage IIIA2|
-|StageGroupEnum|Stage IIIAE|
-|StageGroupEnum|Stage IIIAES|
-|StageGroupEnum|Stage IIIAS|
-|StageGroupEnum|Stage IIIB|
-|StageGroupEnum|Stage IIIBE|
-|StageGroupEnum|Stage IIIBES|
-|StageGroupEnum|Stage IIIBS|
-|StageGroupEnum|Stage IIIC|
-|StageGroupEnum|Stage IIIC1|
-|StageGroupEnum|Stage IIIC2|
-|StageGroupEnum|Stage IIID|
-|StageGroupEnum|Stage IIIE|
-|StageGroupEnum|Stage IIIES|
-|StageGroupEnum|Stage IIIS|
-|StageGroupEnum|Stage IIS|
-|StageGroupEnum|Stage IS|
-|StageGroupEnum|Stage IV|
-|StageGroupEnum|Stage IVA|
-|StageGroupEnum|Stage IVA1|
-|StageGroupEnum|Stage IVA2|
-|StageGroupEnum|Stage IVAE|
-|StageGroupEnum|Stage IVAES|
-|StageGroupEnum|Stage IVAS|
-|StageGroupEnum|Stage IVB|
-|StageGroupEnum|Stage IVBE|
-|StageGroupEnum|Stage IVBES|
-|StageGroupEnum|Stage IVBS|
-|StageGroupEnum|Stage IVC|
-|StageGroupEnum|Stage IVE|
-|StageGroupEnum|Stage IVES|
-|StageGroupEnum|Stage IVS|
-|StageGroupEnum|In situ|
-|StageGroupEnum|Localized|
-|StageGroupEnum|Regionalized|
-|StageGroupEnum|Distant|
-|StageGroupEnum|Stage L1|
-|StageGroupEnum|Stage L2|
-|StageGroupEnum|Stage M|
-|StageGroupEnum|Stage Ms|
-|StageGroupEnum|Stage 2A|
-|StageGroupEnum|Stage 2B|
-|StageGroupEnum|Stage 3|
-|StageGroupEnum|Stage 4|
-|StageGroupEnum|Stage 4S|
-|StageGroupEnum|Occult Carcinoma|
-
-<h2 id="tocS_StorageEnum">StorageEnum</h2>
-
-<a id="schemastorageenum"></a>
-<a id="schema_StorageEnum"></a>
-<a id="tocSstorageenum"></a>
-<a id="tocsstorageenum"></a>
-
-```json
-"Cut slide"
-
-```
-
-StorageEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|StorageEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|StorageEnum|Cut slide|
-|StorageEnum|Frozen in -70 freezer|
-|StorageEnum|Frozen in liquid nitrogen|
-|StorageEnum|Frozen in vapour phase|
-|StorageEnum|Not Applicable|
-|StorageEnum|Other|
-|StorageEnum|Paraffin block|
-|StorageEnum|RNA later frozen|
-|StorageEnum|Unknown|
-
-<h2 id="tocS_SurgeryLocationEnum">SurgeryLocationEnum</h2>
-
-<a id="schemasurgerylocationenum"></a>
-<a id="schema_SurgeryLocationEnum"></a>
-<a id="tocSsurgerylocationenum"></a>
-<a id="tocssurgerylocationenum"></a>
-
-```json
-"Local recurrence"
-
-```
-
-SurgeryLocationEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SurgeryLocationEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SurgeryLocationEnum|Local recurrence|
-|SurgeryLocationEnum|Metastatic|
-|SurgeryLocationEnum|Primary|
-
-<h2 id="tocS_SurgeryTypeEnum">SurgeryTypeEnum</h2>
-
-<a id="schemasurgerytypeenum"></a>
-<a id="schema_SurgeryTypeEnum"></a>
-<a id="tocSsurgerytypeenum"></a>
-<a id="tocssurgerytypeenum"></a>
-
-```json
-"Ablation"
-
-```
-
-SurgeryTypeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|SurgeryTypeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|SurgeryTypeEnum|Ablation|
-|SurgeryTypeEnum|Axillary Clearance|
-|SurgeryTypeEnum|Axillary lymph nodes sampling|
-|SurgeryTypeEnum|Bilateral complete salpingo-oophorectomy|
-|SurgeryTypeEnum|Biopsy|
-|SurgeryTypeEnum|Bypass Gastrojejunostomy|
-|SurgeryTypeEnum|Cholecystectomy|
-|SurgeryTypeEnum|Cholecystojejunostomy|
-|SurgeryTypeEnum|Completion Gastrectomy|
-|SurgeryTypeEnum|Debridement of pancreatic and peripancreatic necrosis|
-|SurgeryTypeEnum|Distal subtotal pancreatectomy|
-|SurgeryTypeEnum|Drainage of abscess|
-|SurgeryTypeEnum|Duodenal preserving pancreatic head resection|
-|SurgeryTypeEnum|Endoscopic biopsy|
-|SurgeryTypeEnum|Endoscopic brushings of gastrointestinal tract|
-|SurgeryTypeEnum|Enucleation|
-|SurgeryTypeEnum|Esophageal bypass surgery/jejunostomy only|
-|SurgeryTypeEnum|Exploratory laparotomy|
-|SurgeryTypeEnum|Fine needle aspiration biopsy|
-|SurgeryTypeEnum|Gastric Antrectomy|
-|SurgeryTypeEnum|Glossectomy|
-|SurgeryTypeEnum|Hepatojejunostomy|
-|SurgeryTypeEnum|Hysterectomy|
-|SurgeryTypeEnum|Incision of thorax|
-|SurgeryTypeEnum|Ivor Lewis subtotal esophagectomy|
-|SurgeryTypeEnum|Laparotomy|
-|SurgeryTypeEnum|Left thoracoabdominal incision|
-|SurgeryTypeEnum|Lobectomy|
-|SurgeryTypeEnum|Mammoplasty|
-|SurgeryTypeEnum|Mastectomy|
-|SurgeryTypeEnum|McKeown esophagectomy|
-|SurgeryTypeEnum|Merendino procedure|
-|SurgeryTypeEnum|Minimally invasive esophagectomy|
-|SurgeryTypeEnum|Omentectomy|
-|SurgeryTypeEnum|Ovariectomy|
-|SurgeryTypeEnum|Pancreaticoduodenectomy (Whipple procedure)|
-|SurgeryTypeEnum|Pancreaticojejunostomy, side-to-side anastomosis|
-|SurgeryTypeEnum|Partial pancreatectomy|
-|SurgeryTypeEnum|Pneumonectomy|
-|SurgeryTypeEnum|Prostatectomy|
-|SurgeryTypeEnum|Proximal subtotal gastrectomy|
-|SurgeryTypeEnum|Pylorus-sparing Whipple operation|
-|SurgeryTypeEnum|Radical pancreaticoduodenectomy|
-|SurgeryTypeEnum|Radical prostatectomy|
-|SurgeryTypeEnum|Reexcision|
-|SurgeryTypeEnum|Segmentectomy|
-|SurgeryTypeEnum|Sentinal Lymph Node Biopsy|
-|SurgeryTypeEnum|Spleen preserving distal pancreatectomy|
-|SurgeryTypeEnum|Splenectomy|
-|SurgeryTypeEnum|Total gastrectomy|
-|SurgeryTypeEnum|Total gastrectomy with extended lymphadenectomy|
-|SurgeryTypeEnum|Total pancreatectomy|
-|SurgeryTypeEnum|Transhiatal esophagectomy|
-|SurgeryTypeEnum|Triple bypass of pancreas|
-|SurgeryTypeEnum|Tumor Debulking|
-|SurgeryTypeEnum|Wedge/localised gastric resection|
-|SurgeryTypeEnum|Wide Local Excision|
-
-<h2 id="tocS_TCategoryEnum">TCategoryEnum</h2>
-
-<a id="schematcategoryenum"></a>
-<a id="schema_TCategoryEnum"></a>
-<a id="tocStcategoryenum"></a>
-<a id="tocstcategoryenum"></a>
-
-```json
-"T0"
-
-```
-
-TCategoryEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TCategoryEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TCategoryEnum|T0|
-|TCategoryEnum|T1|
-|TCategoryEnum|T1a|
-|TCategoryEnum|T1a1|
-|TCategoryEnum|T1a2|
-|TCategoryEnum|T1a(s)|
-|TCategoryEnum|T1a(m)|
-|TCategoryEnum|T1b|
-|TCategoryEnum|T1b1|
-|TCategoryEnum|T1b2|
-|TCategoryEnum|T1b(s)|
-|TCategoryEnum|T1b(m)|
-|TCategoryEnum|T1c|
-|TCategoryEnum|T1d|
-|TCategoryEnum|T1mi|
-|TCategoryEnum|T2|
-|TCategoryEnum|T2(s)|
-|TCategoryEnum|T2(m)|
-|TCategoryEnum|T2a|
-|TCategoryEnum|T2a1|
-|TCategoryEnum|T2a2|
-|TCategoryEnum|T2b|
-|TCategoryEnum|T2c|
-|TCategoryEnum|T2d|
-|TCategoryEnum|T3|
-|TCategoryEnum|T3(s)|
-|TCategoryEnum|T3(m)|
-|TCategoryEnum|T3a|
-|TCategoryEnum|T3b|
-|TCategoryEnum|T3c|
-|TCategoryEnum|T3d|
-|TCategoryEnum|T3e|
-|TCategoryEnum|T4|
-|TCategoryEnum|T4a|
-|TCategoryEnum|T4a(s)|
-|TCategoryEnum|T4a(m)|
-|TCategoryEnum|T4b|
-|TCategoryEnum|T4b(s)|
-|TCategoryEnum|T4b(m)|
-|TCategoryEnum|T4c|
-|TCategoryEnum|T4d|
-|TCategoryEnum|T4e|
-|TCategoryEnum|Ta|
-|TCategoryEnum|Tis|
-|TCategoryEnum|Tis(DCIS)|
-|TCategoryEnum|Tis(LAMN)|
-|TCategoryEnum|Tis(LCIS)|
-|TCategoryEnum|Tis(Paget)|
-|TCategoryEnum|Tis(Paget's)|
-|TCategoryEnum|Tis pu|
-|TCategoryEnum|Tis pd|
-|TCategoryEnum|TX|
-
-<h2 id="tocS_TherapyTypeEnum">TherapyTypeEnum</h2>
-
-<a id="schematherapytypeenum"></a>
-<a id="schema_TherapyTypeEnum"></a>
-<a id="tocStherapytypeenum"></a>
-<a id="tocstherapytypeenum"></a>
-
-```json
-"External"
-
-```
-
-TherapyTypeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TherapyTypeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TherapyTypeEnum|External|
-|TherapyTypeEnum|Internal|
-
-<h2 id="tocS_TobaccoTypeEnum">TobaccoTypeEnum</h2>
-
-<a id="schematobaccotypeenum"></a>
-<a id="schema_TobaccoTypeEnum"></a>
-<a id="tocStobaccotypeenum"></a>
-<a id="tocstobaccotypeenum"></a>
-
-```json
-"Chewing Tobacco"
-
-```
-
-TobaccoTypeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TobaccoTypeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TobaccoTypeEnum|Chewing Tobacco|
-|TobaccoTypeEnum|Cigar|
-|TobaccoTypeEnum|Cigarettes|
-|TobaccoTypeEnum|Electronic cigarettes|
-|TobaccoTypeEnum|Not applicable|
-|TobaccoTypeEnum|Pipe|
-|TobaccoTypeEnum|Roll-ups|
-|TobaccoTypeEnum|Snuff|
-|TobaccoTypeEnum|Unknown|
-|TobaccoTypeEnum|Waterpipe|
-
-<h2 id="tocS_TreatmentIntentEnum">TreatmentIntentEnum</h2>
-
-<a id="schematreatmentintentenum"></a>
-<a id="schema_TreatmentIntentEnum"></a>
-<a id="tocStreatmentintentenum"></a>
-<a id="tocstreatmentintentenum"></a>
-
-```json
-"Curative"
-
-```
-
-TreatmentIntentEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TreatmentIntentEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TreatmentIntentEnum|Curative|
-|TreatmentIntentEnum|Palliative|
-|TreatmentIntentEnum|Supportive|
-|TreatmentIntentEnum|Diagnostic|
-|TreatmentIntentEnum|Preventive|
-|TreatmentIntentEnum|Guidance|
-|TreatmentIntentEnum|Screening|
-|TreatmentIntentEnum|Forensic|
-
-<h2 id="tocS_TreatmentResponseEnum">TreatmentResponseEnum</h2>
-
-<a id="schematreatmentresponseenum"></a>
-<a id="schema_TreatmentResponseEnum"></a>
-<a id="tocStreatmentresponseenum"></a>
-<a id="tocstreatmentresponseenum"></a>
-
-```json
-"Complete response"
-
-```
-
-TreatmentResponseEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TreatmentResponseEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TreatmentResponseEnum|Complete response|
-|TreatmentResponseEnum|Partial response|
-|TreatmentResponseEnum|Progressive disease|
-|TreatmentResponseEnum|Stable disease|
-|TreatmentResponseEnum|Immune complete response (iCR)|
-|TreatmentResponseEnum|Immune partial response (iPR)|
-|TreatmentResponseEnum|Immune uncomfirmed progressive disease (iUPD)|
-|TreatmentResponseEnum|Immune confirmed progressive disease (iCPD)|
-|TreatmentResponseEnum|Immune stable disease (iSD)|
-|TreatmentResponseEnum|Complete remission|
-|TreatmentResponseEnum|Partial remission|
-|TreatmentResponseEnum|Minor response|
-|TreatmentResponseEnum|Complete remission without measurable residual disease (CR MRD-)|
-|TreatmentResponseEnum|Complete remission with incomplete hematologic recovery (CRi)|
-|TreatmentResponseEnum|Morphologic leukemia-free state|
-|TreatmentResponseEnum|Primary refractory disease|
-|TreatmentResponseEnum|Hematologic relapse (after CR MRD-, CR, CRi)|
-|TreatmentResponseEnum|Molecular relapse (after CR MRD-)|
-|TreatmentResponseEnum|Physician assessed complete response|
-|TreatmentResponseEnum|Physician assessed partial response|
-|TreatmentResponseEnum|Physician assessed stable disease|
-|TreatmentResponseEnum|No evidence of disease (NED)|
-|TreatmentResponseEnum|Major response|
-
-<h2 id="tocS_TreatmentResponseMethodEnum">TreatmentResponseMethodEnum</h2>
-
-<a id="schematreatmentresponsemethodenum"></a>
-<a id="schema_TreatmentResponseMethodEnum"></a>
-<a id="tocStreatmentresponsemethodenum"></a>
-<a id="tocstreatmentresponsemethodenum"></a>
-
-```json
-"RECIST 1.1"
-
-```
-
-TreatmentResponseMethodEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TreatmentResponseMethodEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TreatmentResponseMethodEnum|RECIST 1.1|
-|TreatmentResponseMethodEnum|iRECIST|
-|TreatmentResponseMethodEnum|Cheson CLL 2012 Oncology Response Criteria|
-|TreatmentResponseMethodEnum|Response Assessment in Neuro-Oncology (RANO)|
-|TreatmentResponseMethodEnum|AML Response Criteria|
-|TreatmentResponseMethodEnum|Physician Assessed Response Criteria|
-|TreatmentResponseMethodEnum|Blazer score|
-
-<h2 id="tocS_TreatmentSettingEnum">TreatmentSettingEnum</h2>
-
-<a id="schematreatmentsettingenum"></a>
-<a id="schema_TreatmentSettingEnum"></a>
-<a id="tocStreatmentsettingenum"></a>
-<a id="tocstreatmentsettingenum"></a>
-
-```json
-"Adjuvant"
-
-```
-
-TreatmentSettingEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TreatmentSettingEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TreatmentSettingEnum|Adjuvant|
-|TreatmentSettingEnum|Advanced/Metastatic|
-|TreatmentSettingEnum|Neoadjuvant|
-|TreatmentSettingEnum|Conditioning|
-|TreatmentSettingEnum|Induction|
-|TreatmentSettingEnum|Locally advanced|
-|TreatmentSettingEnum|Maintenance|
-|TreatmentSettingEnum|Mobilization|
-|TreatmentSettingEnum|Preventative|
-|TreatmentSettingEnum|Radiosensitization|
-|TreatmentSettingEnum|Salvage|
-
-<h2 id="tocS_TreatmentStatusEnum">TreatmentStatusEnum</h2>
-
-<a id="schematreatmentstatusenum"></a>
-<a id="schema_TreatmentStatusEnum"></a>
-<a id="tocStreatmentstatusenum"></a>
-<a id="tocstreatmentstatusenum"></a>
-
-```json
-"Treatment completed as prescribed"
-
-```
-
-TreatmentStatusEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TreatmentStatusEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TreatmentStatusEnum|Treatment completed as prescribed|
-|TreatmentStatusEnum|Treatment incomplete due to technical or organizational problems|
-|TreatmentStatusEnum|Treatment incomplete because patient died|
-|TreatmentStatusEnum|Patient choice (stopped or interrupted treatment)|
-|TreatmentStatusEnum|Physician decision (stopped or interrupted treatment)|
-|TreatmentStatusEnum|Treatment stopped due to lack of efficacy (disease progression)|
-|TreatmentStatusEnum|Treatment stopped due to acute toxicity|
-|TreatmentStatusEnum|Other|
-|TreatmentStatusEnum|Not applicable|
-|TreatmentStatusEnum|Unknown|
-
-<h2 id="tocS_TreatmentTypeEnum">TreatmentTypeEnum</h2>
-
-<a id="schematreatmenttypeenum"></a>
-<a id="schema_TreatmentTypeEnum"></a>
-<a id="tocStreatmenttypeenum"></a>
-<a id="tocstreatmenttypeenum"></a>
-
-```json
-"Bone marrow transplant"
-
-```
-
-TreatmentTypeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TreatmentTypeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TreatmentTypeEnum|Bone marrow transplant|
-|TreatmentTypeEnum|Chemotherapy|
-|TreatmentTypeEnum|Hormonal therapy|
-|TreatmentTypeEnum|Immunotherapy|
-|TreatmentTypeEnum|No treatment|
-|TreatmentTypeEnum|Other targeting molecular therapy|
-|TreatmentTypeEnum|Photodynamic therapy|
-|TreatmentTypeEnum|Radiation therapy|
-|TreatmentTypeEnum|Stem cell transplant|
-|TreatmentTypeEnum|Surgery|
-
-<h2 id="tocS_TumourClassificationEnum">TumourClassificationEnum</h2>
-
-<a id="schematumourclassificationenum"></a>
-<a id="schema_TumourClassificationEnum"></a>
-<a id="tocStumourclassificationenum"></a>
-<a id="tocstumourclassificationenum"></a>
-
-```json
-"Not applicable"
-
-```
-
-TumourClassificationEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TumourClassificationEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TumourClassificationEnum|Not applicable|
-|TumourClassificationEnum|RX|
-|TumourClassificationEnum|R0|
-|TumourClassificationEnum|R1|
-|TumourClassificationEnum|R2|
-|TumourClassificationEnum|Unknown|
-
-<h2 id="tocS_TumourDesginationEnum">TumourDesginationEnum</h2>
-
-<a id="schematumourdesginationenum"></a>
-<a id="schema_TumourDesginationEnum"></a>
-<a id="tocStumourdesginationenum"></a>
-<a id="tocstumourdesginationenum"></a>
-
-```json
-"Normal"
-
-```
-
-TumourDesginationEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TumourDesginationEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TumourDesginationEnum|Normal|
-|TumourDesginationEnum|Tumour|
-
-<h2 id="tocS_TumourFocalityEnum">TumourFocalityEnum</h2>
-
-<a id="schematumourfocalityenum"></a>
-<a id="schema_TumourFocalityEnum"></a>
-<a id="tocStumourfocalityenum"></a>
-<a id="tocstumourfocalityenum"></a>
-
-```json
-"Cannot be assessed"
-
-```
-
-TumourFocalityEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TumourFocalityEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TumourFocalityEnum|Cannot be assessed|
-|TumourFocalityEnum|Multifocal|
-|TumourFocalityEnum|Not applicable|
-|TumourFocalityEnum|Unifocal|
-|TumourFocalityEnum|Unknown|
-
-<h2 id="tocS_TumourGradeEnum">TumourGradeEnum</h2>
-
-<a id="schematumourgradeenum"></a>
-<a id="schema_TumourGradeEnum"></a>
-<a id="tocStumourgradeenum"></a>
-<a id="tocstumourgradeenum"></a>
-
-```json
-"Low grade"
-
-```
-
-TumourGradeEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TumourGradeEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TumourGradeEnum|Low grade|
-|TumourGradeEnum|High grade|
-|TumourGradeEnum|GX|
-|TumourGradeEnum|G1|
-|TumourGradeEnum|G2|
-|TumourGradeEnum|G3|
-|TumourGradeEnum|G4|
-|TumourGradeEnum|Low|
-|TumourGradeEnum|High|
-|TumourGradeEnum|Grade 1|
-|TumourGradeEnum|Grade 2|
-|TumourGradeEnum|Grade 3|
-|TumourGradeEnum|Grade 4|
-|TumourGradeEnum|Grade I|
-|TumourGradeEnum|Grade II|
-|TumourGradeEnum|Grade III|
-|TumourGradeEnum|Grade IV|
-|TumourGradeEnum|Grade Group 1|
-|TumourGradeEnum|Grade Group 2|
-|TumourGradeEnum|Grade Group 3|
-|TumourGradeEnum|Grade Group 4|
-|TumourGradeEnum|Grade Group 5|
-
-<h2 id="tocS_TumourGradingSystemEnum">TumourGradingSystemEnum</h2>
-
-<a id="schematumourgradingsystemenum"></a>
-<a id="schema_TumourGradingSystemEnum"></a>
-<a id="tocStumourgradingsystemenum"></a>
-<a id="tocstumourgradingsystemenum"></a>
-
-```json
-"FNCLCC grading system"
-
-```
-
-TumourGradingSystemEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TumourGradingSystemEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TumourGradingSystemEnum|FNCLCC grading system|
-|TumourGradingSystemEnum|Four-tier grading system|
-|TumourGradingSystemEnum|Gleason grade group system|
-|TumourGradingSystemEnum|Grading system for GISTs|
-|TumourGradingSystemEnum|Grading system for GNETs|
-|TumourGradingSystemEnum|IASLC grading system|
-|TumourGradingSystemEnum|ISUP grading system|
-|TumourGradingSystemEnum|Nottingham grading system|
-|TumourGradingSystemEnum|Nuclear grading system for DCIS|
-|TumourGradingSystemEnum|Scarff-Bloom-Richardson grading system|
-|TumourGradingSystemEnum|Three-tier grading system|
-|TumourGradingSystemEnum|Two-tier grading system|
-|TumourGradingSystemEnum|WHO grading system for CNS tumours|
-
-<h2 id="tocS_TumourStagingSystemEnum">TumourStagingSystemEnum</h2>
-
-<a id="schematumourstagingsystemenum"></a>
-<a id="schema_TumourStagingSystemEnum"></a>
-<a id="tocStumourstagingsystemenum"></a>
-<a id="tocstumourstagingsystemenum"></a>
-
-```json
-"AJCC 8th edition"
-
-```
-
-TumourStagingSystemEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|TumourStagingSystemEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|TumourStagingSystemEnum|AJCC 8th edition|
-|TumourStagingSystemEnum|AJCC 7th edition|
-|TumourStagingSystemEnum|AJCC 6th edition|
-|TumourStagingSystemEnum|Ann Arbor staging system|
-|TumourStagingSystemEnum|Binet staging system|
-|TumourStagingSystemEnum|Durie-Salmon staging system|
-|TumourStagingSystemEnum|FIGO staging system|
-|TumourStagingSystemEnum|International Neuroblastoma Risk Group Staging System|
-|TumourStagingSystemEnum|International Neuroblastoma Staging System|
-|TumourStagingSystemEnum|Lugano staging system|
-|TumourStagingSystemEnum|Rai staging system|
-|TumourStagingSystemEnum|Revised International staging system (RISS)|
-|TumourStagingSystemEnum|SEER staging system|
-|TumourStagingSystemEnum|St Jude staging system|
-
-<h2 id="tocS_uBooleanEnum">uBooleanEnum</h2>
-
-<a id="schemaubooleanenum"></a>
-<a id="schema_uBooleanEnum"></a>
-<a id="tocSubooleanenum"></a>
-<a id="tocsubooleanenum"></a>
-
-```json
-"Yes"
-
-```
-
-uBooleanEnum
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|uBooleanEnum|string|false|none|none|
-
-#### Enumerated Values
-
-|Property|Value|
-|---|---|
-|uBooleanEnum|Yes|
-|uBooleanEnum|No|
-|uBooleanEnum|Unknown|
-
 <h2 id="tocS_Input">Input</h2>
 
 <a id="schemainput"></a>
@@ -11160,7 +11071,6 @@ continued
 ```json
 {
   "submitter_donor_id": "string",
-  "program_id": "string",
   "gender": "Man",
   "sex_at_birth": "Male",
   "is_deceased": true,
@@ -11172,7 +11082,8 @@ continued
   "date_of_death": "string",
   "primary_site": [
     "Accessory sinuses"
-  ]
+  ],
+  "program_id": "string"
 }
 
 ```
@@ -11184,7 +11095,6 @@ DonorModelSchema
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |submitter_donor_id|string|true|none|none|
-|program_id|string|true|none|none|
 |gender|any|false|none|none|
 
 anyOf
@@ -11361,6 +11271,12 @@ or
 |---|---|---|---|---|
 |» *anonymous*|null|false|none|none|
 
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|program_id|string|true|none|none|
+
 <h2 id="tocS_PagedDonorModelSchema">PagedDonorModelSchema</h2>
 
 <a id="schemapageddonormodelschema"></a>
@@ -11373,7 +11289,6 @@ or
   "items": [
     {
       "submitter_donor_id": "string",
-      "program_id": "string",
       "gender": "Man",
       "sex_at_birth": "Male",
       "is_deceased": true,
@@ -11385,7 +11300,8 @@ or
       "date_of_death": "string",
       "primary_site": [
         "Accessory sinuses"
-      ]
+      ],
+      "program_id": "string"
     }
   ],
   "count": 0,

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -131,37 +131,28 @@ components:
           title: Er Percent Positive
         er_status:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
           - type: 'null'
-          title: Er Status
         her2_ihc_status:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/Her2StatusEnum'
           - type: 'null'
-          title: Her2 Ihc Status
         her2_ish_status:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/Her2StatusEnum'
           - type: 'null'
-          title: Her2 Ish Status
         hpv_ihc_status:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
           - type: 'null'
-          title: Hpv Ihc Status
         hpv_pcr_status:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
           - type: 'null'
-          title: Hpv Pcr Status
         hpv_strain:
           anyOf:
-          - items: {}
+          - items:
+              $ref: '#/components/schemas/HpvStrainEnum'
             type: array
           - type: 'null'
           title: Hpv Strain
@@ -172,10 +163,8 @@ components:
           title: Pr Percent Positive
         pr_status:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
           - type: 'null'
-          title: Pr Status
         program_id:
           title: Program Id
           type: string
@@ -185,7 +174,6 @@ components:
           - type: 'null'
           title: Psa Level
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_follow_up_id:
@@ -400,10 +388,8 @@ components:
           title: Actual Cumulative Drug Dose
         chemotherapy_drug_dose_units:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/DosageUnitsEnum'
           - type: 'null'
-          title: Chemotherapy Drug Dose Units
         drug_name:
           anyOf:
           - maxLength: 255
@@ -412,10 +398,8 @@ components:
           title: Drug Name
         drug_reference_database:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
           - type: 'null'
-          title: Drug Reference Database
         drug_reference_identifier:
           anyOf:
           - maxLength: 64
@@ -431,11 +415,9 @@ components:
           title: Program Id
           type: string
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_treatment_id:
-          maxLength: 64
           title: Submitter Treatment Id
           type: string
         uuid:
@@ -555,33 +537,27 @@ components:
           title: Comorbidity Treatment
         comorbidity_treatment_status:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/uBooleanEnum'
           - type: 'null'
-          title: Comorbidity Treatment Status
         comorbidity_type_code:
           anyOf:
           - maxLength: 64
+            pattern: ^[A-Z][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$
             type: string
           - type: 'null'
           title: Comorbidity Type Code
         laterality_of_prior_malignancy:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/MalignancyLateralityEnum'
           - type: 'null'
-          title: Laterality Of Prior Malignancy
         prior_malignancy:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/uBooleanEnum'
           - type: 'null'
-          title: Prior Malignancy
         program_id:
           title: Program Id
           type: string
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         uuid:
@@ -738,34 +714,33 @@ components:
       properties:
         cause_of_death:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/CauseOfDeathEnum'
           - type: 'null'
-          title: Cause Of Death
         date_alive_after_lost_to_followup:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Date Alive After Lost To Followup
         date_of_birth:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Date Of Birth
         date_of_death:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Date Of Death
         gender:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/GenderEnum'
           - type: 'null'
-          title: Gender
         is_deceased:
           anyOf:
           - type: boolean
@@ -779,13 +754,12 @@ components:
           title: Lost To Followup After Clinical Event Identifier
         lost_to_followup_reason:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/LostToFollowupReasonEnum'
           - type: 'null'
-          title: Lost To Followup Reason
         primary_site:
           anyOf:
-          - items: {}
+          - items:
+              $ref: '#/components/schemas/PrimarySiteEnum'
             type: array
           - type: 'null'
           title: Primary Site
@@ -794,12 +768,11 @@ components:
           type: string
         sex_at_birth:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/SexAtBirthEnum'
           - type: 'null'
-          title: Sex At Birth
         submitter_donor_id:
           maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Donor Id
           type: string
         uuid:
@@ -808,8 +781,8 @@ components:
           - type: 'null'
           title: Uuid
       required:
-      - program_id
       - submitter_donor_id
+      - program_id
       title: DonorIngestSchema
       type: object
     DonorModelSchema:
@@ -1045,18 +1018,16 @@ components:
           title: Program Id
           type: string
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         tobacco_smoking_status:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/SmokingStatusEnum'
           - type: 'null'
-          title: Tobacco Smoking Status
         tobacco_type:
           anyOf:
-          - items: {}
+          - items:
+              $ref: '#/components/schemas/TobaccoTypeEnum'
             type: array
           - type: 'null'
           title: Tobacco Type
@@ -1189,113 +1160,89 @@ components:
       properties:
         anatomic_site_progression_or_recurrence:
           anyOf:
-          - items: {}
+          - items:
+              type: string
             type: array
           - type: 'null'
           title: Anatomic Site Progression Or Recurrence
         date_of_followup:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Date Of Followup
         date_of_relapse:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Date Of Relapse
         disease_status_at_followup:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/DiseaseStatusFollowupEnum'
           - type: 'null'
-          title: Disease Status At Followup
         method_of_progression_status:
           anyOf:
-          - items: {}
+          - items:
+              $ref: '#/components/schemas/ProgressionStatusMethodEnum'
             type: array
           - type: 'null'
           title: Method Of Progression Status
-        primary_diagnosis_uuid_id:
-          anyOf:
-          - format: uuid
-            type: string
-          - type: 'null'
-          title: Primary Diagnosis Uuid
         program_id:
           title: Program Id
           type: string
         recurrence_m_category:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/MCategoryEnum'
           - type: 'null'
-          title: Recurrence M Category
         recurrence_n_category:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/NCategoryEnum'
           - type: 'null'
-          title: Recurrence N Category
         recurrence_stage_group:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/StageGroupEnum'
           - type: 'null'
-          title: Recurrence Stage Group
         recurrence_t_category:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/TCategoryEnum'
           - type: 'null'
-          title: Recurrence T Category
         recurrence_tumour_staging_system:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
           - type: 'null'
-          title: Recurrence Tumour Staging System
         relapse_type:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/RelapseTypeEnum'
           - type: 'null'
-          title: Relapse Type
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_follow_up_id:
           maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Follow Up Id
           type: string
         submitter_primary_diagnosis_id:
           anyOf:
-          - maxLength: 64
-            type: string
+          - type: string
           - type: 'null'
           title: Submitter Primary Diagnosis Id
         submitter_treatment_id:
           anyOf:
-          - maxLength: 64
-            type: string
+          - type: string
           - type: 'null'
           title: Submitter Treatment Id
-        treatment_uuid_id:
-          anyOf:
-          - format: uuid
-            type: string
-          - type: 'null'
-          title: Treatment Uuid
         uuid:
           anyOf:
           - type: string
           - type: 'null'
           title: Uuid
       required:
-      - program_id
       - submitter_follow_up_id
+      - program_id
       - submitter_donor_id
       title: FollowUpIngestSchema
       type: object
@@ -1465,10 +1412,8 @@ components:
           title: Drug Name
         drug_reference_database:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
           - type: 'null'
-          title: Drug Reference Database
         drug_reference_identifier:
           anyOf:
           - maxLength: 64
@@ -1477,10 +1422,8 @@ components:
           title: Drug Reference Identifier
         hormone_drug_dose_units:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/DosageUnitsEnum'
           - type: 'null'
-          title: Hormone Drug Dose Units
         prescribed_cumulative_drug_dose:
           anyOf:
           - type: integer
@@ -1490,11 +1433,9 @@ components:
           title: Program Id
           type: string
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_treatment_id:
-          maxLength: 64
           title: Submitter Treatment Id
           type: string
         uuid:
@@ -1643,10 +1584,8 @@ components:
           title: Drug Name
         drug_reference_database:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
           - type: 'null'
-          title: Drug Reference Database
         drug_reference_identifier:
           anyOf:
           - maxLength: 64
@@ -1655,16 +1594,12 @@ components:
           title: Drug Reference Identifier
         immunotherapy_drug_dose_units:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/DosageUnitsEnum'
           - type: 'null'
-          title: Immunotherapy Drug Dose Units
         immunotherapy_type:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/ImmunotherapyTypeEnum'
           - type: 'null'
-          title: Immunotherapy Type
         prescribed_cumulative_drug_dose:
           anyOf:
           - type: integer
@@ -1674,11 +1609,9 @@ components:
           title: Program Id
           type: string
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_treatment_id:
-          maxLength: 64
           title: Submitter Treatment Id
           type: string
         uuid:
@@ -3138,10 +3071,8 @@ components:
       properties:
         basis_of_diagnosis:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/BasisOfDiagnosisEnum'
           - type: 'null'
-          title: Basis Of Diagnosis
         cancer_type_code:
           anyOf:
           - maxLength: 64
@@ -3150,58 +3081,43 @@ components:
           title: Cancer Type Code
         clinical_m_category:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/MCategoryEnum'
           - type: 'null'
-          title: Clinical M Category
         clinical_n_category:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/NCategoryEnum'
           - type: 'null'
-          title: Clinical N Category
         clinical_stage_group:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/StageGroupEnum'
           - type: 'null'
-          title: Clinical Stage Group
         clinical_t_category:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/TCategoryEnum'
           - type: 'null'
-          title: Clinical T Category
         clinical_tumour_staging_system:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
           - type: 'null'
-          title: Clinical Tumour Staging System
         date_of_diagnosis:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Date Of Diagnosis
         laterality:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
           - type: 'null'
-          title: Laterality
         lymph_nodes_examined_method:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/LymphNodeMethodEnum'
           - type: 'null'
-          title: Lymph Nodes Examined Method
         lymph_nodes_examined_status:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/LymphNodeStatusEnum'
           - type: 'null'
-          title: Lymph Nodes Examined Status
         number_lymph_nodes_positive:
           anyOf:
           - type: integer
@@ -3211,24 +3127,22 @@ components:
           title: Program Id
           type: string
         submitter_donor_id:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
           title: Submitter Donor Id
+          type: string
         submitter_primary_diagnosis_id:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Primary Diagnosis Id
+          type: string
         uuid:
           anyOf:
           - type: string
           - type: 'null'
           title: Uuid
       required:
+      - submitter_primary_diagnosis_id
       - program_id
+      - submitter_donor_id
       title: PrimaryDiagnosisIngestSchema
       type: object
     PrimaryDiagnosisLateralityEnum:
@@ -3421,15 +3335,16 @@ components:
           - type: 'null'
           title: Metadata
         program_id:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Program Id
+          type: string
         updated:
           format: date-time
           title: Updated
           type: string
+      required:
+      - program_id
       title: ProgramIngestSchema
       type: object
     ProgramModelSchema:
@@ -3788,10 +3703,8 @@ components:
       properties:
         anatomical_site_irradiated:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/RadiationAnatomicalSiteEnum'
           - type: 'null'
-          title: Anatomical Site Irradiated
         program_id:
           title: Program Id
           type: string
@@ -3812,16 +3725,12 @@ components:
           title: Radiation Therapy Fractions
         radiation_therapy_modality:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/RadiationTherapyModalityEnum'
           - type: 'null'
-          title: Radiation Therapy Modality
         radiation_therapy_type:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/TherapyTypeEnum'
           - type: 'null'
-          title: Radiation Therapy Type
         reference_radiation_treatment_id:
           anyOf:
           - maxLength: 64
@@ -3829,11 +3738,9 @@ components:
           - type: 'null'
           title: Reference Radiation Treatment Id
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_treatment_id:
-          maxLength: 64
           title: Submitter Treatment Id
           type: string
         uuid:
@@ -3968,48 +3875,39 @@ components:
           type: string
         sample_type:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/SampleTypeEnum'
           - type: 'null'
-          title: Sample Type
         specimen_tissue_source:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/SpecimenTissueSourceEnum'
           - type: 'null'
-          title: Specimen Tissue Source
         specimen_type:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/SpecimenTypeEnum'
           - type: 'null'
-          title: Specimen Type
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_sample_id:
           maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Sample Id
           type: string
         submitter_specimen_id:
-          maxLength: 64
           title: Submitter Specimen Id
           type: string
         tumour_normal_designation:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/TumourDesginationEnum'
           - type: 'null'
-          title: Tumour Normal Designation
         uuid:
           anyOf:
           - type: string
           - type: 'null'
           title: Uuid
       required:
-      - program_id
       - submitter_sample_id
+      - program_id
       - submitter_donor_id
       - submitter_specimen_id
       title: SampleRegistrationIngestSchema
@@ -4198,118 +4096,92 @@ components:
       properties:
         pathological_m_category:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/MCategoryEnum'
           - type: 'null'
-          title: Pathological M Category
         pathological_n_category:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/NCategoryEnum'
           - type: 'null'
-          title: Pathological N Category
         pathological_stage_group:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/StageGroupEnum'
           - type: 'null'
-          title: Pathological Stage Group
         pathological_t_category:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/TCategoryEnum'
           - type: 'null'
-          title: Pathological T Category
         pathological_tumour_staging_system:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
           - type: 'null'
-          title: Pathological Tumour Staging System
         percent_tumour_cells_measurement_method:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/CellsMeasureMethodEnum'
           - type: 'null'
-          title: Percent Tumour Cells Measurement Method
         percent_tumour_cells_range:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/PercentCellsRangeEnum'
           - type: 'null'
-          title: Percent Tumour Cells Range
         program_id:
           title: Program Id
           type: string
         reference_pathology_confirmed_diagnosis:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/ConfirmedDiagnosisTumourEnum'
           - type: 'null'
-          title: Reference Pathology Confirmed Diagnosis
         reference_pathology_confirmed_tumour_presence:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/ConfirmedDiagnosisTumourEnum'
           - type: 'null'
-          title: Reference Pathology Confirmed Tumour Presence
         specimen_anatomic_location:
           anyOf:
           - maxLength: 32
+            pattern: ^[C][0-9]{2}(.[0-9]{1})?$
             type: string
           - type: 'null'
           title: Specimen Anatomic Location
         specimen_collection_date:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Specimen Collection Date
         specimen_laterality:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/SpecimenLateralityEnum'
           - type: 'null'
-          title: Specimen Laterality
         specimen_processing:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/SpecimenProcessingEnum'
           - type: 'null'
-          title: Specimen Processing
         specimen_storage:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/StorageEnum'
           - type: 'null'
-          title: Specimen Storage
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_primary_diagnosis_id:
-          maxLength: 64
           title: Submitter Primary Diagnosis Id
           type: string
         submitter_specimen_id:
           maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Specimen Id
           type: string
         tumour_grade:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/TumourGradeEnum'
           - type: 'null'
-          title: Tumour Grade
         tumour_grading_system:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/TumourGradingSystemEnum'
           - type: 'null'
-          title: Tumour Grading System
         tumour_histological_type:
           anyOf:
           - maxLength: 128
+            pattern: ^[8,9]{1}[0-9]{3}/[0,1,2,3,6,9]{1}[1-9]{0,1}$
             type: string
           - type: 'null'
           title: Tumour Histological Type
@@ -4319,8 +4191,8 @@ components:
           - type: 'null'
           title: Uuid
       required:
-      - program_id
       - submitter_specimen_id
+      - program_id
       - submitter_donor_id
       - submitter_primary_diagnosis_id
       title: SpecimenIngestSchema
@@ -4720,45 +4592,41 @@ components:
           title: Greatest Dimension Tumour
         lymphovascular_invasion:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/LymphovascularInvasionEnum'
           - type: 'null'
-          title: Lymphovascular Invasion
         margin_types_involved:
           anyOf:
-          - items: {}
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
             type: array
           - type: 'null'
           title: Margin Types Involved
         margin_types_not_assessed:
           anyOf:
-          - items: {}
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
             type: array
           - type: 'null'
           title: Margin Types Not Assessed
         margin_types_not_involved:
           anyOf:
-          - items: {}
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
             type: array
           - type: 'null'
           title: Margin Types Not Involved
         perineural_invasion:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/PerineuralInvasionEnum'
           - type: 'null'
-          title: Perineural Invasion
         program_id:
           title: Program Id
           type: string
         residual_tumour_classification:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/TumourClassificationEnum'
           - type: 'null'
-          title: Residual Tumour Classification
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_specimen_id:
@@ -4768,33 +4636,27 @@ components:
           - type: 'null'
           title: Submitter Specimen Id
         submitter_treatment_id:
-          maxLength: 64
           title: Submitter Treatment Id
           type: string
         surgery_location:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/SurgeryLocationEnum'
           - type: 'null'
-          title: Surgery Location
         surgery_site:
           anyOf:
           - maxLength: 255
+            pattern: ^[C][0-9]{2}(.[0-9]{1})?$
             type: string
           - type: 'null'
           title: Surgery Site
         surgery_type:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/SurgeryTypeEnum'
           - type: 'null'
-          title: Surgery Type
         tumour_focality:
           anyOf:
-          - maxLength: 64
-            type: string
+          - $ref: '#/components/schemas/TumourFocalityEnum'
           - type: 'null'
-          title: Tumour Focality
         tumour_length:
           anyOf:
           - type: integer
@@ -5144,10 +5006,8 @@ components:
           title: Days Per Cycle
         is_primary_treatment:
           anyOf:
-          - maxLength: 32
-            type: string
+          - $ref: '#/components/schemas/uBooleanEnum'
           - type: 'null'
-          title: Is Primary Treatment
         line_of_treatment:
           anyOf:
           - type: integer
@@ -5163,61 +5023,53 @@ components:
           type: string
         response_to_treatment:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/TreatmentResponseEnum'
           - type: 'null'
-          title: Response To Treatment
         response_to_treatment_criteria_method:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/TreatmentResponseMethodEnum'
           - type: 'null'
-          title: Response To Treatment Criteria Method
         status_of_treatment:
           anyOf:
-          - maxLength: 255
-            type: string
+          - $ref: '#/components/schemas/TreatmentStatusEnum'
           - type: 'null'
-          title: Status Of Treatment
         submitter_donor_id:
-          maxLength: 64
           title: Submitter Donor Id
           type: string
         submitter_primary_diagnosis_id:
-          maxLength: 64
           title: Submitter Primary Diagnosis Id
           type: string
         submitter_treatment_id:
           maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Treatment Id
           type: string
         treatment_end_date:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Treatment End Date
         treatment_intent:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/TreatmentIntentEnum'
           - type: 'null'
-          title: Treatment Intent
         treatment_setting:
           anyOf:
-          - maxLength: 128
-            type: string
+          - $ref: '#/components/schemas/TreatmentSettingEnum'
           - type: 'null'
-          title: Treatment Setting
         treatment_start_date:
           anyOf:
           - maxLength: 32
+            pattern: ^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?
             type: string
           - type: 'null'
           title: Treatment Start Date
         treatment_type:
           anyOf:
-          - items: {}
+          - items:
+              $ref: '#/components/schemas/TreatmentTypeEnum'
             type: array
           - type: 'null'
           title: Treatment Type
@@ -5227,8 +5079,8 @@ components:
           - type: 'null'
           title: Uuid
       required:
-      - program_id
       - submitter_treatment_id
+      - program_id
       - submitter_donor_id
       - submitter_primary_diagnosis_id
       title: TreatmentIngestSchema
@@ -5507,7 +5359,7 @@ components:
       scheme: bearer
       type: http
 info:
-  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/5c640ce73d080b89ec2bdd80857bf826213dab04/chord_metadata_service/mohpackets/docs/schema.json
+  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/a6cdc8842cb086d3065578080032e148e5a3fdf7/chord_metadata_service/mohpackets/docs/schema.json
   title: MoH Service API
   version: 3.0.0
 openapi: 3.1.0

--- a/chord_metadata_service/mohpackets/models.py
+++ b/chord_metadata_service/mohpackets/models.py
@@ -510,7 +510,7 @@ class Comorbidity(models.Model):
         ordering = ["uuid"]
 
     def __str__(self):
-        return f"{self.program_id}: {self.donor_uuid}"
+        return f"{self.program_id}: {self.submitter_donor_id}"
 
 
 class Exposure(models.Model):
@@ -532,4 +532,4 @@ class Exposure(models.Model):
         ordering = ["uuid"]
 
     def __str__(self):
-        return f"{self.program_id}: {self.donor_uuid}"
+        return f"{self.program_id}: {self.submitter_donor_id}"

--- a/chord_metadata_service/mohpackets/schemas/base.py
+++ b/chord_metadata_service/mohpackets/schemas/base.py
@@ -109,8 +109,8 @@ BaseProgramSchema = create_schema(
 
 BaseDonorSchema = create_schema(
     Donor,
-    name="BaseDonorSchema",  # name display in schema
-    exclude=["uuid"],  # need exclude here, cannot do in config
+    name="BaseDonorSchema",
+    exclude=["uuid", "program_id"],
     custom_fields=[
         ("cause_of_death", Optional[CauseOfDeathEnum], None),
         ("submitter_donor_id", str, Field(pattern=ID_REGEX_PATTERNS, max_length=64)),

--- a/chord_metadata_service/mohpackets/schemas/ingestion.py
+++ b/chord_metadata_service/mohpackets/schemas/ingestion.py
@@ -18,7 +18,24 @@ from chord_metadata_service.mohpackets.models import (
     Surgery,
     Treatment,
 )
-from chord_metadata_service.mohpackets.schemas.base import BaseDonorSchema, BasePrimaryDiagnosisSchema, BaseProgramSchema
+from chord_metadata_service.mohpackets.schemas.base import (
+    BaseBiomarkerSchema,
+    BaseChemotherapySchema,
+    BaseComorbiditySchema,
+    BaseDonorSchema,
+    BaseExposureSchema,
+    BaseFollowUpSchema,
+    BaseHormoneTherapySchema,
+    BaseImmunotherapySchema,
+    BasePrimaryDiagnosisSchema,
+    BaseProgramSchema,
+    BaseRadiationSchema,
+    BaseSampleRegistrationSchema,
+    BaseSpecimenSchema,
+    BaseSurgerySchema,
+    BaseTreatmentSchema,
+)
+
 
 """
 Module with schema used for ingesting
@@ -57,165 +74,116 @@ class PrimaryDiagnosisIngestSchema(BasePrimaryDiagnosisSchema):
         use_enum_values = True
 
 
-class BiomarkerIngestSchema(ModelSchema):
+class BiomarkerIngestSchema(BaseBiomarkerSchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Biomarker
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-        ]
+    class Config(BaseBiomarkerSchema.Config):
+        use_enum_values = True
 
 
-class ChemotherapyIngestSchema(ModelSchema):
+class ChemotherapyIngestSchema(BaseChemotherapySchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Chemotherapy
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-            "treatment_uuid",
-        ]
+    class Config(BaseChemotherapySchema.Config):
+        use_enum_values = True
 
 
-class ComorbidityIngestSchema(ModelSchema):
+class ComorbidityIngestSchema(BaseComorbiditySchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Comorbidity
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-        ]
+    class Config(BaseComorbiditySchema.Config):
+        use_enum_values = True
 
 
-class ExposureIngestSchema(ModelSchema):
+class ExposureIngestSchema(BaseExposureSchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Exposure
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-        ]
+    class Config(BaseExposureSchema.Config):
+        use_enum_values = True
 
 
-class FollowUpIngestSchema(ModelSchema):
+class FollowUpIngestSchema(BaseFollowUpSchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = FollowUp
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-        ]
+    class Config(BaseFollowUpSchema.Config):
+        use_enum_values = True
 
 
-class HormoneTherapyIngestSchema(ModelSchema):
+class HormoneTherapyIngestSchema(BaseHormoneTherapySchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
+    submitter_treatment_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = HormoneTherapy
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-            "treatment_uuid",
-        ]
+    class Config(BaseHormoneTherapySchema.Config):
+        use_enum_values = True
 
 
-class ImmunotherapyIngestSchema(ModelSchema):
+class ImmunotherapyIngestSchema(BaseImmunotherapySchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
+    submitter_treatment_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Immunotherapy
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-            "treatment_uuid",
-        ]
+    class Config(BaseImmunotherapySchema.Config):
+        use_enum_values = True
 
 
-class RadiationIngestSchema(ModelSchema):
+class RadiationIngestSchema(BaseRadiationSchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
+    submitter_treatment_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Radiation
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-            "treatment_uuid",
-        ]
+    class Config(BaseRadiationSchema.Config):
+        use_enum_values = True
 
 
-class SampleRegistrationIngestSchema(ModelSchema):
+class SampleRegistrationIngestSchema(BaseSampleRegistrationSchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
+    submitter_specimen_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = SampleRegistration
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-            "specimen_uuid",
-        ]
+    class Config(BaseSampleRegistrationSchema.Config):
+        use_enum_values = True
 
 
-class SpecimenIngestSchema(ModelSchema):
+class SpecimenIngestSchema(BaseSpecimenSchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
+    submitter_primary_diagnosis_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Specimen
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-            "primary_diagnosis_uuid",
-        ]
+    class Config(BaseSpecimenSchema.Config):
+        use_enum_values = True
 
 
-class SurgeryIngestSchema(ModelSchema):
+class SurgeryIngestSchema(BaseSurgerySchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
+    submitter_treatment_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Surgery
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-            "treatment_uuid",
-        ]
+    class Config(BaseSurgerySchema.Config):
+        use_enum_values = True
 
 
-class TreatmentIngestSchema(ModelSchema):
+class TreatmentIngestSchema(BaseTreatmentSchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
+    submitter_primary_diagnosis_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = Treatment
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-            "primary_diagnosis_uuid",
-        ]
+    class Config(BaseTreatmentSchema.Config):
+        use_enum_values = True

--- a/chord_metadata_service/mohpackets/schemas/ingestion.py
+++ b/chord_metadata_service/mohpackets/schemas/ingestion.py
@@ -1,23 +1,6 @@
 from typing import Optional
 
-from ninja import Field, ModelSchema
-from chord_metadata_service.mohpackets.models import (
-    Biomarker,
-    Chemotherapy,
-    Comorbidity,
-    Donor,
-    Exposure,
-    FollowUp,
-    HormoneTherapy,
-    Immunotherapy,
-    PrimaryDiagnosis,
-    Program,
-    Radiation,
-    SampleRegistration,
-    Specimen,
-    Surgery,
-    Treatment,
-)
+from ninja import Field
 from chord_metadata_service.mohpackets.schemas.base import (
     BaseBiomarkerSchema,
     BaseChemotherapySchema,

--- a/chord_metadata_service/mohpackets/schemas/ingestion.py
+++ b/chord_metadata_service/mohpackets/schemas/ingestion.py
@@ -18,6 +18,7 @@ from chord_metadata_service.mohpackets.models import (
     Surgery,
     Treatment,
 )
+from chord_metadata_service.mohpackets.schemas.base import BaseDonorSchema, BasePrimaryDiagnosisSchema, BaseProgramSchema
 
 """
 Module with schema used for ingesting
@@ -35,32 +36,25 @@ Author: Son Chau
 ########################################
 
 
-class ProgramIngestSchema(ModelSchema):
-    class Meta:
-        model = Program
-        fields = "__all__"
+class ProgramIngestSchema(BaseProgramSchema):
+    pass
 
 
-class DonorIngestSchema(ModelSchema):
+class DonorIngestSchema(BaseDonorSchema):
     program_id_id: str = Field(..., alias="program_id")
     uuid: Optional[str] = None
 
-    class Config:
-        model = Donor
-        model_exclude = ["uuid", "program_id"]
+    class Config(BaseDonorSchema.Config):
+        use_enum_values = True
 
 
-class PrimaryDiagnosisIngestSchema(ModelSchema):
+class PrimaryDiagnosisIngestSchema(BasePrimaryDiagnosisSchema):
     program_id_id: str = Field(..., alias="program_id")
+    submitter_donor_id: str
     uuid: Optional[str] = None
 
-    class Config:
-        model = PrimaryDiagnosis
-        model_exclude = [
-            "uuid",
-            "program_id",
-            "donor_uuid",
-        ]
+    class Config(BasePrimaryDiagnosisSchema.Config):
+        use_enum_values = True
 
 
 class BiomarkerIngestSchema(ModelSchema):

--- a/chord_metadata_service/mohpackets/schemas/ingestion.py
+++ b/chord_metadata_service/mohpackets/schemas/ingestion.py
@@ -86,6 +86,7 @@ class BiomarkerIngestSchema(BaseBiomarkerSchema):
 class ChemotherapyIngestSchema(BaseChemotherapySchema):
     program_id_id: str = Field(..., alias="program_id")
     submitter_donor_id: str
+    submitter_treatment_id: str
     uuid: Optional[str] = None
 
     class Config(BaseChemotherapySchema.Config):
@@ -113,6 +114,8 @@ class ExposureIngestSchema(BaseExposureSchema):
 class FollowUpIngestSchema(BaseFollowUpSchema):
     program_id_id: str = Field(..., alias="program_id")
     submitter_donor_id: str
+    submitter_primary_diagnosis_id: Optional[str] = None
+    submitter_treatment_id: Optional[str] = None
     uuid: Optional[str] = None
 
     class Config(BaseFollowUpSchema.Config):

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_chemotherapy.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_chemotherapy.py
@@ -62,6 +62,32 @@ class IngestTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
+    def test_chemotherapy_ingest_validator(self):
+        """
+        Test invalid data and receive 422 unprocess response.
+
+        Testing Strategy:
+        - Build Chemotherapy data based on the existing treatment_uuid and wrong data for validator
+        - An authorized user (user_2) with admin permission.
+        - User cannot perform a POST request for chemotherapy record creation.
+        """
+        chemotherapy = ChemotherapyFactory.build(treatment_uuid=self.treatments[0])
+        chemotherapy_dict = model_to_dict(chemotherapy)
+        chemotherapy_dict["drug_reference_database"] = "invalid"
+        response = self.client.post(
+            self.chemotherapy_url,
+            data=chemotherapy_dict,
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
+            f"Response content: {response.content}",
+        )
+
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
@@ -60,6 +60,32 @@ class IngestTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
+    def test_donor_ingest_validator(self):
+        """
+        Test invalid data and receive 422 unprocess response.
+
+        Testing Strategy:
+        - Build Donor data based on the existing program_id and wrong data not match with validator
+        - An authorized user (user_2) with admin permission.
+        - User cannot perform a POST request for donor creation.
+        """
+        donor = DonorFactory.build(program_id=self.programs[1])
+        donor_dict = model_to_dict(donor)
+        donor_dict["cause_of_death"] = "invalid"
+        response = self.client.post(
+            self.donor_url,
+            data=donor_dict,
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
+            f"Response content: {response.content}",
+        )
+
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
@@ -65,11 +65,11 @@ class IngestTestCase(BaseTestCase):
         Test invalid data and receive 422 unprocess response.
 
         Testing Strategy:
-        - Build Donor data based on the existing program_id and wrong data not match with validator
+        - Build Donor data based on the existing program_id and wrong data for validator
         - An authorized user (user_2) with admin permission.
         - User cannot perform a POST request for donor creation.
         """
-        donor = DonorFactory.build(program_id=self.programs[1])
+        donor = DonorFactory.build(program_id=self.programs[0])
         donor_dict = model_to_dict(donor)
         donor_dict["cause_of_death"] = "invalid"
         response = self.client.post(

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
@@ -60,6 +60,31 @@ class IngestTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
+    def test_follow_up_ingest_validator(self):
+        """
+        Test invalid data and receive 422 unprocessable entity response for follow-up creation.
+
+        Testing Strategy:
+        - Build FollowUp data based on the existing treatment_uuid and wrong data for validator.
+        - An authorized user (user_2) with admin permission.
+        - User cannot perform a POST request for follow-up creation.
+        """
+        follow_up = FollowUpFactory.build(treatment_uuid=self.treatments[0])
+        follow_up_dict = model_to_dict(follow_up)
+        follow_up_dict["relapse_type"] = "invalid"
+        response = self.client.post(
+            self.follow_up_url,
+            data=follow_up_dict,
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
+            f"Response content: {response.content}",
+        )
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
@@ -86,6 +86,7 @@ class IngestTestCase(BaseTestCase):
             f"Response content: {response.content}",
         )
 
+
 # GET API
 # -------
 class GETTestCase(BaseTestCase):

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
@@ -63,6 +63,32 @@ class IngestTestCase(BaseTestCase):
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
 
+    def test_primary_diagnosis_validator(self):
+        """
+        Test invalid data and receive 422 unprocess response.
+
+        Testing Strategy:
+        - Build primary diagnosis data based on the existing donor_id and wrong data for validator
+        - An authorized user (user_2) with admin permission.
+        - User cannot perform a POST request for primary diagnosis creation.
+        """
+        primary_diagnosis = PrimaryDiagnosisFactory.build(donor_uuid=self.donors[0])
+        primary_diagnosis_dict = model_to_dict(primary_diagnosis)
+        primary_diagnosis_dict["basis_of_diagnosis"] = "invalid"
+        response = self.client.post(
+            self.primary_diagnosis_url,
+            data=primary_diagnosis_dict,
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
+            f"Response content: {response.content}",
+        )
+
 # GET API
 # -------
 class GETTestCase(BaseTestCase):

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
@@ -62,7 +62,6 @@ class IngestTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
-
     def test_primary_diagnosis_ingest_validator(self):
         """
         Test invalid data and receive 422 unprocess response.
@@ -88,6 +87,7 @@ class IngestTestCase(BaseTestCase):
             f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
             f"Response content: {response.content}",
         )
+
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
@@ -63,7 +63,7 @@ class IngestTestCase(BaseTestCase):
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
 
-    def test_primary_diagnosis_validator(self):
+    def test_primary_diagnosis_ingest_validator(self):
         """
         Test invalid data and receive 422 unprocess response.
 

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
@@ -67,12 +67,12 @@ class SampleRegistrationTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
-    def test_sample_registration_create_validator(self):
+    def test_sample_registration_ingest_validator(self):
         """
         Test invalid data and receive 422 unprocess response.
 
         Testing Strategy:
-        - Build SampleRegistration data based on the existing primary_diagnosis_uuid and wrong data for validator
+        - Build SampleRegistration data based on the existing specimen_uuid and wrong data for validator
         - An authorized user (user_2) with admin permission.
         - User cannot perform a POST request for sample registration creation.
         """

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
@@ -76,7 +76,9 @@ class SampleRegistrationTestCase(BaseTestCase):
         - An authorized user (user_2) with admin permission.
         - User cannot perform a POST request for sample registration creation.
         """
-        sample_registration = SampleRegistrationFactory.build(specimen_uuid=self.specimens[0])
+        sample_registration = SampleRegistrationFactory.build(
+            specimen_uuid=self.specimens[0]
+        )
         sample_registration_dict = model_to_dict(sample_registration)
         sample_registration_dict["sample_type"] = "invalid"
         response = self.client.post(
@@ -92,6 +94,7 @@ class SampleRegistrationTestCase(BaseTestCase):
             f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
             f"Response content: {response.content}",
         )
+
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
@@ -67,6 +67,31 @@ class SampleRegistrationTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
+    def test_sample_registration_create_validator(self):
+        """
+        Test invalid data and receive 422 unprocess response.
+
+        Testing Strategy:
+        - Build SampleRegistration data based on the existing primary_diagnosis_uuid and wrong data for validator
+        - An authorized user (user_2) with admin permission.
+        - User cannot perform a POST request for sample registration creation.
+        """
+        sample_registration = SampleRegistrationFactory.build(specimen_uuid=self.specimens[0])
+        sample_registration_dict = model_to_dict(sample_registration)
+        sample_registration_dict["sample_type"] = "invalid"
+        response = self.client.post(
+            self.sample_registration_url,
+            data=sample_registration_dict,
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
+            f"Response content: {response.content}",
+        )
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
@@ -64,6 +64,31 @@ class IngestTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
+    def test_specimen_ingest_validator(self):
+        """
+        Test invalid data and receive 422 unprocess response.
+
+        Testing Strategy:
+        - Build Specimen data based on the existing primary_diagnosis_uuid and wrong data for validator
+        - An authorized user (user_2) with admin permission.
+        - User cannot perform a POST request for specimen creation.
+        """
+        specimen = SpecimenFactory.build(primary_diagnosis_uuid=self.primary_diagnoses[0])
+        specimen_dict = model_to_dict(specimen)
+        specimen_dict["tumour_grade"] = "invalid"
+        response = self.client.post(
+            self.specimen_url,
+            data=specimen_dict,
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
+            f"Response content: {response.content}",
+        )
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
@@ -73,7 +73,9 @@ class IngestTestCase(BaseTestCase):
         - An authorized user (user_2) with admin permission.
         - User cannot perform a POST request for specimen creation.
         """
-        specimen = SpecimenFactory.build(primary_diagnosis_uuid=self.primary_diagnoses[0])
+        specimen = SpecimenFactory.build(
+            primary_diagnosis_uuid=self.primary_diagnoses[0]
+        )
         specimen_dict = model_to_dict(specimen)
         specimen_dict["tumour_grade"] = "invalid"
         response = self.client.post(
@@ -89,6 +91,7 @@ class IngestTestCase(BaseTestCase):
             f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
             f"Response content: {response.content}",
         )
+
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
@@ -73,7 +73,9 @@ class TreatmentsIngestTestCase(BaseTestCase):
         - An authorized user (user_2) with admin permission.
         - User cannot perform a POST request for treatment creation.
         """
-        treatment = TreatmentFactory.build(primary_diagnosis_uuid=self.primary_diagnoses[0])
+        treatment = TreatmentFactory.build(
+            primary_diagnosis_uuid=self.primary_diagnoses[0]
+        )
         treatment_dict = model_to_dict(treatment)
         treatment_dict["treatment_type"] = "invalid"
         response = self.client.post(
@@ -89,6 +91,7 @@ class TreatmentsIngestTestCase(BaseTestCase):
             f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
             f"Response content: {response.content}",
         )
+
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
@@ -64,6 +64,31 @@ class TreatmentsIngestTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
+    def test_treatment_create_validator(self):
+        """
+        Test invalid data and receive 422 unprocess response.
+
+        Testing Strategy:
+        - Build Treatment data based on the existing primary_diagnosis_uuid and wrong data for validator
+        - An authorized user (user_2) with admin permission.
+        - User cannot perform a POST request for treatment creation.
+        """
+        treatment = TreatmentFactory.build(primary_diagnosis_uuid=self.primary_diagnoses[0])
+        treatment_dict = model_to_dict(treatment)
+        treatment_dict["treatment_type"] = "invalid"
+        response = self.client.post(
+            self.treatment_url,
+            data=treatment_dict,
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            f"Expected status code {HTTPStatus.UNPROCESSABLE_ENTITY}, but got {response.status_code}. "
+            f"Response content: {response.content}",
+        )
 
 # GET API
 # -------

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
@@ -64,7 +64,7 @@ class TreatmentsIngestTestCase(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
-    def test_treatment_create_validator(self):
+    def test_treatment_ingest_validator(self):
         """
         Test invalid data and receive 422 unprocess response.
 


### PR DESCRIPTION
##  What's new:
- Refactor ingestion schemas to use base schemas
- Add tests for ingest validator

### How to test:
- Run `python manage.py test chord_metadata_service/mohpackets/tests/endpoints/`
- Or create objects using `http://127.0.0.1:8000/v2/docs#/ingest`