### PR TITLE
DIG-1317: Katsu's convert.py script can specify the name for datasets

### DIFF
--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -20,7 +20,7 @@ MODEL_NAME_MAPPING = {
 }
 
 
-def set_foreign_keys(path):
+def set_foreign_keys(path, program_id):
     """
     Set foreign keys for synthetic data.
     """
@@ -53,7 +53,7 @@ def set_foreign_keys(path):
             data_without_relationships = json.load(f)
 
         print(f"Processing {filename}...")
-        data_with_keys = replace_values(data_without_relationships, relationship)
+        data_with_keys = replace_values(data_without_relationships, relationship, program_id)
 
         with open(output_path, "w") as f:
             json.dump(data_with_keys, f, indent=4)
@@ -61,7 +61,7 @@ def set_foreign_keys(path):
     print("--------------------\n")
 
 
-def replace_values(input_data, transformation_rules):
+def replace_values(input_data, transformation_rules, program_id):
     """
     Replace values in input data using transformation rules.
 
@@ -105,7 +105,7 @@ def replace_values(input_data, transformation_rules):
     }
     """
     field_value_map = {
-        "program_id": "SYNTHETIC-",
+        "program_id": program_id,
         "submitter_donor_id": "DONOR_",
         "submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_",
         "submitter_specimen_id": "SPECIMEN_",
@@ -163,8 +163,8 @@ def main():
         print("Invalid option. Please try again.")
         return
 
-    set_foreign_keys(path)
-
+    program_id = str(input("Enter the dataset name (default: SYNTHETIC-): ")) or "SYNTHETIC-"
+    set_foreign_keys(path, program_id)
 
 if __name__ == "__main__":
     main()

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -25,6 +25,7 @@ def set_foreign_keys(path="small_dataset", program_id="SYNTHETIC-"):
     """
     Set foreign keys for synthetic data.
     """
+    print(f"Processing {program_id} | {path}")
     print("\nStep 1: Set Foreign Keys:\n")
     # Get the absolute path to the synthetic data folder
     script_dir = os.path.dirname(__file__)

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 import argparse
 
 MODEL_NAME_MAPPING = {

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -54,11 +54,6 @@ def set_foreign_keys(path="small_dataset", program_id="SYNTHETIC-"):
         with open(input_path, "r") as f:
             data_without_relationships = json.load(f)
 
-        if model == "programs":
-            # Update the values in Program.json
-            for item in data_without_relationships:
-                item["program_id"] = item["program_id"].replace("SYNTHETIC-", program_id)
-
         print(f"Processing {filename}...")
         data_with_keys = replace_values(data_without_relationships, relationship, program_id)
 

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -21,7 +21,7 @@ MODEL_NAME_MAPPING = {
 }
 
 
-def set_foreign_keys(path, program_id):
+def set_foreign_keys(path="small_dataset", program_id="SYNTHETIC-"):
     """
     Set foreign keys for synthetic data.
     """
@@ -165,8 +165,8 @@ def main():
     args = parse_args()
 
     size_mapping = {'s': 'small', 'm': 'medium', 'l': 'large'}
-    path = f"{size_mapping[args.size]}_dataset" or "small_dataset"
-    program_id = f"{args.program}-" or "SYNTHETIC-"
+    path = f"{size_mapping[args.size]}_dataset"
+    program_id = f"{args.program}-" 
 
     set_foreign_keys(path, program_id)
 

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -166,7 +166,7 @@ def main():
 
     size_mapping = {'s': 'small', 'm': 'medium', 'l': 'large'}
     path = f"{size_mapping[args.size]}_dataset"
-    program_id = f"{args.program}-" 
+    program_id = f"{args.program}-"
 
     set_foreign_keys(path, program_id)
 

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -166,5 +166,6 @@ def main():
     program_id = str(input("Enter the dataset name (default: SYNTHETIC-): ")) or "SYNTHETIC-"
     set_foreign_keys(path, program_id)
 
+
 if __name__ == "__main__":
     main()

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -166,7 +166,7 @@ def main():
 
     size_mapping = {'s': 'small', 'm': 'medium', 'l': 'large'}
     path = f"{size_mapping[args.size]}_dataset" or "small_dataset"
-    program_id = args.program or "SYNTHETIC"
+    program_id = f"{args.program}-" or "SYNTHETIC-"
 
     set_foreign_keys(path, program_id)
 

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -1,5 +1,7 @@
 import json
 import os
+import sys
+import argparse
 
 MODEL_NAME_MAPPING = {
     "programs": "Program.json",
@@ -141,29 +143,28 @@ def replace_values(input_data, transformation_rules, program_id):
     return input_data
 
 
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--size', type=str, default='s', choices=['s', 'm', 'l'], help="Size of the dataset to convert (default: small)")
+    parser.add_argument('--program', type=str, default='SYNTHETIC', help="Program ID prefix (default: SYNTHETIC)")
+    args = parser.parse_args()
+    return args
+
+
 def main():
-    print("Select an option:")
-    print("1. Convert small dataset")
-    print("2. Convert medium dataset")
-    print("3. Convert large dataset")
-    print("4. Exit")
+    args = parse_args()
 
-    choice = int(input("Enter your choice [1-4]: "))
-
-    if choice == 1:
-        path = "small_dataset"
-    elif choice == 2:
-        path = "medium_dataset"
-    elif choice == 3:
-        path = "large_dataset"
-    elif choice == 4:
-        print("Exiting...")
-        exit()
+    if args.size:
+        size_mapping = {'s': 'small', 'm': 'medium', 'l': 'large'}
+        path = f"{size_mapping[args.size]}_dataset"
     else:
-        print("Invalid option. Please try again.")
-        return
+        path = "small_dataset"
 
-    program_id = str(input("Enter the dataset name (default: SYNTHETIC-): ")) or "SYNTHETIC-"
+    if args.program:
+        program_id = args.program
+    else:
+        program_id = "SYNTHETIC"
+
     set_foreign_keys(path, program_id)
 
 

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -53,7 +53,7 @@ def set_foreign_keys(path="small_dataset", program_id="SYNTHETIC-"):
 
         with open(input_path, "r") as f:
             data_without_relationships = json.load(f)
-        
+
         if model == "programs":
             # Update the values in Program.json
             for item in data_without_relationships:

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -53,6 +53,11 @@ def set_foreign_keys(path="small_dataset", program_id="SYNTHETIC-"):
 
         with open(input_path, "r") as f:
             data_without_relationships = json.load(f)
+        
+        if model == "programs":
+            # Update the values in Program.json
+            for item in data_without_relationships:
+                item["program_id"] = item["program_id"].replace("SYNTHETIC-", program_id)
 
         print(f"Processing {filename}...")
         data_with_keys = replace_values(data_without_relationships, relationship, program_id)

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -149,7 +149,7 @@ def parse_args():
         type=str,
         default='s',
         choices=['s', 'm', 'l'],
-        help="Size of the dataset to convert (default: small)"
+        help="Size of the dataset to convert, options: 's' for small, 'm' for medium, 'l' for large (default: small)"
     )
     parser.add_argument(
         '--program',
@@ -164,16 +164,9 @@ def parse_args():
 def main():
     args = parse_args()
 
-    if args.size:
-        size_mapping = {'s': 'small', 'm': 'medium', 'l': 'large'}
-        path = f"{size_mapping[args.size]}_dataset"
-    else:
-        path = "small_dataset"
-
-    if args.program:
-        program_id = args.program
-    else:
-        program_id = "SYNTHETIC"
+    size_mapping = {'s': 'small', 'm': 'medium', 'l': 'large'}
+    path = f"{size_mapping[args.size]}_dataset" or "small_dataset"
+    program_id = args.program or "SYNTHETIC"
 
     set_foreign_keys(path, program_id)
 

--- a/chord_metadata_service/mohpackets/data/data_converter.py
+++ b/chord_metadata_service/mohpackets/data/data_converter.py
@@ -144,8 +144,19 @@ def replace_values(input_data, transformation_rules, program_id):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--size', type=str, default='s', choices=['s', 'm', 'l'], help="Size of the dataset to convert (default: small)")
-    parser.add_argument('--program', type=str, default='SYNTHETIC', help="Program ID prefix (default: SYNTHETIC)")
+    parser.add_argument(
+        '--size',
+        type=str,
+        default='s',
+        choices=['s', 'm', 'l'],
+        help="Size of the dataset to convert (default: small)"
+    )
+    parser.add_argument(
+        '--program',
+        type=str,
+        default='SYNTHETIC',
+        help="Program ID prefix (default: SYNTHETIC)"
+    )
     args = parser.parse_args()
     return args
 

--- a/chord_metadata_service/mohpackets/data/large_dataset/relationships.json
+++ b/chord_metadata_service/mohpackets/data/large_dataset/relationships.json
@@ -1,5 +1,15 @@
 {
-  "programs": [],
+  "programs": [
+    {
+      "range": [1, 10],
+      "targets": [
+        {
+          "range": [1, 10],
+          "field_name": "program_id"
+        }
+      ]
+    }
+  ],
   "donors": [
     {
       "range": [1, 500],

--- a/chord_metadata_service/mohpackets/data/medium_dataset/relationships.json
+++ b/chord_metadata_service/mohpackets/data/medium_dataset/relationships.json
@@ -1,5 +1,15 @@
 {
-  "programs": [],
+  "programs": [
+    {
+      "range": [1, 4],
+      "targets": [
+        {
+          "range": [1, 4],
+          "field_name": "program_id"
+        }
+      ]
+    }
+  ],
   "donors": [
     {
       "range": [1, 40],

--- a/chord_metadata_service/mohpackets/data/small_dataset/relationships.json
+++ b/chord_metadata_service/mohpackets/data/small_dataset/relationships.json
@@ -1,5 +1,15 @@
 {
-  "programs": [],
+  "programs": [
+    {
+      "range": [1, 2],
+      "targets": [
+        {
+          "range": [1, 2],
+          "field_name": "program_id"
+        }
+      ]
+    }
+  ],
   "donors": [
     {
       "range": [1, 6],


### PR DESCRIPTION
- Add an argument to specify the name of the dataset in Katsu’s convert.py. If none is specified, use the default (SYNTHETIC-).