### PR TITLE
DIG-1567: Katsu overview APIs cached in redis

### DIFF
--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -23,6 +23,9 @@ from chord_metadata_service.mohpackets.apis.explorer import (
 from chord_metadata_service.mohpackets.apis.ingestion import router as ingest_router
 from chord_metadata_service.mohpackets.utils import get_schema_url
 
+from django.views.decorators.cache import cache_page
+from ninja.decorators import decorate_view
+
 """
 Module with configurations for APIs
 
@@ -188,6 +191,7 @@ api.add_router(
 
 
 @api.get("/service-info")
+@decorate_view(cache_page(settings.CACHE_DURATION))
 def service_info(request):
     schema_url = get_schema_url()
 

--- a/chord_metadata_service/mohpackets/apis/discovery.py
+++ b/chord_metadata_service/mohpackets/apis/discovery.py
@@ -1,10 +1,15 @@
 from collections import Counter
-from typing import Any, Dict, Type, List
+from typing import Any, Dict, List, Type
+
+from django.conf import settings
 from django.db.models import (
     Count,
     Model,
 )
+from django.views.decorators.cache import cache_page
 from ninja import Query, Router
+from ninja.decorators import decorate_view
+
 from chord_metadata_service.mohpackets.models import (
     Biomarker,
     Chemotherapy,
@@ -34,14 +39,13 @@ from chord_metadata_service.mohpackets.schemas.filter import (
     DonorFilterSchema,
 )
 
-
 """
 Module with overview APIs for the summary page and discovery APIs.
 These APIs do not require authorization but return only donor counts.
 
 Author: Son Chau
 """
-
+CACHE_DURATION = settings.CACHE_DURATION
 discovery_router = Router()
 overview_router = Router()
 discovery_router.add_router("/overview/", overview_router, tags=["overview"])
@@ -91,6 +95,7 @@ def count_donors(model: Type[Model], filters=None) -> Dict[str, int]:
 #                                             #
 ###############################################
 @discovery_router.get("/programs/", response=List[ProgramDiscoverySchema])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_programs(request):
     return Program.objects.only("program_id", "metadata")
 
@@ -185,6 +190,7 @@ def discover_exposures(request):
 #                                             #
 ###############################################
 @discovery_router.get("/sidebar_list/", response=Dict[str, Any])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_sidebar_list(request):
     """
     Retrieve the list of available values for all fields (including for
@@ -226,6 +232,7 @@ def discover_sidebar_list(request):
 
 
 @overview_router.get("/cohort_count/", response=Dict[str, int])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_cohort_count(request):
     """
     Return the number of cohorts in the database.
@@ -234,6 +241,7 @@ def discover_cohort_count(request):
 
 
 @overview_router.get("/patients_per_cohort/", response=Dict[str, int])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_patients_per_cohort(request):
     """
     Return the number of patients per cohort in the database.
@@ -243,15 +251,16 @@ def discover_patients_per_cohort(request):
 
 
 @overview_router.get("/individual_count/", response=Dict[str, int])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_individual_count(request):
     """
     Return the number of individuals in the database.
     """
-
     return {"individual_count": Donor.objects.count()}
 
 
 @overview_router.get("/gender_count/", response=Dict[str, int])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_gender_count(request):
     """
     Return the count for every gender in the database.
@@ -261,6 +270,7 @@ def discover_gender_count(request):
 
 
 @overview_router.get("/cancer_type_count/", response=Dict[str, int])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_cancer_type_count(request):
     """
     Return the count for every cancer type in the database.
@@ -276,6 +286,7 @@ def discover_cancer_type_count(request):
 
 
 @overview_router.get("/treatment_type_count/", response=Dict[str, int])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_treatment_type_count(request):
     """
     Return the count for every treatment type in the database.
@@ -291,6 +302,7 @@ def discover_treatment_type_count(request):
 
 
 @overview_router.get("/diagnosis_age_count/", response=Dict[str, int])
+@decorate_view(cache_page(CACHE_DURATION))
 def discover_diagnosis_age_count(request):
     """
     Return the count for age of diagnosis by calculating the date of birth interval.

--- a/chord_metadata_service/mohpackets/apis/ingestion.py
+++ b/chord_metadata_service/mohpackets/apis/ingestion.py
@@ -57,6 +57,7 @@ def create_instance(payload, model_cls: Type):
             status=HTTPStatus.BAD_REQUEST,
             data={"error": str(e)},
         )
+
     return JsonResponse(
         status=HTTPStatus.CREATED,
         data={"created": str(instance)},

--- a/chord_metadata_service/mohpackets/signals.py
+++ b/chord_metadata_service/mohpackets/signals.py
@@ -1,7 +1,8 @@
 import logging
 
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models.signals import pre_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
 from chord_metadata_service.mohpackets.models import (
@@ -187,3 +188,11 @@ def create_follow_up_foreign_key(sender, instance, **kwargs):
         "submitter_primary_diagnosis_id",
         "primary_diagnosis_uuid_id",
     )
+
+
+@receiver([post_save, post_delete])
+def clear_cache(**kwargs):
+    """
+    Clears the cache when database changes
+    """
+    cache.clear()

--- a/chord_metadata_service/mohpackets/utils.py
+++ b/chord_metadata_service/mohpackets/utils.py
@@ -3,43 +3,36 @@ import logging
 import re
 from enum import Enum
 
-from django.core.cache import cache
-
-
 logger = logging.getLogger(__name__)
 
 
 def get_schema_url():
     """
-    Retrieve the schema URL either from cached or by parsing the first 10 lines of a JSON file.
-    It first checks if the URL is cached in "schema_url".
-    If not cached, it reads the first 6 lines of the JSON file and extracts the URL from the "description".
+    Retrieve the SHA URL from schema.json.
+    It reads the first 6 lines of the JSON file and extracts the URL from the "description".
     """
-
-    schema_url = cache.get("schema_url")
     url_pattern = r"https://[^\s]+"  # get everything after https
 
-    if schema_url is None:
-        try:
-            with open(
-                "chord_metadata_service/mohpackets/docs/schema.json", "r"
-            ) as json_file:
-                # Read the first 6 lines of the JSON file only
-                # The line we are looking for is on the 6th
-                first_6_lines = [next(json_file) for _ in range(6)]
-                first_6_lines.extend(["}", "}"])  # make valid JSON
-                # Concatenate the lines to form a JSON string
-                json_str = "".join(first_6_lines)
-                data = json.loads(json_str)
-                desc_str = data["info"]["description"]
-                schema_url = re.search(url_pattern, desc_str).group()
-                # Cache the schema_version so we won't read it each time
-                cache.set("schema_url", schema_url)
-        except Exception as e:
-            logger.debug(
-                f"An error occurred while fetching the schema URL. Details: {str(e)}"
-            )
-            schema_url = None
+    schema_url = "None"
+
+    try:
+        with open(
+            "chord_metadata_service/mohpackets/docs/schema.json", "r"
+        ) as json_file:
+            # Read the first 6 lines of the JSON file only
+            # The line we are looking for is on the 6th
+            first_6_lines = [next(json_file) for _ in range(6)]
+            first_6_lines.extend(["}", "}"])  # make valid JSON
+            # Concatenate the lines to form a JSON string
+            json_str = "".join(first_6_lines)
+            data = json.loads(json_str)
+            desc_str = data["info"]["description"]
+            schema_url = re.search(url_pattern, desc_str).group()
+    except Exception as e:
+        logger.debug(
+            f"An error occurred while fetching the schema URL. Details: {str(e)}"
+        )
+
     return schema_url
 
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -98,15 +98,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "config.wsgi.application"
 
-# Cache
-# https://docs.djangoproject.com/en/4.1/topics/cache/
-
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-    }
-}
-
 # ==============================================================================
 # AUTHENTICATION AND AUTHORIZATION SETTINGS
 # ==============================================================================
@@ -156,4 +147,4 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # CURRENT KATSU VERSION ACCORDING TO MODEL CHANGES
 # ------------------------------------------------
 
-KATSU_VERSION = "4.1.3"
+KATSU_VERSION = "4.2.0"

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -40,7 +40,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # CANDIG SETTINGS
 # ---------------
-KATSU_AUTHORIZATION = os.getenv("KATSU_AUTHORIZATION")
+CACHE_DURATION = int(os.getenv("CACHE_DURATION", 86400))  # default to 1 day
 CONN_MAX_AGE = int(os.getenv("CONN_MAX_AGE", 0))
 if exists("/run/secrets/opa-root-token"):
     with open("/run/secrets/opa-root-token", "r") as f:
@@ -74,6 +74,17 @@ DATABASES = {
         "PORT": os.environ.get("POSTGRES_PORT"),
     }
 }
+
+# Cache
+# -----
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://:{get_secret(os.environ.get('REDIS_PASSWORD_FILE'))}@{os.environ.get('EXTERNAL_URL')}:6379/1",
+        "TIMEOUT": CACHE_DURATION,
+    }
+}
+
 
 # Logging
 # -------

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -11,7 +11,6 @@
 # - testing query token is "query"                          #
 #############################################################
 
-import os
 import socket
 from .base import *
 
@@ -36,6 +35,16 @@ DATABASES = {
         "PASSWORD": "password_local",
         "HOST": "localhost",
         "PORT": "5432",
+    }
+}
+
+# Cache
+# https://docs.djangoproject.com/en/4.1/topics/cache/
+CACHE_DURATION = 30  # set to 0 to disable cache
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "TIMEOUT": CACHE_DURATION,
     }
 }
 

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -22,7 +22,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # CANDIG SETTINGS
 # ---------------
-KATSU_AUTHORIZATION = os.getenv("KATSU_AUTHORIZATION")
+CACHE_DURATION = int(os.getenv("CACHE_DURATION", 86400))  # default to 1 day
 CONN_MAX_AGE = int(os.getenv("CONN_MAX_AGE", 0))
 if exists("/run/secrets/opa-root-token"):
     with open("/run/secrets/opa-root-token", "r") as f:
@@ -54,6 +54,16 @@ DATABASES = {
         "PASSWORD": get_secret(os.environ.get("POSTGRES_PASSWORD_FILE")),
         "HOST": os.environ.get("POSTGRES_HOST"),
         "PORT": os.environ.get("POSTGRES_PORT"),
+    }
+}
+
+# Cache
+# -----
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://:{get_secret(os.environ.get('REDIS_PASSWORD_FILE'))}@{os.environ.get('EXTERNAL_URL')}:6379/1",
+        "TIMEOUT": CACHE_DURATION,
     }
 }
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 -r local.txt # inherit from local.txt
 uwsgi==2.0.24 #  web server
 whitenoise==6.6.0 # serve static files
+redis[hiredis]==5.0.3 # cache server

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,4 +5,3 @@ tox==4.14.2 # test command line tool
 django-debug-toolbar==4.3.0 # display debug information
 factory-boy==3.3.0 # setup test cases
 tqdm==4.66.2 # progress bar for data loader script
-# django-silk # live profiling and inspection tool

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
 -r base.txt # inherit from base.txt
 uwsgi==2.0.24 #  web server
 whitenoise==6.6.0 # serve static files
-# sentry-sdk # Error reporting/logging tool
+redis[hiredis]==5.0.3 # cache server

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ setenv =
     PYTHONPATH={toxinidir}
     DJANGO_SETTINGS_MODULE={env:DJANGO_SETTINGS_MODULE:config.settings.local}
 passenv =
-    KATSU_AUTHORIZATION
     OPA_*
     POSTGRES_*
 deps =


### PR DESCRIPTION
## What's New:
- Implemented cache for overview APIs
- Added Redis configuration as the caching database

### How to Test:
- For local testing, run `tox`
- For Docker:
  - Update candigv2 develop
  - Pull this branch in candigv2 katsu and rebuild the stack, then run integration tests
- (Optional)You can utilize Swagger UI or any API editor to test the overview response time.