### PR TITLE
Hotfix for UHN prod: add "query" to allowed hosts

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -21,6 +21,7 @@ ALLOWED_HOSTS = [
     "127.0.0.1",
     os.environ.get("HOST_CONTAINER_NAME"),
     os.environ.get("EXTERNAL_URL"),
+    "query"
 ]
 
 # Debug toolbar settings

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -13,7 +13,8 @@ from .base import *
 ALLOWED_HOSTS = [
     os.environ.get("HOST_CONTAINER_NAME"),
     os.environ.get("EXTERNAL_URL"),
-    os.environ.get("CANDIG_INTERNAL_DOMAIN")
+    os.environ.get("CANDIG_INTERNAL_DOMAIN"),
+    "query"
 ]
 
 # Whitenoise

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -13,6 +13,7 @@ from .base import *
 ALLOWED_HOSTS = [
     os.environ.get("HOST_CONTAINER_NAME"),
     os.environ.get("EXTERNAL_URL"),
+    os.environ.get("CANDIG_INTERNAL_DOMAIN")
 ]
 
 # Whitenoise


### PR DESCRIPTION
The query container needs to be referred to inside the containers by its container name, so that should be added to the allowed_hosts.