### PR TITLE
Add EXTERNAL_URL to local.py

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -17,7 +17,7 @@ from .base import *
 
 DEBUG = True
 
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0", os.environ.get("EXTERNAL_URL")]
 
 # Debug toolbar settings
 # ----------------------


### PR DESCRIPTION
# Description
This was a missing piece as to why the nightly build was failing.