### PR TITLE
Cleanup

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -42,10 +42,9 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 # ---------------
 KATSU_AUTHORIZATION = os.getenv("KATSU_AUTHORIZATION")
 CANDIG_OPA_URL = os.getenv("OPA_URL")
-CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("OPA_SITE_ADMIN_KEY")
 CONN_MAX_AGE = int(os.getenv("CONN_MAX_AGE", 0))
-if exists("/run/secrets/opa-root-token"):
-    with open("/run/secrets/opa-root-token", "r") as f:
+if exists("/run/secrets/opa-service-token"):
+    with open("/run/secrets/opa-service-token", "r") as f:
         CANDIG_OPA_SECRET = f.read()
 if exists("/run/secrets/katsu_secret"):
     with open("/run/secrets/katsu_secret", "r") as f:

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -24,10 +24,9 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 # ---------------
 KATSU_AUTHORIZATION = os.getenv("KATSU_AUTHORIZATION")
 CANDIG_OPA_URL = os.getenv("OPA_URL")
-CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("OPA_SITE_ADMIN_KEY")
 CONN_MAX_AGE = int(os.getenv("CONN_MAX_AGE", 0))
-if exists("/run/secrets/opa-root-token"):
-    with open("/run/secrets/opa-root-token", "r") as f:
+if exists("/run/secrets/opa-service-token"):
+    with open("/run/secrets/opa-service-token", "r") as f:
         CANDIG_OPA_SECRET = f.read()
 if exists("/run/secrets/katsu_secret"):
     with open("/run/secrets/katsu_secret", "r") as f:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.0 # CANDIG authorization wrapper
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/aud # CANDIG authorization wrapper
 Django==5.0.1 # Python web framework
 psycopg[binary]==3.1.16 # PostgreSQL driver for Python
 django-cors-headers==4.3.1 # handling the server headers required for CORS


### PR DESCRIPTION
I'm about to update everything so that the containers all use `opa-service-token` instead of `opa-root-token`, so this is fixed here. I also deleted CANDIG_OPA_SITE_ADMIN_KEY and updated (with placeholder, will fix before merge) the version of authx.

This should just be a code review; testing will happen later in a CanDIGv2 PR.