### PR TITLE
DIG-1663: Allow program curators to ingest/delete

### DIFF
--- a/chord_metadata_service/mohpackets/apis/clinical_data.py
+++ b/chord_metadata_service/mohpackets/apis/clinical_data.py
@@ -94,24 +94,6 @@ def require_donor_by_program(func):
 
 ##########################################
 #                                        #
-#           DELETE FUNCTIONS             #
-#                                        #
-##########################################
-@router.delete(
-    "/program/{program_id}/",
-    response={204: None, 404: Dict[str, str]},
-)
-def delete_program(request, program_id: str):
-    try:
-        dataset = Program.objects.get(pk=program_id)
-        dataset.delete()
-        return HTTPStatus.NO_CONTENT, None
-    except Program.DoesNotExist:
-        return HTTPStatus.NOT_FOUND, {"error": "Program matching query does not exist"}
-
-
-##########################################
-#                                        #
 #        DONOR WITH CLINICAL DATA        #
 #                                        #
 ##########################################
@@ -120,9 +102,8 @@ def delete_program(request, program_id: str):
     response={200: DonorWithClinicalDataSchema, 404: Dict[str, str]},
 )
 def get_donor_with_clinical_data(request, program_id: str, donor_id: str):
-    authorized_datasets = request.authorized_datasets
     q = (
-        Q(program_id__in=authorized_datasets)
+        Q(program_id__in=request.read_datasets)
         & Q(program_id=program_id)
         & Q(submitter_donor_id=donor_id)
     )
@@ -175,16 +156,14 @@ def get_donor_with_clinical_data(request, program_id: str, donor_id: str):
     response=List[ProgramModelSchema],
 )
 def list_programs(request, filters: Query[ProgramFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Program.objects.filter(q)
 
 
 @router.get("/donors/", response=List[DonorModelSchema])
 def list_donors(request, filters: Query[DonorFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Donor.objects.filter(q)
 
@@ -201,8 +180,7 @@ def check_filter_donor_with_program(filters):
     response=List[PrimaryDiagnosisModelSchema],
 )
 def list_primary_diagnoses(request, filters: Query[PrimaryDiagnosisFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return PrimaryDiagnosis.objects.filter(q)
 
@@ -212,8 +190,7 @@ def list_primary_diagnoses(request, filters: Query[PrimaryDiagnosisFilterSchema]
     response=List[BiomarkerModelSchema],
 )
 def list_biomarkers(request, filters: Query[BiomarkerFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Biomarker.objects.filter(q)
 
@@ -223,8 +200,7 @@ def list_biomarkers(request, filters: Query[BiomarkerFilterSchema]):
     response=List[ChemotherapyModelSchema],
 )
 def list_chemotherapies(request, filters: Query[ChemotherapyFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Chemotherapy.objects.filter(q)
 
@@ -234,8 +210,7 @@ def list_chemotherapies(request, filters: Query[ChemotherapyFilterSchema]):
     response=List[ComorbidityModelSchema],
 )
 def list_comorbidities(request, filters: Query[ComorbidityFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Comorbidity.objects.filter(q)
 
@@ -245,8 +220,7 @@ def list_comorbidities(request, filters: Query[ComorbidityFilterSchema]):
     response=List[ExposureModelSchema],
 )
 def list_exposures(request, filters: Query[ExposureFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Exposure.objects.filter(q)
 
@@ -256,8 +230,7 @@ def list_exposures(request, filters: Query[ExposureFilterSchema]):
     response=List[FollowUpModelSchema],
 )
 def list_follow_ups(request, filters: Query[FollowUpFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return FollowUp.objects.filter(q)
 
@@ -267,8 +240,7 @@ def list_follow_ups(request, filters: Query[FollowUpFilterSchema]):
     response=List[HormoneTherapyModelSchema],
 )
 def list_hormone_therapies(request, filters: Query[HormoneTherapyFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return HormoneTherapy.objects.filter(q)
 
@@ -278,8 +250,7 @@ def list_hormone_therapies(request, filters: Query[HormoneTherapyFilterSchema]):
     response=List[ImmunotherapyModelSchema],
 )
 def list_immunotherapies(request, filters: Query[ImmunotherapyFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Immunotherapy.objects.filter(q)
 
@@ -289,8 +260,7 @@ def list_immunotherapies(request, filters: Query[ImmunotherapyFilterSchema]):
     response=List[RadiationModelSchema],
 )
 def list_radiations(request, filters: Query[RadiationFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Radiation.objects.filter(q)
 
@@ -300,8 +270,7 @@ def list_radiations(request, filters: Query[RadiationFilterSchema]):
     response=List[SampleRegistrationModelSchema],
 )
 def list_sample_registrations(request, filters: Query[SampleRegistrationFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return SampleRegistration.objects.filter(q)
 
@@ -311,8 +280,7 @@ def list_sample_registrations(request, filters: Query[SampleRegistrationFilterSc
     response=List[SpecimenModelSchema],
 )
 def list_specimens(request, filters: Query[SpecimenFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Specimen.objects.filter(q)
 
@@ -322,8 +290,7 @@ def list_specimens(request, filters: Query[SpecimenFilterSchema]):
     response=List[SurgeryModelSchema],
 )
 def list_surgeries(request, filters: Query[SurgeryFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Surgery.objects.filter(q)
 
@@ -333,7 +300,6 @@ def list_surgeries(request, filters: Query[SurgeryFilterSchema]):
     response=List[TreatmentModelSchema],
 )
 def list_treatments(request, filters: Query[TreatmentFilterSchema]):
-    authorized_datasets = request.authorized_datasets
-    q = Q(program_id__in=authorized_datasets)
+    q = Q(program_id__in=request.read_datasets)
     q &= filters.get_filter_expression()
     return Treatment.objects.filter(q)

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -280,7 +280,7 @@ api = NinjaAPI(
 )
 api.add_router("/discovery/", discovery_router, tags=["discovery"])
 api.add_router("/ingest/", ingest_router, auth=auth.IngestAuth(), tags=["ingest"])
-api.add_router("/authorized/", delete_router, auth=auth.DeleteAuth(), tags=["delete"])
+api.add_router("/ingest/", delete_router, auth=auth.DeleteAuth(), tags=["delete"])
 api.add_router(
     "/authorized/", authorzied_router, auth=auth.GetAuth(), tags=["authorized"]
 )

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -70,6 +70,11 @@ class ORJSONParser(Parser):
 
 
 class NetworkAuth:
+    """
+    The built-in authenticate function in Django has been overridden to use custom OPA logic
+    to authorize for different types of requests.
+    """
+
     class DeleteAuth(HttpBearer):
         def authenticate(self, request, bearer_token):
             """

--- a/chord_metadata_service/mohpackets/apis/ingestion.py
+++ b/chord_metadata_service/mohpackets/apis/ingestion.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Type, List
+from typing import Type, List, Dict
 
 from django.http import HttpResponse, JsonResponse
 from ninja import Router
@@ -66,6 +66,13 @@ def create_instances(payload: List, model_cls: Type):
         status=HTTPStatus.CREATED,
         data={"created": created_instances},
     )
+
+
+##########################################
+#                                        #
+#           CREATE FUNCTIONS             #
+#                                        #
+##########################################
 
 
 @router.post("/programs/")
@@ -169,3 +176,24 @@ def create_treatments(
     request, payload: List[TreatmentIngestSchema], response: HttpResponse
 ):
     return create_instances(payload, Treatment)
+
+
+##########################################
+#                                        #
+#           DELETE FUNCTIONS             #
+#                                        #
+##########################################
+delete_router = Router()
+
+
+@delete_router.delete(
+    "/program/{program_id}/",
+    response={204: None, 404: Dict[str, str]},
+)
+def delete_program(request, program_id: str):
+    try:
+        dataset = Program.objects.get(pk=program_id)
+        dataset.delete()
+        return HTTPStatus.NO_CONTENT, None
+    except Program.DoesNotExist:
+        return HTTPStatus.NOT_FOUND, {"error": "Program matching query does not exist"}

--- a/chord_metadata_service/mohpackets/tests/endpoints/base.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/base.py
@@ -38,10 +38,11 @@ from chord_metadata_service.mohpackets.tests.endpoints.factories import (
 
 
 class TestUser:
-    def __init__(self, token, is_admin, datasets):
+    def __init__(self, token, is_admin, write_datasets, read_datasets):
         self.token = token
         self.is_admin = is_admin
-        self.datasets = datasets
+        self.write_datasets = write_datasets
+        self.read_datasets = read_datasets
 
 
 class BaseTestCase(TestCase):
@@ -72,43 +73,55 @@ class BaseTestCase(TestCase):
             4, treatment_uuid=factory.Iterator(cls.treatments[4:8])
         )
 
-        # Define test users with permission and datasets access
+        # Define users permissions based on test data
+        # The only different between a normal user and a curator is write permission
         cls.user_0 = TestUser(
-            token="token_0",
+            token="user_0",
             is_admin=False,
-            datasets=[],
+            write_datasets=[],
+            read_datasets=[cls.programs[0].program_id],
         )
         cls.user_1 = TestUser(
             token="user_1",
             is_admin=False,
-            datasets=[cls.programs[0].program_id],
+            write_datasets=[cls.programs[1].program_id],
+            read_datasets=[
+                cls.programs[0].program_id,
+                cls.programs[1].program_id,
+            ],
         )
         cls.user_2 = TestUser(
-            token="user_2",
+            token="site_admin",
             is_admin=True,
-            datasets=[cls.programs[0].program_id, cls.programs[1].program_id],
+            write_datasets=[],  # admin can write regardless
+            read_datasets=[
+                cls.programs[0].program_id,
+                cls.programs[1].program_id,
+            ],
         )
+
         # remember to add all the custom users into this list
         cls.users = [cls.user_0, cls.user_1, cls.user_2]
         os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings.local"
 
-        settings.LOCAL_AUTHORIZED_DATASET = [
-            {
-                "token": cls.user_0.token,
+        # Overrides local settings to allow new testing data
+        settings.LOCAL_OPA_DATASET = {
+            cls.user_0.token: {
                 "is_admin": cls.user_0.is_admin,
-                "datasets": cls.user_0.datasets,
+                "write_datasets": cls.user_0.write_datasets,
+                "read_datasets": cls.user_0.read_datasets,
             },
-            {
-                "token": cls.user_1.token,
+            cls.user_1.token: {
                 "is_admin": cls.user_1.is_admin,
-                "datasets": cls.user_1.datasets,
+                "write_datasets": cls.user_1.write_datasets,
+                "read_datasets": cls.user_1.read_datasets,
             },
-            {
-                "token": cls.user_2.token,
+            cls.user_2.token: {
                 "is_admin": cls.user_2.is_admin,
-                "datasets": cls.user_2.datasets,
+                "write_datasets": cls.user_2.write_datasets,
+                "read_datasets": cls.user_2.read_datasets,
             },
-        ]
+        }
 
     def setUp(self):
         logging.disable(logging.WARNING)

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_chemotherapy.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_chemotherapy.py
@@ -143,10 +143,8 @@ class ChemotherapyOthersTestCase(BaseTestCase):
           for each of the test users.
         """
         for user in self.users:
-            authorized_datasets = next(
-                user_data["datasets"]
-                for user_data in settings.LOCAL_AUTHORIZED_DATASET
-                if user_data["token"] == user.token
+            authorized_datasets = settings.LOCAL_OPA_DATASET.get(user.token, {}).get(
+                "read_datasets", []
             )
             expected_datasets = [
                 str(dataset)

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
@@ -153,10 +153,8 @@ class OthersTestCase(BaseTestCase):
           for each of the test users.
         """
         for user in self.users:
-            authorized_datasets = next(
-                user_data["datasets"]
-                for user_data in settings.LOCAL_AUTHORIZED_DATASET
-                if user_data["token"] == user.token
+            authorized_datasets = settings.LOCAL_OPA_DATASET.get(user.token, {}).get(
+                "read_datasets", []
             )
             # get donors from the database
             expected_donors = list(

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
@@ -141,10 +141,8 @@ class OthersTestCase(BaseTestCase):
           for each of the test users.
         """
         for user in self.users:
-            authorized_datasets = next(
-                user_data["datasets"]
-                for user_data in settings.LOCAL_AUTHORIZED_DATASET
-                if user_data["token"] == user.token
+            authorized_datasets = settings.LOCAL_OPA_DATASET.get(user.token, {}).get(
+                "read_datasets", []
             )
             # get follow-ups' datasets from the database
             expected_datasets = list(

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_permission.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_permission.py
@@ -1,0 +1,248 @@
+from http import HTTPStatus
+
+from django.conf import settings
+from django.forms.models import model_to_dict
+
+from chord_metadata_service.mohpackets.tests.endpoints.base import BaseTestCase
+from chord_metadata_service.mohpackets.tests.endpoints.factories import (
+    DonorFactory,
+    PrimaryDiagnosisFactory,
+    ProgramFactory,
+    TreatmentFactory,
+)
+
+"""
+    This module tests users with different roles to ensure they
+    can perform ingestion and deletion operations as appropriate.
+
+    - Site Admin: Bypasses permission checks, allowing them to
+    ingest and delete any data. However, they can only read from authorized_datasets.
+    It is OPA responsibility to ensure authorized_datasets is up to date.
+    - Curator: Can read and write within their authorized_datasets.
+    - Normal User: Has read-only access.
+
+    Author: Son Chau
+"""
+
+
+# INGEST API
+# ----------
+class IngestTestCase(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.donor_url = "/v2/ingest/donors/"
+
+    def test_ingest_with_normal_user(self):
+        """
+        Test that a normal user attempting to create a donor receives a 401 response.
+
+        Testing Strategy:
+        - Build Donor data based on the existing program_id
+        - An unauthorized user (user_0) with no permission.
+        - User cannot perform a POST request for donor creation.
+        """
+        donor = DonorFactory.build(program_id=self.programs[0])
+        data_dict = model_to_dict(donor)
+        response = self.client.post(
+            self.donor_url,
+            data=[data_dict],
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_unauthorized_ingest_with_curator(self):
+        """
+        Test that a curator cannot to create a donor in unauthorized program
+
+        Testing Strategy:
+        - Build Donor data based on the existing program_id
+        - An unauthorized curator (user_1) with no permission on that program_id
+        - User cannot perform a POST request for donor creation.
+        """
+        donor = DonorFactory.build(program_id=self.programs[0])
+        data_dict = model_to_dict(donor)
+        response = self.client.post(
+            self.donor_url,
+            data=[data_dict],
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_authorized_ingest_with_curator(self):
+        """
+        Test that a curator can create a donor with authorized program
+
+        Testing Strategy:
+        - Build Donor data based on the existing program_id
+        - An authorized curator (user_1) with permission on that program_id
+        - User can perform a POST request for donor creation.
+        """
+        donor = DonorFactory.build(program_id=self.programs[1])
+        data_dict = model_to_dict(donor)
+        response = self.client.post(
+            self.donor_url,
+            data=[data_dict],
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_1.token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+
+    def test_ingest_with_site_admin(self):
+        """
+        Test that a site admin can create a donor with any program,
+        even not in authorized dataset
+
+        Testing Strategy:
+        - Build Donor data based on a newly created program_id
+        - A site admin (user_2) can perform a POST request for donor creation.
+        """
+        program = ProgramFactory.create()
+        donor = DonorFactory.build(program_id=program)
+        data_dict = model_to_dict(donor)
+        response = self.client.post(
+            self.donor_url,
+            data=[data_dict],
+            content_type="application/json",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+
+
+# DELETE API
+# ----------
+class DeleteTestCase(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.authorized_url = "/v2/authorized/program/"
+
+    def test_delete_with_normal_user(self):
+        """
+        Test a normal user cannot delete a program
+
+        Testing Strategy:
+        - A normal user (user_0) cannot delete
+        - The request should receive a 401 response.
+        """
+        response = self.client.delete(
+            f"{self.authorized_url}{self.programs[0]}/",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_delete_with_unauthorized_curator(self):
+        """
+        Test a curator cannot delete an unauthorized program
+
+        Testing Strategy:
+        - A curator (user_1) attempts to delete a program
+        - The request should receive a 401 response.
+        """
+        response = self.client.delete(
+            f"{self.authorized_url}{self.programs[0]}/",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_1.token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_delete_with_authorized_curator(self):
+        """
+        Test a curator can delete a authorized program
+
+        Testing Strategy:
+        - A curator (user_1) attempts to delete a program
+        - The request should receive a 204 response.
+        """
+        response = self.client.delete(
+            f"{self.authorized_url}{self.programs[1]}/",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_1.token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+
+    def test_delete_with_site_admin(self):
+        """
+        Test a site admin can delete any program
+
+        Testing Strategy:
+        - Create a new program
+        - A site admin (user_2) can perform delete
+        - The request should receive a 204 response.
+        """
+        program_to_delete = ProgramFactory.create()
+        response = self.client.delete(
+            f"{self.authorized_url}{program_to_delete}/",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+
+
+# GET API
+# -------
+class GETTestCase(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.treatments_url = "/v2/authorized/treatments/"
+
+    def test_get_treatments_with_normal_user(self):
+        """
+        Test a normal user can only see authorized dataset
+
+        Testing Strategy:
+        - An authorized user (user_0) attempts a GET request for authorized treatments.
+        - All the treatments only come from authorized programs
+        """
+        authorized_datasets = settings.LOCAL_OPA_DATASET.get(self.user_0.token, {}).get(
+            "read_datasets", []
+        )
+        response = self.client.get(
+            self.treatments_url,
+            HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",
+        )
+        response = response.json()
+        program_ids = list({treatment["program_id"] for treatment in response["items"]})
+        self.assertCountEqual(program_ids, authorized_datasets)
+
+    def test_get_treatments_with_curator(self):
+        """
+        Test a curator can only see authorized dataset
+
+        Testing Strategy:
+        - An curator (user_1) attempts a GET request for authorized treatments.
+        - All the treatments only come from authorized programs
+        """
+        authorized_datasets = settings.LOCAL_OPA_DATASET.get(self.user_1.token, {}).get(
+            "read_datasets", []
+        )
+        response = self.client.get(
+            self.treatments_url,
+            HTTP_AUTHORIZATION=f"Bearer {self.user_1.token}",
+        )
+        response = response.json()
+        program_ids = list({treatment["program_id"] for treatment in response["items"]})
+        self.assertCountEqual(program_ids, authorized_datasets)
+
+    def test_get_treatments_with_site_admin(self):
+        """
+        Test a site admin can only see authorized dataset, not all
+
+        Testing Strategy:
+        - Create a new treatment with a new program
+        - A site admin (user_2) attempts a GET request for authorized treatments.
+        - The new treatmnet is not in the return treatments
+        """
+        program = ProgramFactory.create()
+        donor = DonorFactory.create(program_id=program)
+        primary_diagnosis = PrimaryDiagnosisFactory.create(donor_uuid=donor)
+        treatment = TreatmentFactory.create(
+            primary_diagnosis_uuid=primary_diagnosis,
+        )
+        response = self.client.get(
+            self.treatments_url,
+            HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
+        )
+        response = response.json()
+        self.assertNotIn(treatment, response["items"])

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_permission.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_permission.py
@@ -119,7 +119,7 @@ class IngestTestCase(BaseTestCase):
 class DeleteTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.authorized_url = "/v2/authorized/program/"
+        self.delete_url = "/v2/ingest/program/"
 
     def test_delete_with_normal_user(self):
         """
@@ -130,7 +130,7 @@ class DeleteTestCase(BaseTestCase):
         - The request should receive a 401 response.
         """
         response = self.client.delete(
-            f"{self.authorized_url}{self.programs[0]}/",
+            f"{self.delete_url}{self.programs[0]}/",
             HTTP_AUTHORIZATION=f"Bearer {self.user_0.token}",
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
@@ -144,7 +144,7 @@ class DeleteTestCase(BaseTestCase):
         - The request should receive a 401 response.
         """
         response = self.client.delete(
-            f"{self.authorized_url}{self.programs[0]}/",
+            f"{self.delete_url}{self.programs[0]}/",
             HTTP_AUTHORIZATION=f"Bearer {self.user_1.token}",
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
@@ -158,7 +158,7 @@ class DeleteTestCase(BaseTestCase):
         - The request should receive a 204 response.
         """
         response = self.client.delete(
-            f"{self.authorized_url}{self.programs[1]}/",
+            f"{self.delete_url}{self.programs[1]}/",
             HTTP_AUTHORIZATION=f"Bearer {self.user_1.token}",
         )
         self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
@@ -174,7 +174,7 @@ class DeleteTestCase(BaseTestCase):
         """
         program_to_delete = ProgramFactory.create()
         response = self.client.delete(
-            f"{self.authorized_url}{program_to_delete}/",
+            f"{self.delete_url}{program_to_delete}/",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
         )
         self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
@@ -143,10 +143,8 @@ class OthersTestCase(BaseTestCase):
           for each of the test users.
         """
         for user in self.users:
-            authorized_datasets = next(
-                user_data["datasets"]
-                for user_data in settings.LOCAL_AUTHORIZED_DATASET
-                if user_data["token"] == user.token
+            authorized_datasets = settings.LOCAL_OPA_DATASET.get(user.token, {}).get(
+                "read_datasets", []
             )
             # get primary diagnoses from the database
             expected_primary_diagnoses = list(

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_program.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_program.py
@@ -70,7 +70,7 @@ class IngestTestCase(BaseTestCase):
 class DeleteTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.authorized_url = "/v2/authorized/program/"
+        self.delete_url = "/v2/ingest/program/"
 
     def test_delete_authorized(self):
         """
@@ -83,14 +83,14 @@ class DeleteTestCase(BaseTestCase):
         """
         program_to_delete = ProgramFactory()
         response = self.client.delete(
-            f"{self.authorized_url}{program_to_delete.program_id}/",
+            f"{self.delete_url}{program_to_delete.program_id}/",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",
         )
         self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
 
     def test_delete_unauthorized(self):
         """
-        Test an unauthorized DELETE request 'authorized/programs/{program_id}/' endpoint.
+        Test an unauthorized DELETE request 'ingest/programs/{program_id}/' endpoint.
 
         Testing Strategy:
         - Create a new program to delete
@@ -99,7 +99,7 @@ class DeleteTestCase(BaseTestCase):
         """
         program_to_delete = ProgramFactory()
         response = self.client.delete(
-            f"{self.authorized_url}{program_to_delete.program_id}/",
+            f"{self.delete_url}{program_to_delete.program_id}/",
             HTTP_AUTHORIZATION=f"Bearer {self.user_1.token}",
         )
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_program.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_program.py
@@ -176,10 +176,8 @@ class OthersTestCase(BaseTestCase):
             )
             response = response.json()
 
-            authorized_datasets = next(
-                user_data["datasets"]
-                for user_data in settings.LOCAL_AUTHORIZED_DATASET
-                if user_data["token"] == user.token
+            authorized_datasets = settings.LOCAL_OPA_DATASET.get(user.token, {}).get(
+                "read_datasets", []
             )
             response_datasets = [program["program_id"] for program in response["items"]]
             self.assertEqual(response_datasets, authorized_datasets)

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
@@ -150,10 +150,8 @@ class OthersTestCase(BaseTestCase):
           for each of the test users.
         """
         for user in self.users:
-            authorized_datasets = next(
-                user_data["datasets"]
-                for user_data in settings.LOCAL_AUTHORIZED_DATASET
-                if user_data["token"] == user.token
+            authorized_datasets = settings.LOCAL_OPA_DATASET.get(user.token, {}).get(
+                "read_datasets", []
             )
             # get sample registrations' datasets from the database
             expected_datasets = list(

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
@@ -147,10 +147,8 @@ class OthersTestCase(BaseTestCase):
           for each of the test users.
         """
         for user in self.users:
-            authorized_datasets = next(
-                user_data["datasets"]
-                for user_data in settings.LOCAL_AUTHORIZED_DATASET
-                if user_data["token"] == user.token
+            authorized_datasets = settings.LOCAL_OPA_DATASET.get(user.token, {}).get(
+                "read_datasets", []
             )
             # get specimens from the database
             # get primary diagnoses from the database

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
@@ -147,10 +147,8 @@ class TreatmentsOthersTestCase(BaseTestCase):
           for each of the test users.
         """
         for user in self.users:
-            authorized_datasets = next(
-                user_data["datasets"]
-                for user_data in settings.LOCAL_AUTHORIZED_DATASET
-                if user_data["token"] == user.token
+            authorized_datasets = settings.LOCAL_OPA_DATASET.get(user.token, {}).get(
+                "read_datasets", []
             )
             # get treatments' datasets from the database
             expected_datasets = list(

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -139,4 +139,4 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # CURRENT KATSU VERSION ACCORDING TO MODEL CHANGES
 # ------------------------------------------------
 
-KATSU_VERSION = "4.5.0"
+KATSU_VERSION = "4.6.0"

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -49,19 +49,27 @@ CACHES = {
     }
 }
 
-# You can change username and datasets to suit your needs
-LOCAL_AUTHORIZED_DATASET = [
-    {
-        "token": "user_1",
+# user_1 is a normal user
+# user_2 is a curator
+# site_admin is admin
+LOCAL_OPA_DATASET = {
+    "user_1": {
         "is_admin": False,
-        "datasets": ["SYNTHETIC-1"],
+        "write_datasets": [],
+        "read_datasets": ["SYNTHETIC-1"],
     },
-    {
-        "token": "user_2",
+    "user_2": {
+        "is_admin": False,
+        "write_datasets": ["SYNTHETIC-2"],
+        "read_datasets": ["SYNTHETIC-2"],
+    },
+    "site_admin": {
         "is_admin": True,
-        "datasets": ["SYNTHETIC-1", "SYNTHETIC-2"],
+        "write_datasets": [],
+        "read_datasets": ["SYNTHETIC-1", "SYNTHETIC-2"],
     },
-]
+}
+
 QUERY_SERVICE_TOKEN = "query"
 
 LOGGING = {


### PR DESCRIPTION
## What's New

- Curator can now perform ingest and delete actions.
- Reworked authorization to use three separate functions for each action: get, post, delete.
- Updated tests for permissions.
- Changed delete URL from `/authorized/program` to `/ingest/program`.

### How to Test

1. Pull this branch.
2. Pull https://github.com/CanDIG/candigv2-ingest/pull/104.
3. Rebuild, add the curator role, and test ingest or delete actions.