### PR TITLE
DIG-1635 : Allow ingest to be completed in batches per object

### DIFF
--- a/chord_metadata_service/mohpackets/apis/ingestion.py
+++ b/chord_metadata_service/mohpackets/apis/ingestion.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Type
+from typing import Type, List
 
 from django.http import HttpResponse, JsonResponse
 from ninja import Router
@@ -48,104 +48,123 @@ Author: Son Chau
 
 router = Router()
 
-
-def create_instance(payload, model_cls: Type):
+def create_instances(payloads: List, model_cls: Type):
+    instances = []
     try:
-        instance = model_cls.objects.create(**payload.dict())
+        for item in payloads:
+            instance = model_cls.objects.create(**item.dict())
+            instances.append(instance)
     except Exception as e:
         return JsonResponse(
             status=HTTPStatus.BAD_REQUEST,
             data={"error": str(e)},
         )
 
+    created_instances = [str(instance) for instance in instances]
     return JsonResponse(
         status=HTTPStatus.CREATED,
-        data={"created": str(instance)},
+        data={"created": created_instances},
     )
 
 
-@router.post("/program/")
-def create_program(request, payload: ProgramIngestSchema, response: HttpResponse):
-    return create_instance(payload, Program)
-
-
-@router.post("/donor/")
-def create_donor(request, payload: DonorIngestSchema, response: HttpResponse):
-    return create_instance(payload, Donor)
-
-
-@router.post("/biomarker/")
-def create_biomarker(request, payload: BiomarkerIngestSchema, response: HttpResponse):
-    return create_instance(payload, Biomarker)
-
-
-@router.post("/chemotherapy/")
-def create_chemotherapy(
-    request, payload: ChemotherapyIngestSchema, response: HttpResponse
+@router.post("/programs/")
+def create_programs(
+    request, payloads: List[ProgramIngestSchema], response: HttpResponse
 ):
-    return create_instance(payload, Chemotherapy)
+    return create_instances(payloads, Program)
 
 
-@router.post("/comorbidity/")
-def create_comorbidity(
-    request, payload: ComorbidityIngestSchema, response: HttpResponse
+@router.post("/donors/")
+def create_donors(request, payloads: List[DonorIngestSchema], response: HttpResponse):
+    return create_instances(payloads, Donor)
+
+
+@router.post("/biomarkers/")
+def create_biomarkers(
+    request, payloads: List[BiomarkerIngestSchema], response: HttpResponse
 ):
-    return create_instance(payload, Comorbidity)
+    return create_instances(payloads, Biomarker)
 
 
-@router.post("/exposure/")
-def create_exposure(request, payload: ExposureIngestSchema, response: HttpResponse):
-    return create_instance(payload, Exposure)
-
-
-@router.post("/follow_up/")
-def create_follow_up(request, payload: FollowUpIngestSchema, response: HttpResponse):
-    return create_instance(payload, FollowUp)
-
-
-@router.post("/hormone_therapy/")
-def create_hormone_therapy(
-    request, payload: HormoneTherapyIngestSchema, response: HttpResponse
+@router.post("/chemotherapies/")
+def create_chemotherapies(
+    request, payloads: List[ChemotherapyIngestSchema], response: HttpResponse
 ):
-    return create_instance(payload, HormoneTherapy)
+    return create_instances(payloads, Chemotherapy)
 
 
-@router.post("/immunotherapy/")
-def create_immunotherapy(
-    request, payload: ImmunotherapyIngestSchema, response: HttpResponse
+@router.post("/comorbidities/")
+def create_comorbidities(
+    request, payloads: List[ComorbidityIngestSchema], response: HttpResponse
 ):
-    return create_instance(payload, Immunotherapy)
+    return create_instances(payloads, Comorbidity)
 
 
-@router.post("/primary_diagnosis/")
-def create_primary_diagnosis(
-    request, payload: PrimaryDiagnosisIngestSchema, response: HttpResponse
+@router.post("/exposures/")
+def create_exposures(
+    request, payloads: List[ExposureIngestSchema], response: HttpResponse
 ):
-    return create_instance(payload, PrimaryDiagnosis)
+    return create_instances(payloads, Exposure)
 
 
-@router.post("/radiation/")
-def create_radiation(request, payload: RadiationIngestSchema, response: HttpResponse):
-    return create_instance(payload, Radiation)
-
-
-@router.post("/sample_registration/")
-def create_sample_registration(
-    request, payload: SampleRegistrationIngestSchema, response: HttpResponse
+@router.post("/followups/")
+def create_followups(
+    request, payloads: List[FollowUpIngestSchema], response: HttpResponse
 ):
-    return create_instance(payload, SampleRegistration)
+    return create_instances(payloads, FollowUp)
 
 
-@router.post("/specimen/")
-def create_specimen(request, payload: SpecimenIngestSchema, response: HttpResponse):
-    return create_instance(payload, Specimen)
+@router.post("/hormone_therapies/")
+def create_hormone_therapies(
+    request, payloads: List[HormoneTherapyIngestSchema], response: HttpResponse
+):
+    return create_instances(payloads, HormoneTherapy)
 
 
-@router.post("/surgery/")
-def create_surgery(request, payload: SurgeryIngestSchema, response: HttpResponse):
-    return create_instance(payload, Surgery)
+@router.post("/immunotherapies/")
+def create_immunotherapies(
+    request, payloads: List[ImmunotherapyIngestSchema], response: HttpResponse
+):
+    return create_instances(payloads, Immunotherapy)
 
 
-@router.post("/treatment/")
-def create_treatment(request, payload: TreatmentIngestSchema, response: HttpResponse):
-    return create_instance(payload, Treatment)
+@router.post("/primary_diagnoses/")
+def create_primary_diagnoses(
+    request, payloads: List[PrimaryDiagnosisIngestSchema], response: HttpResponse
+):
+    return create_instances(payloads, PrimaryDiagnosis)
+
+
+@router.post("/radiations/")
+def create_radiations(
+    request, payloads: List[RadiationIngestSchema], response: HttpResponse
+):
+    return create_instances(payloads, Radiation)
+
+
+@router.post("/sample_registrations/")
+def create_sample_registrations(
+    request, payloads: List[SampleRegistrationIngestSchema], response: HttpResponse
+):
+    return create_instances(payloads, SampleRegistration)
+
+
+@router.post("/specimens/")
+def create_specimens(
+    request, payloads: List[SpecimenIngestSchema], response: HttpResponse
+):
+    return create_instances(payloads, Specimen)
+
+
+@router.post("/surgeries/")
+def create_surgeries(
+    request, payloads: List[SurgeryIngestSchema], response: HttpResponse
+):
+    return create_instances(payloads, Surgery)
+
+
+@router.post("/treatments/")
+def create_treatments(
+    request, payloads: List[TreatmentIngestSchema], response: HttpResponse
+):
+    return create_instances(payloads, Treatment)

--- a/chord_metadata_service/mohpackets/apis/ingestion.py
+++ b/chord_metadata_service/mohpackets/apis/ingestion.py
@@ -48,6 +48,7 @@ Author: Son Chau
 
 router = Router()
 
+
 def create_instances(payloads: List, model_cls: Type):
     instances = []
     try:

--- a/chord_metadata_service/mohpackets/apis/ingestion.py
+++ b/chord_metadata_service/mohpackets/apis/ingestion.py
@@ -49,10 +49,10 @@ Author: Son Chau
 router = Router()
 
 
-def create_instances(payloads: List, model_cls: Type):
+def create_instances(payload: List, model_cls: Type):
     instances = []
     try:
-        for item in payloads:
+        for item in payload:
             instance = model_cls.objects.create(**item.dict())
             instances.append(instance)
     except Exception as e:
@@ -70,102 +70,102 @@ def create_instances(payloads: List, model_cls: Type):
 
 @router.post("/programs/")
 def create_programs(
-    request, payloads: List[ProgramIngestSchema], response: HttpResponse
+    request, payload: List[ProgramIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Program)
+    return create_instances(payload, Program)
 
 
 @router.post("/donors/")
-def create_donors(request, payloads: List[DonorIngestSchema], response: HttpResponse):
-    return create_instances(payloads, Donor)
+def create_donors(request, payload: List[DonorIngestSchema], response: HttpResponse):
+    return create_instances(payload, Donor)
 
 
 @router.post("/biomarkers/")
 def create_biomarkers(
-    request, payloads: List[BiomarkerIngestSchema], response: HttpResponse
+    request, payload: List[BiomarkerIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Biomarker)
+    return create_instances(payload, Biomarker)
 
 
 @router.post("/chemotherapies/")
 def create_chemotherapies(
-    request, payloads: List[ChemotherapyIngestSchema], response: HttpResponse
+    request, payload: List[ChemotherapyIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Chemotherapy)
+    return create_instances(payload, Chemotherapy)
 
 
 @router.post("/comorbidities/")
 def create_comorbidities(
-    request, payloads: List[ComorbidityIngestSchema], response: HttpResponse
+    request, payload: List[ComorbidityIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Comorbidity)
+    return create_instances(payload, Comorbidity)
 
 
 @router.post("/exposures/")
 def create_exposures(
-    request, payloads: List[ExposureIngestSchema], response: HttpResponse
+    request, payload: List[ExposureIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Exposure)
+    return create_instances(payload, Exposure)
 
 
 @router.post("/followups/")
 def create_followups(
-    request, payloads: List[FollowUpIngestSchema], response: HttpResponse
+    request, payload: List[FollowUpIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, FollowUp)
+    return create_instances(payload, FollowUp)
 
 
 @router.post("/hormone_therapies/")
 def create_hormone_therapies(
-    request, payloads: List[HormoneTherapyIngestSchema], response: HttpResponse
+    request, payload: List[HormoneTherapyIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, HormoneTherapy)
+    return create_instances(payload, HormoneTherapy)
 
 
 @router.post("/immunotherapies/")
 def create_immunotherapies(
-    request, payloads: List[ImmunotherapyIngestSchema], response: HttpResponse
+    request, payload: List[ImmunotherapyIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Immunotherapy)
+    return create_instances(payload, Immunotherapy)
 
 
 @router.post("/primary_diagnoses/")
 def create_primary_diagnoses(
-    request, payloads: List[PrimaryDiagnosisIngestSchema], response: HttpResponse
+    request, payload: List[PrimaryDiagnosisIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, PrimaryDiagnosis)
+    return create_instances(payload, PrimaryDiagnosis)
 
 
 @router.post("/radiations/")
 def create_radiations(
-    request, payloads: List[RadiationIngestSchema], response: HttpResponse
+    request, payload: List[RadiationIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Radiation)
+    return create_instances(payload, Radiation)
 
 
 @router.post("/sample_registrations/")
 def create_sample_registrations(
-    request, payloads: List[SampleRegistrationIngestSchema], response: HttpResponse
+    request, payload: List[SampleRegistrationIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, SampleRegistration)
+    return create_instances(payload, SampleRegistration)
 
 
 @router.post("/specimens/")
 def create_specimens(
-    request, payloads: List[SpecimenIngestSchema], response: HttpResponse
+    request, payload: List[SpecimenIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Specimen)
+    return create_instances(payload, Specimen)
 
 
 @router.post("/surgeries/")
 def create_surgeries(
-    request, payloads: List[SurgeryIngestSchema], response: HttpResponse
+    request, payload: List[SurgeryIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Surgery)
+    return create_instances(payload, Surgery)
 
 
 @router.post("/treatments/")
 def create_treatments(
-    request, payloads: List[TreatmentIngestSchema], response: HttpResponse
+    request, payload: List[TreatmentIngestSchema], response: HttpResponse
 ):
-    return create_instances(payloads, Treatment)
+    return create_instances(payload, Treatment)

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_chemotherapy.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_chemotherapy.py
@@ -15,7 +15,7 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import (
 class IngestTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.chemotherapy_url = "/v2/ingest/chemotherapy/"
+        self.chemotherapy_url = "/v2/ingest/chemotherapies/"
 
     def test_chemotherapy_create_authorized(self):
         """
@@ -30,7 +30,7 @@ class IngestTestCase(BaseTestCase):
         data_dict = model_to_dict(chemotherapy)
         response = self.client.post(
             self.chemotherapy_url,
-            data=data_dict,
+            data=[data_dict],
             format="json",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
@@ -55,7 +55,7 @@ class IngestTestCase(BaseTestCase):
         data_dict = model_to_dict(chemotherapy)
         response = self.client.post(
             self.chemotherapy_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
@@ -26,7 +26,7 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import DonorFac
 class IngestTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.donor_url = "/v2/ingest/donor/"
+        self.donor_url = "/v2/ingest/donors/"
 
     def test_donor_create_authorized(self):
         """
@@ -38,10 +38,10 @@ class IngestTestCase(BaseTestCase):
         - User can perform a POST request for donor creation.
         """
         donor = DonorFactory.build(program_id=self.programs[0])
-        donor_dict = model_to_dict(donor)
+        data_dict = model_to_dict(donor)
         response = self.client.post(
             self.donor_url,
-            data=donor_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
@@ -63,10 +63,10 @@ class IngestTestCase(BaseTestCase):
         - User cannot perform a POST request for donor creation.
         """
         donor = DonorFactory.build(program_id=self.programs[0])
-        donor_dict = model_to_dict(donor)
+        data_dict = model_to_dict(donor)
         response = self.client.post(
             self.donor_url,
-            data=donor_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
@@ -13,7 +13,7 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import FollowUp
 class IngestTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.follow_up_url = "/v2/ingest/follow_up/"
+        self.follow_up_url = "/v2/ingest/followups/"
 
     def test_follow_up_create_authorized(self):
         """
@@ -28,7 +28,7 @@ class IngestTestCase(BaseTestCase):
         data_dict = model_to_dict(follow_up)
         response = self.client.post(
             self.follow_up_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
@@ -53,7 +53,7 @@ class IngestTestCase(BaseTestCase):
         data_dict = model_to_dict(follow_up)
         response = self.client.post(
             self.follow_up_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
@@ -15,7 +15,7 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import (
 class IngestTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.primary_diagnosis_url = "/v2/ingest/primary_diagnosis/"
+        self.primary_diagnosis_url = "/v2/ingest/primary_diagnoses/"
 
     def test_primary_diagnosis_create_authorized(self):
         """
@@ -30,7 +30,7 @@ class IngestTestCase(BaseTestCase):
         data_dict = model_to_dict(primary_diagnosis)
         response = self.client.post(
             self.primary_diagnosis_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
@@ -55,7 +55,7 @@ class IngestTestCase(BaseTestCase):
         data_dict = model_to_dict(primary_diagnosis)
         response = self.client.post(
             self.primary_diagnosis_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_program.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_program.py
@@ -19,7 +19,7 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import ProgramF
 class IngestTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.ingest_url = "/v2/ingest/program/"
+        self.ingest_url = "/v2/ingest/programs/"
 
     def test_ingest_authorized(self):
         """
@@ -30,10 +30,10 @@ class IngestTestCase(BaseTestCase):
         - User can perform a POST request for program ingestion.
         """
         ingest_program = ProgramFactory.build()
-        program_dict = model_to_dict(ingest_program)
+        data_dict = model_to_dict(ingest_program)
         response = self.client.post(
             self.ingest_url,
-            data=program_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
@@ -54,10 +54,10 @@ class IngestTestCase(BaseTestCase):
         - User cannot perform a POST request for program ingestion.
         """
         ingest_program = ProgramFactory.build()
-        program_dict = model_to_dict(ingest_program)
+        data_dict = model_to_dict(ingest_program)
         response = self.client.post(
             self.ingest_url,
-            data=program_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
@@ -15,7 +15,7 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import (
 class SampleRegistrationTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.sample_registration_url = "/v2/ingest/sample_registration/"
+        self.sample_registration_url = "/v2/ingest/sample_registrations/"
 
     def test_sample_registration_create_authorized(self):
         """
@@ -33,7 +33,7 @@ class SampleRegistrationTestCase(BaseTestCase):
 
         response = self.client.post(
             self.sample_registration_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
@@ -60,7 +60,7 @@ class SampleRegistrationTestCase(BaseTestCase):
         data_dict = model_to_dict(sample_registration)
         response = self.client.post(
             self.sample_registration_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
@@ -13,7 +13,7 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import Specimen
 class IngestTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.specimen_url = "/v2/ingest/specimen/"
+        self.specimen_url = "/v2/ingest/specimens/"
 
     def test_specimen_create_authorized(self):
         """
@@ -30,7 +30,7 @@ class IngestTestCase(BaseTestCase):
         data_dict = model_to_dict(specimen)
         response = self.client.post(
             self.specimen_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
@@ -57,7 +57,7 @@ class IngestTestCase(BaseTestCase):
         data_dict = model_to_dict(specimen)
         response = self.client.post(
             self.specimen_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
@@ -13,7 +13,7 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import Treatmen
 class TreatmentsIngestTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.treatment_url = "/v2/ingest/treatment/"
+        self.treatment_url = "/v2/ingest/treatments/"
 
     def test_treatment_create_authorized(self):
         """
@@ -30,7 +30,7 @@ class TreatmentsIngestTestCase(BaseTestCase):
         data_dict = model_to_dict(treatment)
         response = self.client.post(
             self.treatment_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
@@ -57,7 +57,7 @@ class TreatmentsIngestTestCase(BaseTestCase):
         data_dict = model_to_dict(treatment)
         response = self.client.post(
             self.treatment_url,
-            data=data_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -139,4 +139,4 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # CURRENT KATSU VERSION ACCORDING TO MODEL CHANGES
 # ------------------------------------------------
 
-KATSU_VERSION = "4.4.0"
+KATSU_VERSION = "4.5.0"


### PR DESCRIPTION
## What's New
- The `ingest` api now accepts a list of objects instead of a single item.
- Endpoints have been renamed to reflect this change.

### How to Test
1. Test within the candigv2 stack.
2. Rebuild katsu with branch `sonchau/katsu_batch`.
3. Pull https://github.com/CanDIG/candigv2-ingest/pull/103
