### PR TITLE
DIG-1582: Implement overview thresholds & DIG-1533: Change cancer_type to primary_site

### DIFF
--- a/.github/workflows/update-schema.yaml
+++ b/.github/workflows/update-schema.yaml
@@ -34,6 +34,7 @@ jobs:
         run: |
           export DJANGO_SETTINGS_MODULE=config.settings.base
           echo "CACHE_DURATION = 0" >> config/settings/base.py
+          echo "AGGREGATE_COUNT_THRESHOLD = 5" >> config/settings/base.py
           python manage.py export_openapi_schema --api chord_metadata_service.mohpackets.apis.core.api | python -m json.tool > chord_metadata_service/mohpackets/docs/schema.json
       
       - name: Commit new schema.json

--- a/chord_metadata_service/mohpackets/apis/discovery.py
+++ b/chord_metadata_service/mohpackets/apis/discovery.py
@@ -52,7 +52,7 @@ overview_router = Router()
 discovery_router.add_router("/overview/", overview_router, tags=["overview"])
 
 # To protect privacy, numbers below a certain threshold will be censored, e.g., <5
-SMALL_NUMBER_THRESHOLD = settings.AGGREGATE_COUNT_THRESHOLD
+SMALL_NUMBER_THRESHOLD = int(settings.AGGREGATE_COUNT_THRESHOLD)
 SMALL_NUMBER_DISPLAY = "<" + str(SMALL_NUMBER_THRESHOLD)
 
 
@@ -183,11 +183,15 @@ def discover_individual_count(request):
     Return the number of individuals in the database.
     """
     donor_count = Donor.objects.count()
-    return {
-        "individual_count": str(donor_count)
-        if donor_count >= SMALL_NUMBER_THRESHOLD
-        else SMALL_NUMBER_DISPLAY
-    }
+
+    if donor_count == 0:
+        result = "0"
+    elif donor_count < SMALL_NUMBER_THRESHOLD:
+        result = SMALL_NUMBER_DISPLAY
+    else:
+        result = str(donor_count)
+
+    return {"individual_count": result}
 
 
 @overview_router.get("/gender_count/", response=List[GenderCountSchema])

--- a/chord_metadata_service/mohpackets/apis/discovery.py
+++ b/chord_metadata_service/mohpackets/apis/discovery.py
@@ -283,7 +283,7 @@ def discover_diagnosis_age_count(request):
                 Cast("date_of_birth__month_interval", output_field=IntegerField())
             ),
             age_at_diagnosis=Case(
-                When(Q(date_of_birth__isnull=True), then=Value(None)),
+                When(Q(date_of_birth__isnull=True), then=Value("null")),
                 When(abs_month_interval__lt=240, then=Value("0-19")),
                 When(abs_month_interval__lt=360, then=Value("20-29")),
                 When(abs_month_interval__lt=480, then=Value("30-39")),

--- a/chord_metadata_service/mohpackets/docs/schema.json
+++ b/chord_metadata_service/mohpackets/docs/schema.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "MoH Service API",
         "version": "4.2.1",
-        "description": "This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/a5656164c539273637fe7ae7709f41d61bf86ced/chord_metadata_service/mohpackets/docs/schema.json"
+        "description": "This is the RESTful API for the MoH Service."
     },
     "paths": {
         "/v2/service-info": {
@@ -3943,6 +3943,7 @@
                         }
                     }
                 },
+                "description": "Return all the programs in the database.",
                 "tags": [
                     "discovery"
                 ]
@@ -3952,171 +3953,6 @@
             "get": {
                 "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_donors",
                 "summary": "Discover Donors",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "submitter_donor_id",
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Submitter Donor Id"
-                        },
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "program_id",
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Program Id"
-                        },
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "gender",
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "q": "gender__icontains",
-                            "title": "Gender"
-                        },
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "sex_at_birth",
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Sex At Birth"
-                        },
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "is_deceased",
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "boolean"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Is Deceased"
-                        },
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "lost_to_followup_after_clinical_event_identifier",
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Lost To Followup After Clinical Event Identifier"
-                        },
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "lost_to_followup_reason",
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Lost To Followup Reason"
-                        },
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "cause_of_death",
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Cause Of Death"
-                        },
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "primary_site",
-                        "schema": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "q": "primary_site__overlap",
-                            "title": "Primary Site",
-                            "type": "array"
-                        },
-                        "required": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/specimen/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_specimens",
-                "summary": "Discover Specimens",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -4124,276 +3960,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
+                                    "items": {
+                                        "$ref": "#/components/schemas/DiscoveryDonorSchema"
+                                    },
+                                    "title": "Response",
+                                    "type": "array"
                                 }
                             }
                         }
                     }
                 },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/sample_registrations/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_sample_registrations",
-                "summary": "Discover Sample Registrations",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/primary_diagnoses/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_primary_diagnoses",
-                "summary": "Discover Primary Diagnoses",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/treatments/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_treatments",
-                "summary": "Discover Treatments",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/chemotherapies/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_chemotherapies",
-                "summary": "Discover Chemotherapies",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/hormone_therapies/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_hormone_therapies",
-                "summary": "Discover Hormone Therapies",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/radiations/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_radiations",
-                "summary": "Discover Radiations",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/immunotherapies/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_immunotherapies",
-                "summary": "Discover Immunotherapies",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/surgeries/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_surgeries",
-                "summary": "Discover Surgeries",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/follow_ups/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_follow_ups",
-                "summary": "Discover Follow Ups",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/biomarkers/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_biomarkers",
-                "summary": "Discover Biomarkers",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/comorbidities/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_comorbidities",
-                "summary": "Discover Comorbidities",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": [
-                    "discovery"
-                ]
-            }
-        },
-        "/v2/discovery/exposures/": {
-            "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_exposures",
-                "summary": "Discover Exposures",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DiscoverySchema"
-                                }
-                            }
-                        }
-                    }
-                },
+                "description": "Return the number of donors per cohort in the database.",
                 "tags": [
                     "discovery"
                 ]
@@ -4461,11 +4038,11 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "additionalProperties": {
-                                        "type": "integer"
+                                    "items": {
+                                        "$ref": "#/components/schemas/PatientPerCohortSchema"
                                     },
                                     "title": "Response",
-                                    "type": "object"
+                                    "type": "array"
                                 }
                             }
                         }
@@ -4489,7 +4066,7 @@
                             "application/json": {
                                 "schema": {
                                     "additionalProperties": {
-                                        "type": "integer"
+                                        "type": "string"
                                     },
                                     "title": "Response",
                                     "type": "object"
@@ -4515,11 +4092,11 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "additionalProperties": {
-                                        "type": "integer"
+                                    "items": {
+                                        "$ref": "#/components/schemas/GenderCountSchema"
                                     },
                                     "title": "Response",
-                                    "type": "object"
+                                    "type": "array"
                                 }
                             }
                         }
@@ -4531,10 +4108,10 @@
                 ]
             }
         },
-        "/v2/discovery/overview/cancer_type_count/": {
+        "/v2/discovery/overview/primary_site_count/": {
             "get": {
-                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_cancer_type_count",
-                "summary": "Discover Cancer Type Count",
+                "operationId": "chord_metadata_service_mohpackets_apis_discovery_discover_primary_site_count",
+                "summary": "Discover Primary Site Count",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -4542,11 +4119,11 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "additionalProperties": {
-                                        "type": "integer"
+                                    "items": {
+                                        "$ref": "#/components/schemas/PrimarySiteCountSchema"
                                     },
                                     "title": "Response",
-                                    "type": "object"
+                                    "type": "array"
                                 }
                             }
                         }
@@ -4569,11 +4146,11 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "additionalProperties": {
-                                        "type": "integer"
+                                    "items": {
+                                        "$ref": "#/components/schemas/TreatmentTypeCountSchema"
                                     },
                                     "title": "Response",
-                                    "type": "object"
+                                    "type": "array"
                                 }
                             }
                         }
@@ -4596,11 +4173,11 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "additionalProperties": {
-                                        "type": "integer"
+                                    "items": {
+                                        "$ref": "#/components/schemas/DiagnosisAgeCountSchema"
                                     },
                                     "title": "Response",
-                                    "type": "object"
+                                    "type": "array"
                                 }
                             }
                         }
@@ -14219,20 +13796,119 @@
                 "title": "ProgramDiscoverySchema",
                 "type": "object"
             },
-            "DiscoverySchema": {
+            "DiscoveryDonorSchema": {
                 "properties": {
-                    "donors_by_cohort": {
-                        "additionalProperties": {
-                            "type": "integer"
-                        },
-                        "title": "Donors By Cohort",
-                        "type": "object"
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "donors_count": {
+                        "title": "Donors Count",
+                        "type": "string"
                     }
                 },
                 "required": [
-                    "donors_by_cohort"
+                    "program_id",
+                    "donors_count"
                 ],
-                "title": "DiscoverySchema",
+                "title": "DiscoveryDonorSchema",
+                "type": "object"
+            },
+            "PatientPerCohortSchema": {
+                "properties": {
+                    "program_id": {
+                        "title": "Program Id",
+                        "type": "string"
+                    },
+                    "patients_count": {
+                        "title": "Patients Count",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "program_id",
+                    "patients_count"
+                ],
+                "title": "PatientPerCohortSchema",
+                "type": "object"
+            },
+            "GenderCountSchema": {
+                "properties": {
+                    "gender": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gender"
+                    },
+                    "gender_count": {
+                        "title": "Gender Count",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "gender",
+                    "gender_count"
+                ],
+                "title": "GenderCountSchema",
+                "type": "object"
+            },
+            "PrimarySiteCountSchema": {
+                "properties": {
+                    "primary_site_name": {
+                        "title": "Primary Site Name",
+                        "type": "string"
+                    },
+                    "primary_site_count": {
+                        "title": "Primary Site Count",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "primary_site_name",
+                    "primary_site_count"
+                ],
+                "title": "PrimarySiteCountSchema",
+                "type": "object"
+            },
+            "TreatmentTypeCountSchema": {
+                "properties": {
+                    "treatment_type_name": {
+                        "title": "Treatment Type Name",
+                        "type": "string"
+                    },
+                    "treatment_type_count": {
+                        "title": "Treatment Type Count",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "treatment_type_name",
+                    "treatment_type_count"
+                ],
+                "title": "TreatmentTypeCountSchema",
+                "type": "object"
+            },
+            "DiagnosisAgeCountSchema": {
+                "properties": {
+                    "age_at_diagnosis": {
+                        "title": "Age At Diagnosis",
+                        "type": "string"
+                    },
+                    "age_count": {
+                        "title": "Age Count",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "age_at_diagnosis",
+                    "age_count"
+                ],
+                "title": "DiagnosisAgeCountSchema",
                 "type": "object"
             },
             "DonorExplorerFilterSchema": {

--- a/chord_metadata_service/mohpackets/docs/schema.md
+++ b/chord_metadata_service/mohpackets/docs/schema.md
@@ -1,7 +1,7 @@
 
 <h1 id="moh-service-api">MoH Service API v4.2.1</h1>
 
-This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/a5656164c539273637fe7ae7709f41d61bf86ced/chord_metadata_service/mohpackets/docs/schema.json
+This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/52d470cfd8a3fd5c2b60f7145204a19066e783f2/chord_metadata_service/mohpackets/docs/schema.json
 
 Base URLs:
 
@@ -1440,6 +1440,8 @@ Base URLs:
 
 *Discover Programs*
 
+Return all the programs in the database.
+
 > Example responses
 
 > 200 Response
@@ -1461,304 +1463,19 @@ Base URLs:
 
 *Discover Donors*
 
-<h3 id="chord_metadata_service_mohpackets_apis_discovery_discover_donors-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|submitter_donor_id|query|any|false|none|
-|program_id|query|any|false|none|
-|gender|query|any|false|none|
-|sex_at_birth|query|any|false|none|
-|is_deceased|query|any|false|none|
-|lost_to_followup_after_clinical_event_identifier|query|any|false|none|
-|lost_to_followup_reason|query|any|false|none|
-|cause_of_death|query|any|false|none|
-|primary_site|query|array[string]|false|none|
+Return the number of donors per cohort in the database.
 
 > Example responses
 
 > 200 Response
 
 ```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
+[
+  {
+    "program_id": "string",
+    "donors_count": "string"
   }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_specimens
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_specimens"></a>
-
-`GET /v2/discovery/specimen/`
-
-*Discover Specimens*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_sample_registrations
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_sample_registrations"></a>
-
-`GET /v2/discovery/sample_registrations/`
-
-*Discover Sample Registrations*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_primary_diagnoses
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_primary_diagnoses"></a>
-
-`GET /v2/discovery/primary_diagnoses/`
-
-*Discover Primary Diagnoses*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_treatments
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_treatments"></a>
-
-`GET /v2/discovery/treatments/`
-
-*Discover Treatments*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_chemotherapies
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_chemotherapies"></a>
-
-`GET /v2/discovery/chemotherapies/`
-
-*Discover Chemotherapies*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_hormone_therapies
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_hormone_therapies"></a>
-
-`GET /v2/discovery/hormone_therapies/`
-
-*Discover Hormone Therapies*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_radiations
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_radiations"></a>
-
-`GET /v2/discovery/radiations/`
-
-*Discover Radiations*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_immunotherapies
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_immunotherapies"></a>
-
-`GET /v2/discovery/immunotherapies/`
-
-*Discover Immunotherapies*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_surgeries
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_surgeries"></a>
-
-`GET /v2/discovery/surgeries/`
-
-*Discover Surgeries*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_follow_ups
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_follow_ups"></a>
-
-`GET /v2/discovery/follow_ups/`
-
-*Discover Follow Ups*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_biomarkers
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_biomarkers"></a>
-
-`GET /v2/discovery/biomarkers/`
-
-*Discover Biomarkers*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_comorbidities
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_comorbidities"></a>
-
-`GET /v2/discovery/comorbidities/`
-
-*Discover Comorbidities*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-```
-
-## chord_metadata_service_mohpackets_apis_discovery_discover_exposures
-
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_exposures"></a>
-
-`GET /v2/discovery/exposures/`
-
-*Discover Exposures*
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
-}
+]
 ```
 
 ## chord_metadata_service_mohpackets_apis_discovery_discover_sidebar_list
@@ -1818,10 +1535,12 @@ Return the number of patients per cohort in the database.
 > 200 Response
 
 ```json
-{
-  "property1": 0,
-  "property2": 0
-}
+[
+  {
+    "program_id": "string",
+    "patients_count": "string"
+  }
+]
 ```
 
 ## chord_metadata_service_mohpackets_apis_discovery_discover_individual_count
@@ -1840,8 +1559,8 @@ Return the number of individuals in the database.
 
 ```json
 {
-  "property1": 0,
-  "property2": 0
+  "property1": "string",
+  "property2": "string"
 }
 ```
 
@@ -1860,19 +1579,21 @@ Return the count for every gender in the database.
 > 200 Response
 
 ```json
-{
-  "property1": 0,
-  "property2": 0
-}
+[
+  {
+    "gender": "string",
+    "gender_count": "string"
+  }
+]
 ```
 
-## chord_metadata_service_mohpackets_apis_discovery_discover_cancer_type_count
+## chord_metadata_service_mohpackets_apis_discovery_discover_primary_site_count
 
-<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_cancer_type_count"></a>
+<a id="opIdchord_metadata_service_mohpackets_apis_discovery_discover_primary_site_count"></a>
 
-`GET /v2/discovery/overview/cancer_type_count/`
+`GET /v2/discovery/overview/primary_site_count/`
 
-*Discover Cancer Type Count*
+*Discover Primary Site Count*
 
 Return the count for every cancer type in the database.
 
@@ -1881,10 +1602,12 @@ Return the count for every cancer type in the database.
 > 200 Response
 
 ```json
-{
-  "property1": 0,
-  "property2": 0
-}
+[
+  {
+    "primary_site_name": "string",
+    "primary_site_count": "string"
+  }
+]
 ```
 
 ## chord_metadata_service_mohpackets_apis_discovery_discover_treatment_type_count
@@ -1902,10 +1625,12 @@ Return the count for every treatment type in the database.
 > 200 Response
 
 ```json
-{
-  "property1": 0,
-  "property2": 0
-}
+[
+  {
+    "treatment_type_name": "string",
+    "treatment_type_count": "string"
+  }
+]
 ```
 
 ## chord_metadata_service_mohpackets_apis_discovery_discover_diagnosis_age_count
@@ -1923,10 +1648,12 @@ Return the count for age of diagnosis by calculating the date of birth interval.
 > 200 Response
 
 ```json
-{
-  "property1": 0,
-  "property2": 0
-}
+[
+  {
+    "age_at_diagnosis": "string",
+    "age_count": "string"
+  }
+]
 ```
 
 <h1 id="moh-service-api-explorer">explorer</h1>
@@ -18627,31 +18354,166 @@ ProgramDiscoverySchema
 |program_id|string|true|none|none|
 |metadata|any|true|none|none|
 
-<h2 id="tocS_DiscoverySchema">DiscoverySchema</h2>
+<h2 id="tocS_DiscoveryDonorSchema">DiscoveryDonorSchema</h2>
 
-<a id="schemadiscoveryschema"></a>
-<a id="schema_DiscoverySchema"></a>
-<a id="tocSdiscoveryschema"></a>
-<a id="tocsdiscoveryschema"></a>
+<a id="schemadiscoverydonorschema"></a>
+<a id="schema_DiscoveryDonorSchema"></a>
+<a id="tocSdiscoverydonorschema"></a>
+<a id="tocsdiscoverydonorschema"></a>
 
 ```json
 {
-  "donors_by_cohort": {
-    "property1": 0,
-    "property2": 0
-  }
+  "program_id": "string",
+  "donors_count": "string"
 }
 
 ```
 
-DiscoverySchema
+DiscoveryDonorSchema
 
 ### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|donors_by_cohort|object|true|none|none|
-|» **additionalProperties**|integer|false|none|none|
+|program_id|string|true|none|none|
+|donors_count|string|true|none|none|
+
+<h2 id="tocS_PatientPerCohortSchema">PatientPerCohortSchema</h2>
+
+<a id="schemapatientpercohortschema"></a>
+<a id="schema_PatientPerCohortSchema"></a>
+<a id="tocSpatientpercohortschema"></a>
+<a id="tocspatientpercohortschema"></a>
+
+```json
+{
+  "program_id": "string",
+  "patients_count": "string"
+}
+
+```
+
+PatientPerCohortSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|program_id|string|true|none|none|
+|patients_count|string|true|none|none|
+
+<h2 id="tocS_GenderCountSchema">GenderCountSchema</h2>
+
+<a id="schemagendercountschema"></a>
+<a id="schema_GenderCountSchema"></a>
+<a id="tocSgendercountschema"></a>
+<a id="tocsgendercountschema"></a>
+
+```json
+{
+  "gender": "string",
+  "gender_count": "string"
+}
+
+```
+
+GenderCountSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|gender|any|true|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|string|false|none|none|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|null|false|none|none|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|gender_count|string|true|none|none|
+
+<h2 id="tocS_PrimarySiteCountSchema">PrimarySiteCountSchema</h2>
+
+<a id="schemaprimarysitecountschema"></a>
+<a id="schema_PrimarySiteCountSchema"></a>
+<a id="tocSprimarysitecountschema"></a>
+<a id="tocsprimarysitecountschema"></a>
+
+```json
+{
+  "primary_site_name": "string",
+  "primary_site_count": "string"
+}
+
+```
+
+PrimarySiteCountSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|primary_site_name|string|true|none|none|
+|primary_site_count|string|true|none|none|
+
+<h2 id="tocS_TreatmentTypeCountSchema">TreatmentTypeCountSchema</h2>
+
+<a id="schematreatmenttypecountschema"></a>
+<a id="schema_TreatmentTypeCountSchema"></a>
+<a id="tocStreatmenttypecountschema"></a>
+<a id="tocstreatmenttypecountschema"></a>
+
+```json
+{
+  "treatment_type_name": "string",
+  "treatment_type_count": "string"
+}
+
+```
+
+TreatmentTypeCountSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|treatment_type_name|string|true|none|none|
+|treatment_type_count|string|true|none|none|
+
+<h2 id="tocS_DiagnosisAgeCountSchema">DiagnosisAgeCountSchema</h2>
+
+<a id="schemadiagnosisagecountschema"></a>
+<a id="schema_DiagnosisAgeCountSchema"></a>
+<a id="tocSdiagnosisagecountschema"></a>
+<a id="tocsdiagnosisagecountschema"></a>
+
+```json
+{
+  "age_at_diagnosis": "string",
+  "age_count": "string"
+}
+
+```
+
+DiagnosisAgeCountSchema
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|age_at_diagnosis|string|true|none|none|
+|age_count|string|true|none|none|
 
 <h2 id="tocS_DonorExplorerFilterSchema">DonorExplorerFilterSchema</h2>
 

--- a/chord_metadata_service/mohpackets/docs/schema.md
+++ b/chord_metadata_service/mohpackets/docs/schema.md
@@ -1,7 +1,7 @@
 
 <h1 id="moh-service-api">MoH Service API v4.2.1</h1>
 
-This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/52d470cfd8a3fd5c2b60f7145204a19066e783f2/chord_metadata_service/mohpackets/docs/schema.json
+This is the RESTful API for the MoH Service.
 
 Base URLs:
 

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -628,16 +628,31 @@ components:
       - month_interval
       title: DateInterval
       type: object
-    DiscoverySchema:
+    DiagnosisAgeCountSchema:
       properties:
-        donors_by_cohort:
-          additionalProperties:
-            type: integer
-          title: Donors By Cohort
-          type: object
+        age_at_diagnosis:
+          title: Age At Diagnosis
+          type: string
+        age_count:
+          title: Age Count
+          type: string
       required:
-      - donors_by_cohort
-      title: DiscoverySchema
+      - age_at_diagnosis
+      - age_count
+      title: DiagnosisAgeCountSchema
+      type: object
+    DiscoveryDonorSchema:
+      properties:
+        donors_count:
+          title: Donors Count
+          type: string
+        program_id:
+          title: Program Id
+          type: string
+      required:
+      - program_id
+      - donors_count
+      title: DiscoveryDonorSchema
       type: object
     DiseaseStatusFollowupEnum:
       enum:
@@ -1371,6 +1386,21 @@ components:
       - program_id
       - submitter_donor_id
       title: FollowUpModelSchema
+      type: object
+    GenderCountSchema:
+      properties:
+        gender:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Gender
+        gender_count:
+          title: Gender Count
+          type: string
+      required:
+      - gender
+      - gender_count
+      title: GenderCountSchema
       type: object
     GenderEnum:
       enum:
@@ -2994,6 +3024,19 @@ components:
       - previous_page
       title: PagedTreatmentModelSchema
       type: object
+    PatientPerCohortSchema:
+      properties:
+        patients_count:
+          title: Patients Count
+          type: string
+        program_id:
+          title: Program Id
+          type: string
+      required:
+      - program_id
+      - patients_count
+      title: PatientPerCohortSchema
+      type: object
     PercentCellsRangeEnum:
       enum:
       - 0-19%
@@ -3239,6 +3282,19 @@ components:
       - program_id
       - submitter_donor_id
       title: PrimaryDiagnosisModelSchema
+      type: object
+    PrimarySiteCountSchema:
+      properties:
+        primary_site_count:
+          title: Primary Site Count
+          type: string
+        primary_site_name:
+          title: Primary Site Name
+          type: string
+      required:
+      - primary_site_name
+      - primary_site_count
+      title: PrimarySiteCountSchema
       type: object
     PrimarySiteEnum:
       enum:
@@ -5228,6 +5284,19 @@ components:
       - Unknown
       title: TreatmentStatusEnum
       type: string
+    TreatmentTypeCountSchema:
+      properties:
+        treatment_type_count:
+          title: Treatment Type Count
+          type: string
+        treatment_type_name:
+          title: Treatment Type Name
+          type: string
+      required:
+      - treatment_type_name
+      - treatment_type_count
+      title: TreatmentTypeCountSchema
+      type: object
     TreatmentTypeEnum:
       enum:
       - Bone marrow transplant
@@ -5344,7 +5413,7 @@ components:
       name: X-Service-Token
       type: apiKey
 info:
-  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/a5656164c539273637fe7ae7709f41d61bf86ced/chord_metadata_service/mohpackets/docs/schema.json
+  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/52d470cfd8a3fd5c2b60f7145204a19066e783f2/chord_metadata_service/mohpackets/docs/schema.json
   title: MoH Service API
   version: 4.2.1
 openapi: 3.1.0
@@ -7201,210 +7270,24 @@ paths:
       summary: List Treatments
       tags:
       - authorized
-  /v2/discovery/biomarkers/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_biomarkers
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Biomarkers
-      tags:
-      - discovery
-  /v2/discovery/chemotherapies/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_chemotherapies
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Chemotherapies
-      tags:
-      - discovery
-  /v2/discovery/comorbidities/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_comorbidities
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Comorbidities
-      tags:
-      - discovery
   /v2/discovery/donors/:
     get:
+      description: Return the number of donors per cohort in the database.
       operationId: chord_metadata_service_mohpackets_apis_discovery_discover_donors
-      parameters:
-      - in: query
-        name: submitter_donor_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Donor Id
-      - in: query
-        name: program_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Program Id
-      - in: query
-        name: gender
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          q: gender__icontains
-          title: Gender
-      - in: query
-        name: sex_at_birth
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Sex At Birth
-      - in: query
-        name: is_deceased
-        required: false
-        schema:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          title: Is Deceased
-      - in: query
-        name: lost_to_followup_after_clinical_event_identifier
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Lost To Followup After Clinical Event Identifier
-      - in: query
-        name: lost_to_followup_reason
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Lost To Followup Reason
-      - in: query
-        name: cause_of_death
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cause Of Death
-      - in: query
-        name: primary_site
-        required: false
-        schema:
-          items:
-            type: string
-          q: primary_site__overlap
-          title: Primary Site
-          type: array
+      parameters: []
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DiscoverySchema'
+                items:
+                  $ref: '#/components/schemas/DiscoveryDonorSchema'
+                title: Response
+                type: array
           description: OK
       summary: Discover Donors
       tags:
       - discovery
-  /v2/discovery/exposures/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_exposures
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Exposures
-      tags:
-      - discovery
-  /v2/discovery/follow_ups/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_follow_ups
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Follow Ups
-      tags:
-      - discovery
-  /v2/discovery/hormone_therapies/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_hormone_therapies
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Hormone Therapies
-      tags:
-      - discovery
-  /v2/discovery/immunotherapies/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_immunotherapies
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Immunotherapies
-      tags:
-      - discovery
-  /v2/discovery/overview/cancer_type_count/:
-    get:
-      description: Return the count for every cancer type in the database.
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_cancer_type_count
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: integer
-                title: Response
-                type: object
-          description: OK
-      summary: Discover Cancer Type Count
-      tags:
-      - overview
   /v2/discovery/overview/cohort_count/:
     get:
       description: Return the number of cohorts in the database.
@@ -7434,10 +7317,10 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties:
-                  type: integer
+                items:
+                  $ref: '#/components/schemas/DiagnosisAgeCountSchema'
                 title: Response
-                type: object
+                type: array
           description: OK
       summary: Discover Diagnosis Age Count
       tags:
@@ -7452,10 +7335,10 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties:
-                  type: integer
+                items:
+                  $ref: '#/components/schemas/GenderCountSchema'
                 title: Response
-                type: object
+                type: array
           description: OK
       summary: Discover Gender Count
       tags:
@@ -7471,7 +7354,7 @@ paths:
             application/json:
               schema:
                 additionalProperties:
-                  type: integer
+                  type: string
                 title: Response
                 type: object
           description: OK
@@ -7488,12 +7371,30 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties:
-                  type: integer
+                items:
+                  $ref: '#/components/schemas/PatientPerCohortSchema'
                 title: Response
-                type: object
+                type: array
           description: OK
       summary: Discover Patients Per Cohort
+      tags:
+      - overview
+  /v2/discovery/overview/primary_site_count/:
+    get:
+      description: Return the count for every cancer type in the database.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_primary_site_count
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PrimarySiteCountSchema'
+                title: Response
+                type: array
+          description: OK
+      summary: Discover Primary Site Count
       tags:
       - overview
   /v2/discovery/overview/treatment_type_count/:
@@ -7506,30 +7407,17 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties:
-                  type: integer
+                items:
+                  $ref: '#/components/schemas/TreatmentTypeCountSchema'
                 title: Response
-                type: object
+                type: array
           description: OK
       summary: Discover Treatment Type Count
       tags:
       - overview
-  /v2/discovery/primary_diagnoses/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_primary_diagnoses
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Primary Diagnoses
-      tags:
-      - discovery
   /v2/discovery/programs/:
     get:
+      description: Return all the programs in the database.
       operationId: chord_metadata_service_mohpackets_apis_discovery_discover_programs
       parameters: []
       responses:
@@ -7543,34 +7431,6 @@ paths:
                 type: array
           description: OK
       summary: Discover Programs
-      tags:
-      - discovery
-  /v2/discovery/radiations/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_radiations
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Radiations
-      tags:
-      - discovery
-  /v2/discovery/sample_registrations/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_sample_registrations
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Sample Registrations
       tags:
       - discovery
   /v2/discovery/sidebar_list/:
@@ -7590,48 +7450,6 @@ paths:
                 type: object
           description: OK
       summary: Discover Sidebar List
-      tags:
-      - discovery
-  /v2/discovery/specimen/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_specimens
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Specimens
-      tags:
-      - discovery
-  /v2/discovery/surgeries/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_surgeries
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Surgeries
-      tags:
-      - discovery
-  /v2/discovery/treatments/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_treatments
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiscoverySchema'
-          description: OK
-      summary: Discover Treatments
       tags:
       - discovery
   /v2/explorer/donors/:

--- a/chord_metadata_service/mohpackets/docs/schema.yml
+++ b/chord_metadata_service/mohpackets/docs/schema.yml
@@ -5413,7 +5413,7 @@ components:
       name: X-Service-Token
       type: apiKey
 info:
-  description: This is the RESTful API for the MoH Service. Based on https://raw.githubusercontent.com/CanDIG/katsu/52d470cfd8a3fd5c2b60f7145204a19066e783f2/chord_metadata_service/mohpackets/docs/schema.json
+  description: This is the RESTful API for the MoH Service.
   title: MoH Service API
   version: 4.2.1
 openapi: 3.1.0

--- a/chord_metadata_service/mohpackets/schemas/discovery.py
+++ b/chord_metadata_service/mohpackets/schemas/discovery.py
@@ -1,6 +1,6 @@
-from typing import Dict
-from ninja import Schema
+from typing import Optional
 
+from ninja import Schema
 
 """
 Module with schema used for discovery response
@@ -14,5 +14,35 @@ class ProgramDiscoverySchema(Schema):
     metadata: object
 
 
-class DiscoverySchema(Schema):
-    donors_by_cohort: Dict[str, int]
+# class DiscoverySchema(Schema):
+#     donors_by_cohort: Dict[str, int]
+
+
+class DiscoveryDonorSchema(Schema):
+    program_id: str
+    donors_count: str
+
+
+class PatientPerCohortSchema(Schema):
+    program_id: str
+    patients_count: str
+
+
+class GenderCountSchema(Schema):
+    gender: Optional[str]
+    gender_count: str
+
+
+class PrimarySiteCountSchema(Schema):
+    primary_site_name: str
+    primary_site_count: str
+
+
+class TreatmentTypeCountSchema(Schema):
+    treatment_type_name: str
+    treatment_type_count: str
+
+
+class DiagnosisAgeCountSchema(Schema):
+    age_at_diagnosis: str
+    age_count: str

--- a/chord_metadata_service/mohpackets/tests/endpoints/factories.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/factories.py
@@ -73,16 +73,20 @@ class DonorFactory(factory.django.DjangoModelFactory):
         ),
         no_declaration=None,
     )
-    date_of_birth = {
-        "month_interval": random.randint(0, 100),
-        "day_interval": random.randint(0, 300),
-    }
+    date_of_birth = factory.LazyFunction(
+        lambda: {
+            "month_interval": random.randint(0, 1000),
+            "day_interval": random.randint(0, 3000),
+        }
+    )
     date_of_death = factory.Maybe(
         "is_deceased",
-        yes_declaration={
-            "month_interval": random.randint(0, 100),
-            "day_interval": random.randint(0, 300),
-        },
+        yes_declaration=factory.LazyFunction(
+            lambda: {
+                "month_interval": random.randint(0, 1000),
+                "day_interval": random.randint(0, 3000),
+            }
+        ),
         no_declaration=None,
     )
     primary_site = factory.Faker(
@@ -103,10 +107,12 @@ class PrimaryDiagnosisFactory(factory.django.DjangoModelFactory):
 
     # Default values
     submitter_primary_diagnosis_id = factory.Sequence(lambda n: "DIAG_%d" % n)
-    date_of_diagnosis = {
-        "month_interval": random.randint(0, 100),
-        "day_interval": random.randint(0, 300),
-    }
+    date_of_diagnosis = factory.LazyFunction(
+        lambda: {
+            "month_interval": random.randint(0, 1000),
+            "day_interval": random.randint(0, 3000),
+        }
+    )
     cancer_type_code = factory.Faker("uuid4")
     basis_of_diagnosis = factory.Faker(
         "random_element", elements=PERM_VAL.BASIS_OF_DIAGNOSIS
@@ -147,8 +153,8 @@ class PrimaryDiagnosisFactory(factory.django.DjangoModelFactory):
                 PERM_VAL.LOST_TO_FOLLOWUP_REASON
             )
             donor.date_alive_after_lost_to_followup = {
-                "month_interval": random.randint(0, 100),
-                "day_interval": random.randint(0, 300),
+                "month_interval": random.randint(0, 1000),
+                "day_interval": random.randint(0, 3000),
             }
             donor.save()
 

--- a/chord_metadata_service/mohpackets/tests/endpoints/factories.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/factories.py
@@ -39,6 +39,8 @@ from chord_metadata_service.mohpackets.models import (
     Note:
         These factories use the Factory Boy library (https://factoryboy.readthedocs.io/)
         to generate test data.
+        Some business logic is not strictly enforced. For example,
+        date_of_birth could have mismatched month_interval and day_interval.
 
     Author: Son Chau
 """

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_overview.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_overview.py
@@ -1,0 +1,203 @@
+from http import HTTPStatus
+
+import chord_metadata_service.mohpackets.permissible_values as PERM_VAL
+from chord_metadata_service.mohpackets.models import Donor, Treatment
+from chord_metadata_service.mohpackets.tests.endpoints.base import BaseTestCase
+from chord_metadata_service.mohpackets.tests.endpoints.factories import (
+    DonorFactory,
+    TreatmentFactory,
+)
+
+"""
+    This module contains API tests related to overview endpoints.
+
+    It includes tests for:
+    - Displaying actual number if data >5
+    - Censoring if data <5
+
+    Author: Son Chau
+"""
+
+
+class OverviewTestCase(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.patients_per_cohort_url = "/v2/discovery/overview/patients_per_cohort/"
+        self.individual_count_url = "/v2/discovery/overview/individual_count/"
+        self.gender_count_url = "/v2/discovery/overview/gender_count/"
+        self.primary_site_count_url = "/v2/discovery/overview/primary_site_count/"
+        self.treatment_type_count_url = "/v2/discovery/overview/treatment_type_count/"
+        self.diagnosis_age_count_url = "/v2/discovery/overview/diagnosis_age_count/"
+        self.discover_donors_url = "/v2/discovery/donors/"
+        # The default dataset are <5 so we need to add 5 more donors
+        # and 5 more treatments to display data >5
+        self.gender_man = PERM_VAL.GENDER[0]  # Man
+        self.primary_site_sinus = PERM_VAL.PRIMARY_SITE[0]  # Accessory sinuses
+        self.treatment_type_bone = PERM_VAL.TREATMENT_TYPE[0]  # Bone marrow transplant
+        self.donors.extend(
+            DonorFactory.create_batch(
+                5,
+                program_id=self.programs[0],
+                gender=self.gender_man,
+                primary_site=[self.primary_site_sinus],
+                date_of_birth={"month_interval": 840},  # 70-79 age
+            )
+        )
+        self.treatments.extend(
+            TreatmentFactory.create_batch(
+                5,
+                primary_diagnosis_uuid=self.primary_diagnoses[0],
+                treatment_type=[self.treatment_type_bone],
+            )
+        )
+
+    def test_individual_count_api_no_censoring(self):
+        """
+        Verify individual_count endpoint does not censor number >5.
+
+        Testing Strategy:
+        - Total number of donors is 9
+        - Send a request to individual_count endpoint
+        - Ensure that the response show the full number
+        """
+        response = self.client.get(self.individual_count_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        individual_count_value = response.json()["individual_count"]
+        self.assertGreaterEqual(len(self.donors), 5)
+        self.assertEqual(individual_count_value, str(len(self.donors)))
+
+    def test_individual_count_api_censoring(self):
+        """
+        Verify individual_count endpoint censoring for small datasets.
+
+        Testing Strategy:
+        - Remove some donors (total count is 2 now)
+        - Send a request to individual_count endpoint.
+        - Ensure that the response does not reveal the number when it is less than 5.
+        """
+        Donor.objects.filter(program_id=self.programs[0]).delete()
+        donors = Donor.objects.all()
+        response = self.client.get(self.individual_count_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        individual_count_value = response.json()["individual_count"]
+        self.assertLess(len(donors), 5)
+        self.assertEqual(individual_count_value, "<5")
+
+    def test_patients_per_cohort_api_censoring(self):
+        """
+        Verify the censoring of patient counts per cohort endpoint.
+
+        Testing Strategy:
+        - Program 0 has 7, Program 1 has 2 donors
+        - Send a request to patients_per_cohort endpoint.
+        - Ensure that the response does not reveal the number when it is less than 5 donors.
+        """
+        response = self.client.get(self.patients_per_cohort_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        for item in response.json():
+            patients_count_value = item["patients_count"]
+            patients_count = Donor.objects.filter(program_id=item["program_id"]).count()
+            if patients_count < 5:
+                self.assertEqual(patients_count_value, "<5")
+            else:
+                self.assertEqual(patients_count_value, str(patients_count))
+
+    def test_gender_count_api_censoring(self):
+        """
+        Test gender count API censoring for small datasets.
+
+        Testing Strategy:
+        - "Man" gender is greater or equal to 5
+        - Other genders is less than 5
+        - Send a request to gender_count endpoint.
+        - Ensure that the response does not reveal the count when it is less than 5.
+        """
+
+        response = self.client.get(self.gender_count_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        for item in response.json():
+            gender_count_value = item["gender_count"]
+            gender_count = Donor.objects.filter(gender=item["gender"]).count()
+            if gender_count < 5:
+                self.assertEqual(gender_count_value, "<5")
+            else:
+                self.assertEqual(gender_count_value, str(gender_count))
+
+    def test_primary_site_count_api_censoring(self):
+        """
+        Test primary site count API censoring for small datasets.
+
+        Testing Strategy:
+        - "Accessory sinuses" primary site is greater or equal to 5
+        - Other primary site is less than 5
+        - Send a request to primary_site_count endpoint.
+        - Ensure that the response does not reveal the count when it is less than 5.
+        """
+        response = self.client.get(self.primary_site_count_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        for item in response.json():
+            primary_site_count_value = item["primary_site_count"]
+            primary_site_count = Donor.objects.filter(
+                primary_site__contains=[item["primary_site_name"]]
+            ).count()
+            if primary_site_count < 5:
+                self.assertEqual(primary_site_count_value, "<5")
+            else:
+                self.assertEqual(primary_site_count_value, str(primary_site_count))
+
+    def test_treatment_type_count_api_censoring(self):
+        """
+        Test treatment type count count API censoring for small datasets.
+
+        Testing Strategy:
+        - "Bone marrow transplant" treatment type is greater or equal to 5
+        - Other treatment type should be less than 5 (but might not since randomized)
+        - Send a request to treatment_type_count endpoint.
+        - Ensure that the response does not reveal the count when it is less than 5.
+        """
+        response = self.client.get(self.treatment_type_count_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        for item in response.json():
+            treatment_type_count_value = item["treatment_type_count"]
+            treatment_type_count = Treatment.objects.filter(
+                treatment_type__contains=[item["treatment_type_name"]]
+            ).count()
+            if treatment_type_count < 5:
+                self.assertEqual(treatment_type_count_value, "<5")
+            else:
+                self.assertEqual(treatment_type_count_value, str(treatment_type_count))
+
+    def test_diagnosis_age_count_api_censoring(self):
+        """
+        Test diagnosis age count count API censoring for small datasets.
+
+        Testing Strategy:
+        - "70-79" age bracket is greater or equal to 5
+        - Other age bracket is less than 5
+        - Send a request to diagnosis_age_count endpoint.
+        - Ensure that the response does not reveal the count when it is less than 5.
+        """
+        response = self.client.get(self.diagnosis_age_count_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        for item in response.json():
+            if item["age_at_diagnosis"] != "70-79":
+                self.assertEqual(item["age_count"], "<5")
+
+    def test_discover_donors_api_censoring(self):
+        """
+        Test discovery donor API censoring for small datasets.
+
+        Testing Strategy:
+        - Program 0 has 7, Program 1 has 2 donors
+        - Send a request to discovery donors endpoint.
+        - Ensure that the response does not reveal the count when it is less than 5.
+        """
+        response = self.client.get(self.discover_donors_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        for item in response.json():
+            donors_count_value = item["donors_count"]
+            donors_count = Donor.objects.filter(program_id=item["program_id"]).count()
+            if donors_count < 5:
+                self.assertEqual(donors_count_value, "<5")
+            else:
+                self.assertEqual(donors_count_value, str(donors_count))

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -147,4 +147,4 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # CURRENT KATSU VERSION ACCORDING TO MODEL CHANGES
 # ------------------------------------------------
 
-KATSU_VERSION = "4.2.1"
+KATSU_VERSION = "4.3.0"

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -14,7 +14,6 @@ from os.path import exists
 
 from .base import *
 
-# Required environment variables
 required_env_vars = [
     "HOST_CONTAINER_NAME",
     "EXTERNAL_URL",
@@ -28,7 +27,6 @@ required_env_vars = [
     "REDIS_PASSWORD_FILE",
 ]
 
-# Check for missing environment variables
 missing_vars = [var for var in required_env_vars if not os.getenv(var)]
 if missing_vars:
     raise EnvironmentError(

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -14,16 +14,37 @@ from os.path import exists
 
 from .base import *
 
+# Required environment variables
+required_env_vars = [
+    "HOST_CONTAINER_NAME",
+    "EXTERNAL_URL",
+    "AGGREGATE_COUNT_THRESHOLD",
+    "OPA_URL",
+    "POSTGRES_DATABASE",
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD_FILE",
+    "POSTGRES_HOST",
+    "POSTGRES_PORT",
+    "REDIS_PASSWORD_FILE",
+]
+
+# Check for missing environment variables
+missing_vars = [var for var in required_env_vars if not os.getenv(var)]
+if missing_vars:
+    raise EnvironmentError(
+        f"Missing required environment variables: {', '.join(missing_vars)}"
+    )
+
 DEBUG = True
 
 ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
-    os.environ.get("HOST_CONTAINER_NAME"),
-    os.environ.get("EXTERNAL_URL"),
-    "query"
+    os.environ["HOST_CONTAINER_NAME"],
+    os.environ["EXTERNAL_URL"],
+    "query",
 ]
-AGGREGATE_COUNT_THRESHOLD = os.environ.get("AGGREGATE_COUNT_THRESHOLD")
+AGGREGATE_COUNT_THRESHOLD = os.environ["AGGREGATE_COUNT_THRESHOLD"]
 
 # Debug toolbar settings
 # ----------------------
@@ -31,8 +52,8 @@ INSTALLED_APPS.append("debug_toolbar")
 MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
 INTERNAL_IPS = type("c", (), {"__contains__": lambda *a: True})()
 DEBUG_TOOLBAR_CONFIG = {
-    'RENDER_PANELS': False,
-    'RESULTS_CACHE_SIZE': 100,
+    "RENDER_PANELS": False,
+    "RESULTS_CACHE_SIZE": 100,
 }
 
 # Whitenoise
@@ -42,7 +63,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # CANDIG SETTINGS
 # ---------------
-CANDIG_OPA_URL = os.getenv("OPA_URL")
+CANDIG_OPA_URL = os.environ["OPA_URL"]
 CACHE_DURATION = int(os.getenv("CACHE_DURATION", 86400))  # default to 1 day
 CONN_MAX_AGE = int(os.getenv("CONN_MAX_AGE", 0))
 if exists("/run/secrets/opa-service-token"):
@@ -70,11 +91,11 @@ def get_secret(path):
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.environ.get("POSTGRES_DATABASE"),
-        "USER": os.environ.get("POSTGRES_USER"),
-        "PASSWORD": get_secret(os.environ.get("POSTGRES_PASSWORD_FILE")),
-        "HOST": os.environ.get("POSTGRES_HOST"),
-        "PORT": os.environ.get("POSTGRES_PORT"),
+        "NAME": os.environ["POSTGRES_DATABASE"],
+        "USER": os.environ["POSTGRES_USER"],
+        "PASSWORD": get_secret(os.environ["POSTGRES_PASSWORD_FILE"]),
+        "HOST": os.environ["POSTGRES_HOST"],
+        "PORT": os.environ["POSTGRES_PORT"],
     }
 }
 
@@ -83,7 +104,7 @@ DATABASES = {
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": f"redis://:{get_secret(os.environ.get('REDIS_PASSWORD_FILE'))}@{os.environ.get('EXTERNAL_URL')}:6379/1",
+        "LOCATION": f"redis://:{get_secret(os.environ['REDIS_PASSWORD_FILE'])}@{os.environ['EXTERNAL_URL']}:6379/1",
         "TIMEOUT": CACHE_DURATION,
     }
 }

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -23,6 +23,7 @@ ALLOWED_HOSTS = [
     os.environ.get("EXTERNAL_URL"),
     "query"
 ]
+AGGREGATE_COUNT_THRESHOLD = os.environ.get("AGGREGATE_COUNT_THRESHOLD")
 
 # Debug toolbar settings
 # ----------------------

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -17,6 +17,7 @@ from .base import *
 DEBUG = True
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
+AGGREGATE_COUNT_THRESHOLD = 5
 
 # Debug toolbar settings
 # ----------------------

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -16,6 +16,7 @@ ALLOWED_HOSTS = [
     os.environ.get("CANDIG_INTERNAL_DOMAIN"),
     "query"
 ]
+AGGREGATE_COUNT_THRESHOLD = os.environ.get("AGGREGATE_COUNT_THRESHOLD")
 
 # Whitenoise
 # ----------

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -10,7 +10,6 @@ from os.path import exists
 
 from .base import *
 
-# Required environment variables
 required_env_vars = [
     "HOST_CONTAINER_NAME",
     "EXTERNAL_URL",
@@ -25,7 +24,6 @@ required_env_vars = [
     "REDIS_PASSWORD_FILE",
 ]
 
-# Check for missing environment variables
 missing_vars = [var for var in required_env_vars if not os.getenv(var)]
 if missing_vars:
     raise EnvironmentError(

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -31,9 +31,9 @@ if missing_vars:
     )
 
 ALLOWED_HOSTS = [
-    os.environ.get("HOST_CONTAINER_NAME"),
-    os.environ.get("EXTERNAL_URL"),
-    os.environ.get("CANDIG_INTERNAL_DOMAIN"),
+    os.environ["HOST_CONTAINER_NAME"],
+    os.environ["EXTERNAL_URL"],
+    os.environ["CANDIG_INTERNAL_DOMAIN"],
     "127.0.0.1",
     "query",
 ]


### PR DESCRIPTION
## What's new
- Introduce a threshold mechanism to display masked values for small counts, e.g., "<5".
- Rewrite queries for masking and improved performance.
- Update return types from int to str to handle masked values.
- Update schema return structure to accommodate new queries.
- Rename `discover_cancer_type_count` to `discover_primary_site_count`
- Use lazyFunction for enhanced random seeds in testing
- Add a test suite to ensure proper functionality of overview masking for small counts.

### Types of Change(s)
- [x] ✨ New feature 
- [x] 💥 Breaking change

Which other services does it affect?
- [x] data-portal
- [x] query

### Has it been tested for:
- [x] Locally tested
- [x] Docker tested

### How to test
- For local, run tox
- For docker, pull this branch, add to docker-compose ` AGGREGATE_COUNT_THRESHOLD=${AGGREGATE_COUNT_THRESHOLD}` and run test-integration
- Optional: Add some data and call overview endpoints to see if value <5 gets properly masked.