### PR TITLE
Sonchau/hot fix explorer

### DIFF
--- a/chord_metadata_service/mohpackets/apis/explorer.py
+++ b/chord_metadata_service/mohpackets/apis/explorer.py
@@ -1,13 +1,21 @@
 from typing import List
-from django.db.models.functions import Abs
-from ninja import Query, Router
-from django.db.models import Q
-from django.db.models import Case, When, IntegerField, CharField, Value
-from django.db.models import Func
-from django.db.models import OuterRef, Subquery
-from django.db.models.functions import Cast
+
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.contrib.postgres.expressions import ArraySubquery
+from django.db.models import (
+    Case,
+    CharField,
+    Func,
+    IntegerField,
+    OuterRef,
+    Q,
+    Subquery,
+    Value,
+    When,
+)
+from django.db.models.functions import Abs, Cast
+from ninja import Query, Router
+
 from chord_metadata_service.mohpackets.models import (
     Donor,
     Treatment,
@@ -18,7 +26,6 @@ from chord_metadata_service.mohpackets.schemas.explorer import (
 from chord_metadata_service.mohpackets.schemas.filter import (
     DonorExplorerFilterSchema,
 )
-
 
 explorer_router = Router()
 
@@ -91,7 +98,9 @@ def explorer_donor(request, filters: DonorExplorerFilterSchema = Query(...)):
             output_field=CharField(),
         ),
         submitter_sample_ids=ArrayAgg(
-            "sampleregistration__submitter_sample_id", distinct=True
+            "sampleregistration__submitter_sample_id",
+            distinct=True,
+            filter=~Q(sampleregistration__submitter_sample_id=None),
         ),
         treatment_type=ArraySubquery(Subquery(treatment_type_names)),
     ).values(

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -156,4 +156,4 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # CURRENT KATSU VERSION ACCORDING TO MODEL CHANGES
 # ------------------------------------------------
 
-KATSU_VERSION = "4.1.2"
+KATSU_VERSION = "4.1.3"


### PR DESCRIPTION
## What's New
- The Explorer API should no longer throw errors if the sample ID is missing.

### How to Test

- Run `python manage.py flush`
- Download data.json and place it in the root folder. This is the same data as run through test-integration
- Run `python manage.py loaddata data.json`
- Verify that the endpoint `/v2/explorer/donors/` is functioning correctly.

Alternatively, rebuild docker stack with this branch and run test-integration with `KEEP_TEST_DATA=true`

[data.json](https://github.com/CanDIG/katsu/files/14952631/data.json)
