### PR TITLE
Do not log service-info (prevent health check flooding)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER root
 RUN groupadd -r candig && useradd -r -g candig candig
 
 RUN apt-get update && apt-get -y install \
-	postgresql-client
+	postgresql-client libpcre3 libpcre3-dev
 	
 RUN mkdir /app
 WORKDIR /app

--- a/katsu_wsgi.ini
+++ b/katsu_wsgi.ini
@@ -21,3 +21,5 @@ http-socket = 0.0.0.0:8000
 # Set the user and group
 uid = candig
 gid = candig
+
+route = /service-info donotlog:


### PR DESCRIPTION
**Requires the `bugfix/silence-service-info` branch from the main CanDIGv2 repo, in order to fix the health check.**

# Description
This prevents uwsgi from logging calls to /service-info endpoints, which should silence the flood of messages from health checks.