### PR TITLE
Manually update katsu's OpenAPI spec to v3.0 data model

### DIFF
--- a/chord_metadata_service/mohpackets/docs/README.MD
+++ b/chord_metadata_service/mohpackets/docs/README.MD
@@ -4,21 +4,24 @@ This folder contains the schema and documentation for **MoH models**
 
 ## Katsu API Documentation
 
-To view the API documentation, simply open [schema_v3.md](schema_v3.md) or [Redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/CanDIG/katsu/feature/manual_schema/chord_metadata_service/mohpackets/docs/schema_manual.yml).
+To view the API documentation, simply open [schema.md](schema.md) or [Redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/CanDIG/katsu/feature/manual_schema/chord_metadata_service/mohpackets/docs/schema_manual.yml).
 
-To generate the `schema_v3.json` file, run the following command:
+> [!WARNING]
+> Katsu is currently being transitioned to the MoH clinical data model v3.0.0. There is a manually created v3.0.0 of the OpenAPI schema at [schema_v3.yml](schema_v3.yml) that can be used as a reference in the interim period. This file will be replaced by the automatically generated schema documentaion files once katsu is fully transitions to model v3.0.0
 
-```bash
-python manage.py export_openapi_schema --api chord_metadata_service.mohpackets.apis.core.api | python -m json.tool > chord_metadata_service/mohpackets/docs/schema_v3.json
-```
-
-To generate the `schema_v3.md` file, install [widdershins](https://github.com/Mermade/widdershins) and then run the following command:
+To generate the `schema.json` file, run the following command:
 
 ```bash
-widdershins ./chord_metadata_service/mohpackets/docs/schema_v3.json -o ./chord_metadata_service/mohpackets/docs/schema_v3.md -u ./chord_metadata_service/mohpackets/docs/widdershins/templates/openapi3 -c true --omitHeader true
+python manage.py export_openapi_schema --api chord_metadata_service.mohpackets.apis.core.api | python -m json.tool > chord_metadata_service/mohpackets/docs/schema.json
 ```
 
-This will create the schema_v3.md file with the updated documentation.
+To generate the `schema.md` file, install [widdershins](https://github.com/Mermade/widdershins) and then run the following command:
+
+```bash
+widdershins ./chord_metadata_service/mohpackets/docs/schema.json -o ./chord_metadata_service/mohpackets/docs/schema.md -u ./chord_metadata_service/mohpackets/docs/widdershins/templates/openapi3 -c true --omitHeader true
+```
+
+This will create the schema.md file with the updated documentation.
 
 ## Katsu MoH data model Documentation
 

--- a/chord_metadata_service/mohpackets/docs/README.MD
+++ b/chord_metadata_service/mohpackets/docs/README.MD
@@ -6,8 +6,8 @@ This folder contains the schema and documentation for **MoH models**
 
 To view the API documentation, simply open [schema.md](schema.md) or [Redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/CanDIG/katsu/feature/manual_schema/chord_metadata_service/mohpackets/docs/schema_manual.yml).
 
-> [!WARNING]
-> Katsu is currently being transitioned to the MoH clinical data model v3.0.0. There is a manually created v3.0.0 of the OpenAPI schema at [schema_v3.yml](schema_v3.yml) that can be used as a reference in the interim period. This file will be replaced by the automatically generated schema documentaion files once katsu is fully transitions to model v3.0.0
+> [!IMPORTANT]
+> Katsu is currently being transitioned to MoH clinical data model v3.0.0. There is a manually created v3.0.0 of the OpenAPI schema at [schema_v3.yml](schema_v3.yml) that can be used as a reference in the interim period. This file will be replaced by the automatically generated schema documentaion files once katsu is fully transitioned to model v3.0.0.
 
 To generate the `schema.json` file, run the following command:
 

--- a/chord_metadata_service/mohpackets/docs/README.MD
+++ b/chord_metadata_service/mohpackets/docs/README.MD
@@ -4,33 +4,35 @@ This folder contains the schema and documentation for **MoH models**
 
 ## Katsu API Documentation
 
-To view the API documentation, simply open [schema.md](schema.md) or [Redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.json).
+To view the API documentation, simply open [schema_v3.md](schema_v3.md) or [Redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/CanDIG/katsu/feature/manual_schema/chord_metadata_service/mohpackets/docs/schema_manual.yml).
 
-To generate the `schema.json` file, run the following command:
-
-```bash
-python manage.py export_openapi_schema --api chord_metadata_service.mohpackets.apis.core.api | python -m json.tool > chord_metadata_service/mohpackets/docs/schema.json
-```
-
-To generate the `schema.md` file, install [widdershins](https://github.com/Mermade/widdershins) and then run the following command:
+To generate the `schema_v3.json` file, run the following command:
 
 ```bash
-widdershins ./chord_metadata_service/mohpackets/docs/schema.json -o ./chord_metadata_service/mohpackets/docs/schema.md -u ./chord_metadata_service/mohpackets/docs/widdershins/templates/openapi3 -c true --omitHeader true
+python manage.py export_openapi_schema --api chord_metadata_service.mohpackets.apis.core.api | python -m json.tool > chord_metadata_service/mohpackets/docs/schema_v3.json
 ```
 
-This will create the schema.md file with the updated documentation.
+To generate the `schema_v3.md` file, install [widdershins](https://github.com/Mermade/widdershins) and then run the following command:
+
+```bash
+widdershins ./chord_metadata_service/mohpackets/docs/schema_v3.json -o ./chord_metadata_service/mohpackets/docs/schema_v3.md -u ./chord_metadata_service/mohpackets/docs/widdershins/templates/openapi3 -c true --omitHeader true
+```
+
+This will create the schema_v3.md file with the updated documentation.
 
 ## Katsu MoH data model Documentation
 
-To regenerate the `er_diagram.md` file, run the following from the commandline in the current directory: 
+To regenerate the `er_diagram.md` file, run the following from the commandline in the current directory:
 
 To update the model classes:
+
 ```bash
 pip install pylint
 pyreverse -o mmd ../models.py
 ```
 
 To update the markdown file
+
 ```bash
 python make_er_diagram.py
 ```

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -1152,31 +1152,6 @@ components:
           - type: string
           - type: 'null'
           title: Program Id
-        recurrence_m_category:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence M Category
-        recurrence_n_category:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence N Category
-        recurrence_stage_group:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence Stage Group
-        recurrence_t_category:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence T Category
-        recurrence_tumour_staging_system:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence Tumour Staging System
         relapse_type:
           anyOf:
           - type: string
@@ -1235,26 +1210,6 @@ components:
         program_id:
           title: Program Id
           type: string
-        recurrence_m_category:
-          anyOf:
-          - $ref: '#/components/schemas/MCategoryEnum'
-          - type: 'null'
-        recurrence_n_category:
-          anyOf:
-          - $ref: '#/components/schemas/NCategoryEnum'
-          - type: 'null'
-        recurrence_stage_group:
-          anyOf:
-          - $ref: '#/components/schemas/StageGroupEnum'
-          - type: 'null'
-        recurrence_t_category:
-          anyOf:
-          - $ref: '#/components/schemas/TCategoryEnum'
-          - type: 'null'
-        recurrence_tumour_staging_system:
-          anyOf:
-          - $ref: '#/components/schemas/TumourStagingSystemEnum'
-          - type: 'null'
         relapse_type:
           anyOf:
           - $ref: '#/components/schemas/RelapseTypeEnum'
@@ -1319,26 +1274,6 @@ components:
         program_id:
           title: Program Id
           type: string
-        recurrence_m_category:
-          anyOf:
-          - $ref: '#/components/schemas/MCategoryEnum'
-          - type: 'null'
-        recurrence_n_category:
-          anyOf:
-          - $ref: '#/components/schemas/NCategoryEnum'
-          - type: 'null'
-        recurrence_stage_group:
-          anyOf:
-          - $ref: '#/components/schemas/StageGroupEnum'
-          - type: 'null'
-        recurrence_t_category:
-          anyOf:
-          - $ref: '#/components/schemas/TCategoryEnum'
-          - type: 'null'
-        recurrence_tumour_staging_system:
-          anyOf:
-          - $ref: '#/components/schemas/TumourStagingSystemEnum'
-          - type: 'null'
         relapse_type:
           anyOf:
           - $ref: '#/components/schemas/RelapseTypeEnum'
@@ -2060,26 +1995,6 @@ components:
             type: array
           - type: 'null'
           title: Method Of Progression Status
-        recurrence_m_category:
-          anyOf:
-          - $ref: '#/components/schemas/MCategoryEnum'
-          - type: 'null'
-        recurrence_n_category:
-          anyOf:
-          - $ref: '#/components/schemas/NCategoryEnum'
-          - type: 'null'
-        recurrence_stage_group:
-          anyOf:
-          - $ref: '#/components/schemas/StageGroupEnum'
-          - type: 'null'
-        recurrence_t_category:
-          anyOf:
-          - $ref: '#/components/schemas/TCategoryEnum'
-          - type: 'null'
-        recurrence_tumour_staging_system:
-          anyOf:
-          - $ref: '#/components/schemas/TumourStagingSystemEnum'
-          - type: 'null'
         relapse_type:
           anyOf:
           - $ref: '#/components/schemas/RelapseTypeEnum'
@@ -6047,46 +5962,6 @@ paths:
           q: anatomic_site_progression_or_recurrence__overlap
           title: Anatomic Site Progression Or Recurrence
           type: array
-      - in: query
-        name: recurrence_tumour_staging_system
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence Tumour Staging System
-      - in: query
-        name: recurrence_t_category
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence T Category
-      - in: query
-        name: recurrence_n_category
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence N Category
-      - in: query
-        name: recurrence_m_category
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence M Category
-      - in: query
-        name: recurrence_stage_group
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Recurrence Stage Group
       - in: query
         name: page
         required: false

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -325,7 +325,7 @@ components:
       properties:
         actual_cumulative_drug_dose:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Actual Cumulative Drug Dose
         drug_dose_units:
@@ -350,7 +350,7 @@ components:
           title: Drug Reference Identifier
         prescribed_cumulative_drug_dose:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
         systemic_therapy_type:
@@ -389,7 +389,7 @@ components:
       properties:
         actual_cumulative_drug_dose:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Actual Cumulative Drug Dose
         drug_dose_units:
@@ -414,7 +414,7 @@ components:
           title: Drug Reference Identifier
         prescribed_cumulative_drug_dose:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
         systemic_therapy_type:
@@ -467,7 +467,7 @@ components:
       properties:
         actual_cumulative_drug_dose:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Actual Cumulative Drug Dose
         drug_dose_units:
@@ -492,7 +492,7 @@ components:
           title: Drug Reference Identifier
         prescribed_cumulative_drug_dose:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
         systemic_therapy_type:
@@ -1486,6 +1486,7 @@ components:
       - M1d(1)
       - M1e
       - MX
+      - Not applicable
       title: MCategoryEnum
       type: string
     MalignancyLateralityEnum:
@@ -1631,7 +1632,7 @@ components:
       properties:
         actual_cumulative_drug_dose:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Actual Cumulative Drug Dose
         drug_dose_units:
@@ -1656,7 +1657,7 @@ components:
           title: Drug Reference Identifier
         prescribed_cumulative_drug_dose:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
         systemic_therapy_type:
@@ -1785,22 +1786,22 @@ components:
       properties:
         pathological_m_category:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/MCategoryEnum'
           - type: 'null'
           title: Pathological M Category
         pathological_n_category:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/NCategoryEnum'
           - type: 'null'
           title: Pathological N Category
         pathological_stage_group:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/StageGroupEnum'
           - type: 'null'
           title: Pathological Stage Group
         pathological_t_category:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/TCategoryEnum'
           - type: 'null'
           title: Pathological T Category
         pathological_tumour_staging_system:
@@ -4395,7 +4396,7 @@ components:
     SystemicTherapyTypeEnum:
       enum:
       - Chemotherapy
-      - Hormone Therapy
+      - Hormone therapy
       - Immunotherapy
       title: SystemicTherapyTypeEnum
       type: string
@@ -5089,7 +5090,7 @@ paths:
         required: false
         schema:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
       - in: query
@@ -5097,7 +5098,7 @@ paths:
         required: false
         schema:
           anyOf:
-          - type: integer
+          - type: number
           - type: 'null'
           title: Actual Cumulative Drug Dose
       - in: query

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -2106,11 +2106,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/uBooleanEnum'
           - type: 'null'
-        line_of_treatment:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Line Of Treatment
         radiations:
           items:
             $ref: '#/components/schemas/NestedRadiationSchema'
@@ -2145,10 +2140,6 @@ components:
         treatment_intent:
           anyOf:
           - $ref: '#/components/schemas/TreatmentIntentEnum'
-          - type: 'null'
-        treatment_setting:
-          anyOf:
-          - $ref: '#/components/schemas/TreatmentSettingEnum'
           - type: 'null'
         treatment_start_date:
           anyOf:
@@ -4479,11 +4470,6 @@ components:
           - type: string
           - type: 'null'
           title: Is Primary Treatment
-        line_of_treatment:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Line Of Treatment
         program_id:
           anyOf:
           - type: string
@@ -4524,11 +4510,6 @@ components:
           - type: string
           - type: 'null'
           title: Treatment Intent
-        treatment_setting:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Treatment Setting
         treatment_type:
           items:
             type: string
@@ -4543,11 +4524,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/uBooleanEnum'
           - type: 'null'
-        line_of_treatment:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Line Of Treatment
         program_id:
           title: Program Id
           type: string
@@ -4581,10 +4557,6 @@ components:
         treatment_intent:
           anyOf:
           - $ref: '#/components/schemas/TreatmentIntentEnum'
-          - type: 'null'
-        treatment_setting:
-          anyOf:
-          - $ref: '#/components/schemas/TreatmentSettingEnum'
           - type: 'null'
         treatment_start_date:
           anyOf:
@@ -4627,11 +4599,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/uBooleanEnum'
           - type: 'null'
-        line_of_treatment:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Line Of Treatment
         program_id:
           title: Program Id
           type: string
@@ -4665,10 +4632,6 @@ components:
         treatment_intent:
           anyOf:
           - $ref: '#/components/schemas/TreatmentIntentEnum'
-          - type: 'null'
-        treatment_setting:
-          anyOf:
-          - $ref: '#/components/schemas/TreatmentSettingEnum'
           - type: 'null'
         treatment_start_date:
           anyOf:
@@ -4725,21 +4688,6 @@ components:
       - Physician Assessed Response Criteria
       - Blazer score
       title: TreatmentResponseMethodEnum
-      type: string
-    TreatmentSettingEnum:
-      enum:
-      - Adjuvant
-      - Advanced/Metastatic
-      - Neoadjuvant
-      - Conditioning
-      - Induction
-      - Locally advanced
-      - Maintenance
-      - Mobilization
-      - Preventative
-      - Radiosensitization
-      - Salvage
-      title: TreatmentSettingEnum
       type: string
     TreatmentStatusEnum:
       enum:
@@ -6423,22 +6371,6 @@ paths:
           - type: string
           - type: 'null'
           title: Is Primary Treatment
-      - in: query
-        name: line_of_treatment
-        required: false
-        schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Line Of Treatment
-      - in: query
-        name: treatment_setting
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Treatment Setting
       - in: query
         name: treatment_intent
         required: false

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -2434,12 +2434,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/TumourClassificationEnum'
           - type: 'null'
-        submitter_specimen_id:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Submitter Specimen Id
         submitter_treatment_id:
           anyOf:
           - maxLength: 64
@@ -4544,11 +4538,6 @@ components:
           - type: string
           - type: 'null'
           title: Submitter Donor Id
-        submitter_specimen_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Specimen Id
         submitter_treatment_id:
           anyOf:
           - type: string
@@ -4632,13 +4621,11 @@ components:
         submitter_donor_id:
           title: Submitter Donor Id
           type: string
-        submitter_specimen_id:
+        submitter_treatment_id:
           anyOf:
           - maxLength: 64
             type: string
           - type: 'null'
-          title: Submitter Specimen Id
-        submitter_treatment_id:
           title: Submitter Treatment Id
           type: string
         surgery_location:
@@ -4734,12 +4721,6 @@ components:
         submitter_donor_id:
           title: Submitter Donor Id
           type: string
-        submitter_specimen_id:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Submitter Specimen Id
         submitter_treatment_id:
           title: Submitter Treatment Id
           type: string
@@ -6922,14 +6903,6 @@ paths:
           - type: string
           - type: 'null'
           title: Submitter Treatment Id
-      - in: query
-        name: submitter_specimen_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Specimen Id
       - in: query
         name: surgery_type
         required: false

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -751,6 +751,12 @@ components:
           q: treatment_type__overlap
           title: Treatment Type
           type: array
+        primary_site:
+          items:
+            type: string
+          q: primary_site__overlap
+          title: Primary Site
+          type: array
       title: DonorExplorerFilterSchema
       type: object
     DonorExplorerSchema:
@@ -825,12 +831,6 @@ components:
           - type: string
           - type: 'null'
           title: Lost To Followup Reason
-        primary_site:
-          items:
-            type: string
-          q: primary_site__overlap
-          title: Primary Site
-          type: array
         program_id:
           anyOf:
           - type: string
@@ -1861,6 +1861,11 @@ components:
           pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Primary Diagnosis Id
           type: string
+        primary_site:
+          anyOf:
+          - $ref: '#/components/schemas/PrimarySiteEnum'
+          - type: 'null'
+          title: Primary Site
         treatments:
           items:
             $ref: '#/components/schemas/NestedTreatmentSchema'
@@ -2604,6 +2609,11 @@ components:
           - type: string
           - type: 'null'
           title: Laterality
+        primary_site:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Primary Site
         program_id:
           anyOf:
           - type: string
@@ -2778,8 +2788,10 @@ components:
           - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
           - type: 'null'
         primary_site:
+          anyOf:
+          - $ref: '#/components/schemas/PrimarySiteEnum'
+          - type: 'null'
           title: Primary Site
-          type: string
         program_id:
           title: Program Id
           type: string
@@ -5338,15 +5350,6 @@ paths:
           - type: string
           - type: 'null'
           title: Cause Of Death
-      - in: query
-        name: primary_site
-        required: false
-        schema:
-          items:
-            type: string
-          q: primary_site__overlap
-          title: Primary Site
-          type: array
       - in: query
         name: page
         required: false

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -321,18 +321,18 @@ components:
       - Unknown
       title: CellsMeasureMethodEnum
       type: string
-    ChemotherapyFilterSchema:
+    SystemicTherapyFilterSchema:
       properties:
         actual_cumulative_drug_dose:
           anyOf:
           - type: integer
           - type: 'null'
           title: Actual Cumulative Drug Dose
-        chemotherapy_drug_dose_units:
+        drug_dose_units:
           anyOf:
           - type: string
           - type: 'null'
-          title: Chemotherapy Drug Dose Units
+          title: Drug Dose Units
         drug_name:
           anyOf:
           - type: string
@@ -353,6 +353,11 @@ components:
           - type: integer
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
+        systemic_therapy_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Systemic Therapy Type
         program_id:
           anyOf:
           - type: string
@@ -368,16 +373,16 @@ components:
           - type: string
           - type: 'null'
           title: Submitter Treatment Id
-      title: ChemotherapyFilterSchema
+      title: SystemicTherapyFilterSchema
       type: object
-    ChemotherapyIngestSchema:
+    SystemicTherapyIngestSchema:
       properties:
         actual_cumulative_drug_dose:
           anyOf:
           - type: integer
           - type: 'null'
           title: Actual Cumulative Drug Dose
-        chemotherapy_drug_dose_units:
+        drug_dose_units:
           anyOf:
           - $ref: '#/components/schemas/DosageUnitsEnum'
           - type: 'null'
@@ -402,6 +407,11 @@ components:
           - type: integer
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
+        systemic_therapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/SystemicTherapyTypeEnum'
+          - type: 'null'
+          title: Systemic Therapy Type
         program_id:
           title: Program Id
           type: string
@@ -420,16 +430,16 @@ components:
       - program_id
       - submitter_donor_id
       - submitter_treatment_id
-      title: ChemotherapyIngestSchema
+      title: SystemicTherapyIngestSchema
       type: object
-    ChemotherapyModelSchema:
+    SystemicTherapyModelSchema:
       properties:
         actual_cumulative_drug_dose:
           anyOf:
           - type: integer
           - type: 'null'
           title: Actual Cumulative Drug Dose
-        chemotherapy_drug_dose_units:
+        drug_dose_units:
           anyOf:
           - $ref: '#/components/schemas/DosageUnitsEnum'
           - type: 'null'
@@ -454,6 +464,10 @@ components:
           - type: integer
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
+        systemic_therapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/SystemicTherapyTypeEnum'
+          - type: 'null'
         program_id:
           title: Program Id
           type: string
@@ -467,7 +481,7 @@ components:
       - program_id
       - submitter_donor_id
       - submitter_treatment_id
-      title: ChemotherapyModelSchema
+      title: SystemicTherapyModelSchema
       type: object
     ComorbidityFilterSchema:
       properties:
@@ -668,25 +682,15 @@ components:
       type: string
     DonorExplorerFilterSchema:
       properties:
-        chemotherapy_drug_name:
+        systemic_therapy_drug_name:
           items:
             type: string
-          title: Chemotherapy Drug Name
+          title: Systemic Therapy Drug Name
           type: array
         exclude_cohorts:
           items:
             type: string
           title: Exclude Cohorts
-          type: array
-        hormone_therapy_drug_name:
-          items:
-            type: string
-          title: Hormone Therapy Drug Name
-          type: array
-        immunotherapy_drug_name:
-          items:
-            type: string
-          title: Immunotherapy Drug Name
           type: array
         treatment_type:
           items:
@@ -1334,154 +1338,6 @@ components:
       - Unknown
       title: Her2StatusEnum
       type: string
-    HormoneTherapyFilterSchema:
-      properties:
-        actual_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-        drug_name:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Name
-        drug_reference_database:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Reference Database
-        drug_reference_identifier:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-        hormone_drug_dose_units:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Hormone Drug Dose Units
-        prescribed_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-        program_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Program Id
-        submitter_donor_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Donor Id
-        submitter_treatment_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Treatment Id
-      title: HormoneTherapyFilterSchema
-      type: object
-    HormoneTherapyIngestSchema:
-      properties:
-        actual_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-        drug_name:
-          anyOf:
-          - maxLength: 255
-            type: string
-          - type: 'null'
-          title: Drug Name
-        drug_reference_database:
-          anyOf:
-          - $ref: '#/components/schemas/DrugReferenceDbEnum'
-          - type: 'null'
-        drug_reference_identifier:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-        hormone_drug_dose_units:
-          anyOf:
-          - $ref: '#/components/schemas/DosageUnitsEnum'
-          - type: 'null'
-        prescribed_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-        program_id:
-          title: Program Id
-          type: string
-        submitter_donor_id:
-          title: Submitter Donor Id
-          type: string
-        submitter_treatment_id:
-          title: Submitter Treatment Id
-          type: string
-        uuid:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Uuid
-      required:
-      - program_id
-      - submitter_donor_id
-      - submitter_treatment_id
-      title: HormoneTherapyIngestSchema
-      type: object
-    HormoneTherapyModelSchema:
-      properties:
-        actual_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-        drug_name:
-          anyOf:
-          - maxLength: 255
-            type: string
-          - type: 'null'
-          title: Drug Name
-        drug_reference_database:
-          anyOf:
-          - $ref: '#/components/schemas/DrugReferenceDbEnum'
-          - type: 'null'
-        drug_reference_identifier:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-        hormone_drug_dose_units:
-          anyOf:
-          - $ref: '#/components/schemas/DosageUnitsEnum'
-          - type: 'null'
-        prescribed_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-        program_id:
-          title: Program Id
-          type: string
-        submitter_donor_id:
-          title: Submitter Donor Id
-          type: string
-        submitter_treatment_id:
-          title: Submitter Treatment Id
-          type: string
-      required:
-      - program_id
-      - submitter_donor_id
-      - submitter_treatment_id
-      title: HormoneTherapyModelSchema
-      type: object
     HpvStrainEnum:
       enum:
       - HPV16
@@ -1501,167 +1357,6 @@ components:
       - HPV73
       title: HpvStrainEnum
       type: string
-    ImmunotherapyFilterSchema:
-      properties:
-        actual_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-        drug_name:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Name
-        drug_reference_database:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Reference Database
-        drug_reference_identifier:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-        immunotherapy_drug_dose_units:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Immunotherapy Drug Dose Units
-        immunotherapy_type:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Immunotherapy Type
-        prescribed_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-        program_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Program Id
-        submitter_donor_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Donor Id
-        submitter_treatment_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Treatment Id
-      title: ImmunotherapyFilterSchema
-      type: object
-    ImmunotherapyIngestSchema:
-      properties:
-        actual_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-        drug_name:
-          anyOf:
-          - maxLength: 255
-            type: string
-          - type: 'null'
-          title: Drug Name
-        drug_reference_database:
-          anyOf:
-          - $ref: '#/components/schemas/DrugReferenceDbEnum'
-          - type: 'null'
-        drug_reference_identifier:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-        immunotherapy_drug_dose_units:
-          anyOf:
-          - $ref: '#/components/schemas/DosageUnitsEnum'
-          - type: 'null'
-        immunotherapy_type:
-          anyOf:
-          - $ref: '#/components/schemas/ImmunotherapyTypeEnum'
-          - type: 'null'
-        prescribed_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-        program_id:
-          title: Program Id
-          type: string
-        submitter_donor_id:
-          title: Submitter Donor Id
-          type: string
-        submitter_treatment_id:
-          title: Submitter Treatment Id
-          type: string
-        uuid:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Uuid
-      required:
-      - program_id
-      - submitter_donor_id
-      - submitter_treatment_id
-      title: ImmunotherapyIngestSchema
-      type: object
-    ImmunotherapyModelSchema:
-      properties:
-        actual_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-        drug_name:
-          anyOf:
-          - maxLength: 255
-            type: string
-          - type: 'null'
-          title: Drug Name
-        drug_reference_database:
-          anyOf:
-          - $ref: '#/components/schemas/DrugReferenceDbEnum'
-          - type: 'null'
-        drug_reference_identifier:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-        immunotherapy_drug_dose_units:
-          anyOf:
-          - $ref: '#/components/schemas/DosageUnitsEnum'
-          - type: 'null'
-        immunotherapy_type:
-          anyOf:
-          - $ref: '#/components/schemas/ImmunotherapyTypeEnum'
-          - type: 'null'
-        prescribed_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-        program_id:
-          title: Program Id
-          type: string
-        submitter_donor_id:
-          title: Submitter Donor Id
-          type: string
-        submitter_treatment_id:
-          title: Submitter Treatment Id
-          type: string
-      required:
-      - program_id
-      - submitter_donor_id
-      - submitter_treatment_id
-      title: ImmunotherapyModelSchema
-      type: object
     ImmunotherapyTypeEnum:
       enum:
       - Cell-based
@@ -1879,14 +1574,14 @@ components:
           - type: 'null'
       title: NestedBiomarkerSchema
       type: object
-    NestedChemotherapySchema:
+    NestedSystemicTherapySchema:
       properties:
         actual_cumulative_drug_dose:
           anyOf:
           - type: integer
           - type: 'null'
           title: Actual Cumulative Drug Dose
-        chemotherapy_drug_dose_units:
+        drug_dose_units:
           anyOf:
           - $ref: '#/components/schemas/DosageUnitsEnum'
           - type: 'null'
@@ -1911,7 +1606,11 @@ components:
           - type: integer
           - type: 'null'
           title: Prescribed Cumulative Drug Dose
-      title: NestedChemotherapySchema
+        systemic_therapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/SystemicTherapyTypeEnum'
+          - type: 'null'
+      title: NestedSystemicTherapySchema
       type: object
     NestedComorbiditySchema:
       properties:
@@ -2007,78 +1706,6 @@ components:
       required:
       - submitter_follow_up_id
       title: NestedFollowUpSchema
-      type: object
-    NestedHormoneTherapySchema:
-      properties:
-        actual_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-        drug_name:
-          anyOf:
-          - maxLength: 255
-            type: string
-          - type: 'null'
-          title: Drug Name
-        drug_reference_database:
-          anyOf:
-          - $ref: '#/components/schemas/DrugReferenceDbEnum'
-          - type: 'null'
-        drug_reference_identifier:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-        hormone_drug_dose_units:
-          anyOf:
-          - $ref: '#/components/schemas/DosageUnitsEnum'
-          - type: 'null'
-        prescribed_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-      title: NestedHormoneTherapySchema
-      type: object
-    NestedImmunotherapySchema:
-      properties:
-        actual_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-        drug_name:
-          anyOf:
-          - maxLength: 255
-            type: string
-          - type: 'null'
-          title: Drug Name
-        drug_reference_database:
-          anyOf:
-          - $ref: '#/components/schemas/DrugReferenceDbEnum'
-          - type: 'null'
-        drug_reference_identifier:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-        immunotherapy_drug_dose_units:
-          anyOf:
-          - $ref: '#/components/schemas/DosageUnitsEnum'
-          - type: 'null'
-        immunotherapy_type:
-          anyOf:
-          - $ref: '#/components/schemas/ImmunotherapyTypeEnum'
-          - type: 'null'
-        prescribed_cumulative_drug_dose:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-      title: NestedImmunotherapySchema
       type: object
     NestedPrimaryDiagnosisSchema:
       properties:
@@ -2397,10 +2024,10 @@ components:
       type: object
     NestedTreatmentSchema:
       properties:
-        chemotherapies:
+        systemic_therapies:
           items:
-            $ref: '#/components/schemas/NestedChemotherapySchema'
-          title: Chemotherapies
+            $ref: '#/components/schemas/NestedSystemicTherapySchema'
+          title: Systemic Therapies
           type: array
         days_per_cycle:
           anyOf:
@@ -2411,16 +2038,6 @@ components:
           items:
             $ref: '#/components/schemas/NestedFollowUpSchema'
           title: Followups
-          type: array
-        hormone_therapies:
-          items:
-            $ref: '#/components/schemas/NestedHormoneTherapySchema'
-          title: Hormone Therapies
-          type: array
-        immunotherapies:
-          items:
-            $ref: '#/components/schemas/NestedImmunotherapySchema'
-          title: Immunotherapies
           type: array
         is_primary_treatment:
           anyOf:
@@ -2519,7 +2136,7 @@ components:
       - previous_page
       title: PagedBiomarkerModelSchema
       type: object
-    PagedChemotherapyModelSchema:
+    PagedSystemicTherapyModelSchema:
       properties:
         count:
           anyOf:
@@ -2528,7 +2145,7 @@ components:
           title: Count
         items:
           items:
-            $ref: '#/components/schemas/ChemotherapyModelSchema'
+            $ref: '#/components/schemas/SystemicTherapyModelSchema'
           title: Items
           type: array
         next_page:
@@ -2546,7 +2163,7 @@ components:
       - count
       - next_page
       - previous_page
-      title: PagedChemotherapyModelSchema
+      title: PagedSystemicTherapyModelSchema
       type: object
     PagedComorbidityModelSchema:
       properties:
@@ -2663,64 +2280,6 @@ components:
       - next_page
       - previous_page
       title: PagedFollowUpModelSchema
-      type: object
-    PagedHormoneTherapyModelSchema:
-      properties:
-        count:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Count
-        items:
-          items:
-            $ref: '#/components/schemas/HormoneTherapyModelSchema'
-          title: Items
-          type: array
-        next_page:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Next Page
-        previous_page:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Previous Page
-      required:
-      - items
-      - count
-      - next_page
-      - previous_page
-      title: PagedHormoneTherapyModelSchema
-      type: object
-    PagedImmunotherapyModelSchema:
-      properties:
-        count:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Count
-        items:
-          items:
-            $ref: '#/components/schemas/ImmunotherapyModelSchema'
-          title: Items
-          type: array
-        next_page:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Next Page
-        previous_page:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Previous Page
-      required:
-      - items
-      - count
-      - next_page
-      - previous_page
-      title: PagedImmunotherapyModelSchema
       type: object
     PagedPrimaryDiagnosisModelSchema:
       properties:
@@ -4778,6 +4337,13 @@ components:
       - UMLS
       title: SurgeryReferenceDatabaseEnum
       type: string
+    SystemicTherapyTypeEnum:
+      enum:
+      - Chemotherapy
+      - Hormone Therapy
+      - Immunotherapy
+      title: SystemicTherapyTypeEnum
+      type: string
     TCategoryEnum:
       enum:
       - T0
@@ -5476,9 +5042,9 @@ paths:
       summary: List Biomarkers
       tags:
       - authorized
-  /v2/authorized/chemotherapies/:
+  /v2/authorized/systemic_therapies/:
     get:
-      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_chemotherapies
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_systemic_therapies
       parameters:
       - in: query
         name: program_id
@@ -5529,13 +5095,13 @@ paths:
           - type: 'null'
           title: Drug Reference Identifier
       - in: query
-        name: chemotherapy_drug_dose_units
+        name: drug_dose_units
         required: false
         schema:
           anyOf:
           - type: string
           - type: 'null'
-          title: Chemotherapy Drug Dose Units
+          title: Drug Dose Units
       - in: query
         name: prescribed_cumulative_drug_dose
         required: false
@@ -5552,6 +5118,14 @@ paths:
           - type: integer
           - type: 'null'
           title: Actual Cumulative Drug Dose
+      - in: query
+        name: systemic_therapy_type
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Systemic Therapy Type
       - in: query
         name: page
         required: false
@@ -5571,11 +5145,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PagedChemotherapyModelSchema'
+                $ref: '#/components/schemas/PagedSystemicTherapyModelSchema'
           description: OK
       security:
       - LoginAuth: []
-      summary: List Chemotherapies
+      summary: List Systemic Therapies
       tags:
       - authorized
   /v2/authorized/comorbidities/:
@@ -5986,218 +5560,6 @@ paths:
       security:
       - LoginAuth: []
       summary: List Follow Ups
-      tags:
-      - authorized
-  /v2/authorized/hormone_therapies/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_hormone_therapies
-      parameters:
-      - in: query
-        name: program_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Program Id
-      - in: query
-        name: submitter_donor_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Donor Id
-      - in: query
-        name: submitter_treatment_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Treatment Id
-      - in: query
-        name: drug_reference_database
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Reference Database
-      - in: query
-        name: drug_name
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Name
-      - in: query
-        name: drug_reference_identifier
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-      - in: query
-        name: hormone_drug_dose_units
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Hormone Drug Dose Units
-      - in: query
-        name: prescribed_cumulative_drug_dose
-        required: false
-        schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-      - in: query
-        name: actual_cumulative_drug_dose
-        required: false
-        schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-      - in: query
-        name: page
-        required: false
-        schema:
-          minimum: 1
-          title: Page
-          type: integer
-      - in: query
-        name: page_size
-        required: false
-        schema:
-          minimum: 1
-          title: Page Size
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PagedHormoneTherapyModelSchema'
-          description: OK
-      security:
-      - LoginAuth: []
-      summary: List Hormone Therapies
-      tags:
-      - authorized
-  /v2/authorized/immunotherapies/:
-    get:
-      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_immunotherapies
-      parameters:
-      - in: query
-        name: program_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Program Id
-      - in: query
-        name: submitter_donor_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Donor Id
-      - in: query
-        name: submitter_treatment_id
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Submitter Treatment Id
-      - in: query
-        name: drug_reference_database
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Reference Database
-      - in: query
-        name: immunotherapy_type
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Immunotherapy Type
-      - in: query
-        name: drug_name
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Name
-      - in: query
-        name: drug_reference_identifier
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Drug Reference Identifier
-      - in: query
-        name: immunotherapy_drug_dose_units
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Immunotherapy Drug Dose Units
-      - in: query
-        name: prescribed_cumulative_drug_dose
-        required: false
-        schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Prescribed Cumulative Drug Dose
-      - in: query
-        name: actual_cumulative_drug_dose
-        required: false
-        schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Actual Cumulative Drug Dose
-      - in: query
-        name: page
-        required: false
-        schema:
-          minimum: 1
-          title: Page
-          type: integer
-      - in: query
-        name: page_size
-        required: false
-        schema:
-          minimum: 1
-          title: Page Size
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PagedImmunotherapyModelSchema'
-          description: OK
-      security:
-      - LoginAuth: []
-      summary: List Immunotherapies
       tags:
       - authorized
   /v2/authorized/primary_diagnoses/:
@@ -7321,28 +6683,12 @@ paths:
           title: Primary Site
           type: array
       - in: query
-        name: chemotherapy_drug_name
+        name: systemic_therapy_drug_name
         required: false
         schema:
           items:
             type: string
-          title: Chemotherapy Drug Name
-          type: array
-      - in: query
-        name: immunotherapy_drug_name
-        required: false
-        schema:
-          items:
-            type: string
-          title: Immunotherapy Drug Name
-          type: array
-      - in: query
-        name: hormone_therapy_drug_name
-        required: false
-        schema:
-          items:
-            type: string
-          title: Hormone Therapy Drug Name
+          title: Systemic Therapy Drug Name
           type: array
       - in: query
         name: exclude_cohorts
@@ -7385,22 +6731,22 @@ paths:
       summary: Create Biomarker
       tags:
       - ingest
-  /v2/ingest/chemotherapy/:
+  /v2/ingest/systemic_therapy/:
     post:
-      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_chemotherapy
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_systemic_therapy
       parameters: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ChemotherapyIngestSchema'
+              $ref: '#/components/schemas/SystemicTherapyIngestSchema'
         required: true
       responses:
         '200':
           description: OK
       security:
       - LoginAuth: []
-      summary: Create Chemotherapy
+      summary: Create Systemic Therapy
       tags:
       - ingest
   /v2/ingest/comorbidity/:
@@ -7473,42 +6819,6 @@ paths:
       security:
       - LoginAuth: []
       summary: Create Follow Up
-      tags:
-      - ingest
-  /v2/ingest/hormone_therapy/:
-    post:
-      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_hormone_therapy
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/HormoneTherapyIngestSchema'
-        required: true
-      responses:
-        '200':
-          description: OK
-      security:
-      - LoginAuth: []
-      summary: Create Hormone Therapy
-      tags:
-      - ingest
-  /v2/ingest/immunotherapy/:
-    post:
-      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_immunotherapy
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ImmunotherapyIngestSchema'
-        required: true
-      responses:
-        '200':
-          description: OK
-      security:
-      - LoginAuth: []
-      summary: Create Immunotherapy
       tags:
       - ingest
   /v2/ingest/primary_diagnosis/:

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -1,0 +1,7806 @@
+components:
+  schemas:
+    BasisOfDiagnosisEnum:
+      enum:
+      - Clinical investigation
+      - Clinical
+      - Cytology
+      - Death certificate only
+      - Histology of a metastasis
+      - Histology of a primary tumour
+      - Specific tumour markers
+      - Unknown
+      title: BasisOfDiagnosisEnum
+      type: string
+    BiomarkerFilterSchema:
+      properties:
+        ca125:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Ca125
+        cea:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cea
+        er_percent_positive:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Er Percent Positive
+        er_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Er Status
+        her2_ihc_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Her2 Ihc Status
+        her2_ish_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Her2 Ish Status
+        hpv_ihc_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hpv Ihc Status
+        hpv_pcr_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hpv Pcr Status
+        hpv_strain:
+          items:
+            type: string
+          q: hpv_strain__overlap
+          title: Hpv Strain
+          type: array
+        pr_percent_positive:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pr Percent Positive
+        pr_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pr Status
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        psa_level:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Psa Level
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_follow_up_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Follow Up Id
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_specimen_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      title: BiomarkerFilterSchema
+      type: object
+    BiomarkerIngestSchema:
+      properties:
+        ca125:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Ca125
+        cea:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cea
+        er_percent_positive:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Er Percent Positive
+        er_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        her2_ihc_status:
+          anyOf:
+          - $ref: '#/components/schemas/Her2StatusEnum'
+          - type: 'null'
+        her2_ish_status:
+          anyOf:
+          - $ref: '#/components/schemas/Her2StatusEnum'
+          - type: 'null'
+        hpv_ihc_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        hpv_pcr_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        hpv_strain:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/HpvStrainEnum'
+            type: array
+          - type: 'null'
+          title: Hpv Strain
+        pr_percent_positive:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pr Percent Positive
+        pr_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        psa_level:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Psa Level
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_follow_up_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Follow Up Id
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_specimen_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        submitter_treatment_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+        test_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - program_id
+      - submitter_donor_id
+      title: BiomarkerIngestSchema
+      type: object
+    BiomarkerModelSchema:
+      properties:
+        ca125:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Ca125
+        cea:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cea
+        er_percent_positive:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Er Percent Positive
+        er_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        her2_ihc_status:
+          anyOf:
+          - $ref: '#/components/schemas/Her2StatusEnum'
+          - type: 'null'
+        her2_ish_status:
+          anyOf:
+          - $ref: '#/components/schemas/Her2StatusEnum'
+          - type: 'null'
+        hpv_ihc_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        hpv_pcr_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        hpv_strain:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/HpvStrainEnum'
+            type: array
+          - type: 'null'
+          title: Hpv Strain
+        pr_percent_positive:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pr Percent Positive
+        pr_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        psa_level:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Psa Level
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_follow_up_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Follow Up Id
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_specimen_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        submitter_treatment_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+        test_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+      required:
+      - program_id
+      - submitter_donor_id
+      title: BiomarkerModelSchema
+      type: object
+    CauseOfDeathEnum:
+      enum:
+      - Died of cancer
+      - Died of other reasons
+      - Unknown
+      title: CauseOfDeathEnum
+      type: string
+    CellsMeasureMethodEnum:
+      enum:
+      - Genomics
+      - Image analysis
+      - Pathology estimate by percent nuclei
+      - Unknown
+      title: CellsMeasureMethodEnum
+      type: string
+    ChemotherapyFilterSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        chemotherapy_drug_dose_units:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Chemotherapy Drug Dose Units
+        drug_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Database
+        drug_reference_identifier:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      title: ChemotherapyFilterSchema
+      type: object
+    ChemotherapyIngestSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        chemotherapy_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: ChemotherapyIngestSchema
+      type: object
+    ChemotherapyModelSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        chemotherapy_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: ChemotherapyModelSchema
+      type: object
+    ComorbidityFilterSchema:
+      properties:
+        age_at_comorbidity_diagnosis:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Age At Comorbidity Diagnosis
+        comorbidity_treatment:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comorbidity Treatment
+        comorbidity_treatment_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comorbidity Treatment Status
+        comorbidity_type_code:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comorbidity Type Code
+        laterality_of_prior_malignancy:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Laterality Of Prior Malignancy
+        prior_malignancy:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Prior Malignancy
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      title: ComorbidityFilterSchema
+      type: object
+    ComorbidityIngestSchema:
+      properties:
+        age_at_comorbidity_diagnosis:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Age At Comorbidity Diagnosis
+        comorbidity_treatment:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Comorbidity Treatment
+        comorbidity_treatment_status:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+        comorbidity_type_code:
+          anyOf:
+          - maxLength: 64
+            pattern: ^[A-Z][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$
+            type: string
+          - type: 'null'
+          title: Comorbidity Type Code
+        laterality_of_prior_malignancy:
+          anyOf:
+          - $ref: '#/components/schemas/MalignancyLateralityEnum'
+          - type: 'null'
+        prior_malignancy:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - program_id
+      - submitter_donor_id
+      title: ComorbidityIngestSchema
+      type: object
+    ComorbidityModelSchema:
+      properties:
+        age_at_comorbidity_diagnosis:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Age At Comorbidity Diagnosis
+        comorbidity_treatment:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Comorbidity Treatment
+        comorbidity_treatment_status:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+        comorbidity_type_code:
+          anyOf:
+          - maxLength: 64
+            pattern: ^[A-Z][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$
+            type: string
+          - type: 'null'
+          title: Comorbidity Type Code
+        laterality_of_prior_malignancy:
+          anyOf:
+          - $ref: '#/components/schemas/MalignancyLateralityEnum'
+          - type: 'null'
+        prior_malignancy:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+      required:
+      - program_id
+      - submitter_donor_id
+      title: ComorbidityModelSchema
+      type: object
+    ConfirmedDiagnosisTumourEnum:
+      enum:
+      - 'Yes'
+      - 'No'
+      - Not done
+      - Unknown
+      title: ConfirmedDiagnosisTumourEnum
+      type: string
+    DateInterval:
+      properties:
+        day_interval:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          description: number of days since first diagnosis
+          title: Day Interval
+        month_interval:
+          description: number of months since first diagnosis
+          title: Month Interval
+          type: integer
+      required:
+      - month_interval
+      title: DateInterval
+      type: object
+    DiagnosisAgeCountSchema:
+      properties:
+        age_at_diagnosis:
+          title: Age At Diagnosis
+          type: string
+        age_count:
+          title: Age Count
+          type: string
+      required:
+      - age_at_diagnosis
+      - age_count
+      title: DiagnosisAgeCountSchema
+      type: object
+    DiscoveryDonorSchema:
+      properties:
+        donors_count:
+          title: Donors Count
+          type: string
+        program_id:
+          title: Program Id
+          type: string
+      required:
+      - program_id
+      - donors_count
+      title: DiscoveryDonorSchema
+      type: object
+    DiseaseStatusFollowupEnum:
+      enum:
+      - Complete remission
+      - Distant progression
+      - Loco-regional progression
+      - No evidence of disease
+      - Partial remission
+      - Progression not otherwise specified
+      - Relapse or recurrence
+      - Stable
+      title: DiseaseStatusFollowupEnum
+      type: string
+    DonorExplorerFilterSchema:
+      properties:
+        chemotherapy_drug_name:
+          items:
+            type: string
+          title: Chemotherapy Drug Name
+          type: array
+        exclude_cohorts:
+          items:
+            type: string
+          title: Exclude Cohorts
+          type: array
+        hormone_therapy_drug_name:
+          items:
+            type: string
+          title: Hormone Therapy Drug Name
+          type: array
+        immunotherapy_drug_name:
+          items:
+            type: string
+          title: Immunotherapy Drug Name
+          type: array
+        primary_site:
+          items:
+            type: string
+          q: primary_site__overlap
+          title: Primary Site
+          type: array
+        treatment_type:
+          items:
+            type: string
+          q: treatment_type__overlap
+          title: Treatment Type
+          type: array
+      title: DonorExplorerFilterSchema
+      type: object
+    DonorExplorerSchema:
+      properties:
+        age_at_diagnosis:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Age At Diagnosis
+        primary_site:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Primary Site
+        program_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Donor Id
+          type: string
+        submitter_sample_ids:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Submitter Sample Ids
+        treatment_type:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Treatment Type
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_sample_ids
+      title: DonorExplorerSchema
+      type: object
+    DonorFilterSchema:
+      properties:
+        cause_of_death:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cause Of Death
+        gender:
+          anyOf:
+          - type: string
+          - type: 'null'
+          q: gender__icontains
+          title: Gender
+        is_deceased:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Deceased
+        lost_to_followup_after_clinical_event_identifier:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lost To Followup After Clinical Event Identifier
+        lost_to_followup_reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lost To Followup Reason
+        primary_site:
+          items:
+            type: string
+          q: primary_site__overlap
+          title: Primary Site
+          type: array
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        sex_at_birth:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sex At Birth
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      title: DonorFilterSchema
+      type: object
+    DonorIngestSchema:
+      properties:
+        cause_of_death:
+          anyOf:
+          - $ref: '#/components/schemas/CauseOfDeathEnum'
+          - type: 'null'
+        date_alive_after_lost_to_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_birth:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_death:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_resolution:
+          anyOf:
+          - maxLength: 32
+            type: string
+          - type: 'null'
+          title: Date Resolution
+        gender:
+          anyOf:
+          - $ref: '#/components/schemas/GenderEnum'
+          - type: 'null'
+        is_deceased:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Deceased
+        lost_to_followup_after_clinical_event_identifier:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Lost To Followup After Clinical Event Identifier
+        lost_to_followup_reason:
+          anyOf:
+          - $ref: '#/components/schemas/LostToFollowupReasonEnum'
+          - type: 'null'
+        primary_site:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/PrimarySiteEnum'
+            type: array
+          - type: 'null'
+          title: Primary Site
+        program_id:
+          title: Program Id
+          type: string
+        sex_at_birth:
+          anyOf:
+          - $ref: '#/components/schemas/SexAtBirthEnum'
+          - type: 'null'
+        submitter_donor_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Donor Id
+          type: string
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - submitter_donor_id
+      - program_id
+      title: DonorIngestSchema
+      type: object
+    DonorModelSchema:
+      properties:
+        cause_of_death:
+          anyOf:
+          - $ref: '#/components/schemas/CauseOfDeathEnum'
+          - type: 'null'
+        date_alive_after_lost_to_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_birth:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_death:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_resolution:
+          anyOf:
+          - maxLength: 32
+            type: string
+          - type: 'null'
+          title: Date Resolution
+        gender:
+          anyOf:
+          - $ref: '#/components/schemas/GenderEnum'
+          - type: 'null'
+        is_deceased:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Deceased
+        lost_to_followup_after_clinical_event_identifier:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Lost To Followup After Clinical Event Identifier
+        lost_to_followup_reason:
+          anyOf:
+          - $ref: '#/components/schemas/LostToFollowupReasonEnum'
+          - type: 'null'
+        primary_site:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/PrimarySiteEnum'
+            type: array
+          - type: 'null'
+          title: Primary Site
+        program_id:
+          title: Program Id
+          type: string
+        sex_at_birth:
+          anyOf:
+          - $ref: '#/components/schemas/SexAtBirthEnum'
+          - type: 'null'
+        submitter_donor_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Donor Id
+          type: string
+      required:
+      - submitter_donor_id
+      - program_id
+      title: DonorModelSchema
+      type: object
+    DonorWithClinicalDataSchema:
+      properties:
+        biomarkers:
+          items:
+            $ref: '#/components/schemas/NestedBiomarkerSchema'
+          title: Biomarkers
+          type: array
+        cause_of_death:
+          anyOf:
+          - $ref: '#/components/schemas/CauseOfDeathEnum'
+          - type: 'null'
+        comorbidities:
+          items:
+            $ref: '#/components/schemas/NestedComorbiditySchema'
+          title: Comorbidities
+          type: array
+        date_alive_after_lost_to_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_birth:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_death:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_resolution:
+          anyOf:
+          - maxLength: 32
+            type: string
+          - type: 'null'
+          title: Date Resolution
+        exposures:
+          items:
+            $ref: '#/components/schemas/NestedExposureSchema'
+          title: Exposures
+          type: array
+        followups:
+          items:
+            $ref: '#/components/schemas/NestedFollowUpSchema'
+          title: Followups
+          type: array
+        gender:
+          anyOf:
+          - $ref: '#/components/schemas/GenderEnum'
+          - type: 'null'
+        is_deceased:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Deceased
+        lost_to_followup_after_clinical_event_identifier:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Lost To Followup After Clinical Event Identifier
+        lost_to_followup_reason:
+          anyOf:
+          - $ref: '#/components/schemas/LostToFollowupReasonEnum'
+          - type: 'null'
+        primary_diagnoses:
+          items:
+            $ref: '#/components/schemas/NestedPrimaryDiagnosisSchema'
+          title: Primary Diagnoses
+          type: array
+        primary_site:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/PrimarySiteEnum'
+            type: array
+          - type: 'null'
+          title: Primary Site
+        program_id:
+          title: Program Id
+          type: string
+        sex_at_birth:
+          anyOf:
+          - $ref: '#/components/schemas/SexAtBirthEnum'
+          - type: 'null'
+        submitter_donor_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Donor Id
+          type: string
+      required:
+      - submitter_donor_id
+      - program_id
+      title: DonorWithClinicalDataSchema
+      type: object
+    DosageUnitsEnum:
+      enum:
+      - mg/m2
+      - IU/m2
+      - IU/kg
+      - ug/m2
+      - g/m2
+      - mg/kg
+      - cells/kg
+      title: DosageUnitsEnum
+      type: string
+    DrugReferenceDbEnum:
+      enum:
+      - RxNorm
+      - PubChem
+      - NCI Thesaurus
+      title: DrugReferenceDbEnum
+      type: string
+    ErPrHpvStatusEnum:
+      enum:
+      - Cannot be determined
+      - Negative
+      - Not applicable
+      - Positive
+      - Unknown
+      title: ErPrHpvStatusEnum
+      type: string
+    ExposureFilterSchema:
+      properties:
+        pack_years_smoked:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pack Years Smoked
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        tobacco_smoking_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tobacco Smoking Status
+        tobacco_type:
+          items:
+            type: string
+          q: tobacco_type__overlap
+          title: Tobacco Type
+          type: array
+      title: ExposureFilterSchema
+      type: object
+    ExposureIngestSchema:
+      properties:
+        pack_years_smoked:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pack Years Smoked
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        tobacco_smoking_status:
+          anyOf:
+          - $ref: '#/components/schemas/SmokingStatusEnum'
+          - type: 'null'
+        tobacco_type:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TobaccoTypeEnum'
+            type: array
+          - type: 'null'
+          title: Tobacco Type
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - program_id
+      - submitter_donor_id
+      title: ExposureIngestSchema
+      type: object
+    ExposureModelSchema:
+      properties:
+        pack_years_smoked:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pack Years Smoked
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        tobacco_smoking_status:
+          anyOf:
+          - $ref: '#/components/schemas/SmokingStatusEnum'
+          - type: 'null'
+        tobacco_type:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TobaccoTypeEnum'
+            type: array
+          - type: 'null'
+          title: Tobacco Type
+      required:
+      - program_id
+      - submitter_donor_id
+      title: ExposureModelSchema
+      type: object
+    FollowUpFilterSchema:
+      properties:
+        anatomic_site_progression_or_recurrence:
+          items:
+            type: string
+          q: anatomic_site_progression_or_recurrence__overlap
+          title: Anatomic Site Progression Or Recurrence
+          type: array
+        disease_status_at_followup:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Disease Status At Followup
+        method_of_progression_status:
+          items:
+            type: string
+          q: method_of_progression_status__overlap
+          title: Method Of Progression Status
+          type: array
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        recurrence_m_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence M Category
+        recurrence_n_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence N Category
+        recurrence_stage_group:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence Stage Group
+        recurrence_t_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence T Category
+        recurrence_tumour_staging_system:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence Tumour Staging System
+        relapse_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Relapse Type
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_follow_up_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Follow Up Id
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      title: FollowUpFilterSchema
+      type: object
+    FollowUpIngestSchema:
+      properties:
+        anatomic_site_progression_or_recurrence:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Anatomic Site Progression Or Recurrence
+        date_of_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_relapse:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        disease_status_at_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DiseaseStatusFollowupEnum'
+          - type: 'null'
+        method_of_progression_status:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/ProgressionStatusMethodEnum'
+            type: array
+          - type: 'null'
+          title: Method Of Progression Status
+        program_id:
+          title: Program Id
+          type: string
+        recurrence_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        recurrence_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        recurrence_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        recurrence_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        recurrence_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        relapse_type:
+          anyOf:
+          - $ref: '#/components/schemas/RelapseTypeEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_follow_up_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Follow Up Id
+          type: string
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - submitter_follow_up_id
+      - program_id
+      - submitter_donor_id
+      title: FollowUpIngestSchema
+      type: object
+    FollowUpModelSchema:
+      properties:
+        anatomic_site_progression_or_recurrence:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Anatomic Site Progression Or Recurrence
+        date_of_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_relapse:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        disease_status_at_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DiseaseStatusFollowupEnum'
+          - type: 'null'
+        method_of_progression_status:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/ProgressionStatusMethodEnum'
+            type: array
+          - type: 'null'
+          title: Method Of Progression Status
+        program_id:
+          title: Program Id
+          type: string
+        recurrence_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        recurrence_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        recurrence_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        recurrence_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        recurrence_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        relapse_type:
+          anyOf:
+          - $ref: '#/components/schemas/RelapseTypeEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_follow_up_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Follow Up Id
+          type: string
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      required:
+      - submitter_follow_up_id
+      - program_id
+      - submitter_donor_id
+      title: FollowUpModelSchema
+      type: object
+    GenderCountSchema:
+      properties:
+        gender:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Gender
+        gender_count:
+          title: Gender Count
+          type: string
+      required:
+      - gender
+      - gender_count
+      title: GenderCountSchema
+      type: object
+    GenderEnum:
+      enum:
+      - Man
+      - Woman
+      - Non-binary
+      title: GenderEnum
+      type: string
+    Her2StatusEnum:
+      enum:
+      - Cannot be determined
+      - Equivocal
+      - Positive
+      - Negative
+      - Not applicable
+      - Unknown
+      title: Her2StatusEnum
+      type: string
+    HormoneTherapyFilterSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        drug_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Database
+        drug_reference_identifier:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        hormone_drug_dose_units:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hormone Drug Dose Units
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      title: HormoneTherapyFilterSchema
+      type: object
+    HormoneTherapyIngestSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        hormone_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: HormoneTherapyIngestSchema
+      type: object
+    HormoneTherapyModelSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        hormone_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: HormoneTherapyModelSchema
+      type: object
+    HpvStrainEnum:
+      enum:
+      - HPV16
+      - HPV18
+      - HPV31
+      - HPV33
+      - HPV35
+      - HPV39
+      - HPV45
+      - HPV51
+      - HPV52
+      - HPV56
+      - HPV58
+      - HPV59
+      - HPV66
+      - HPV68
+      - HPV73
+      title: HpvStrainEnum
+      type: string
+    ImmunotherapyFilterSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        drug_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Database
+        drug_reference_identifier:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        immunotherapy_drug_dose_units:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Immunotherapy Drug Dose Units
+        immunotherapy_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Immunotherapy Type
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      title: ImmunotherapyFilterSchema
+      type: object
+    ImmunotherapyIngestSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        immunotherapy_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        immunotherapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/ImmunotherapyTypeEnum'
+          - type: 'null'
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: ImmunotherapyIngestSchema
+      type: object
+    ImmunotherapyModelSchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        immunotherapy_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        immunotherapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/ImmunotherapyTypeEnum'
+          - type: 'null'
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: ImmunotherapyModelSchema
+      type: object
+    ImmunotherapyTypeEnum:
+      enum:
+      - Cell-based
+      - Immune checkpoint inhibitors
+      - Monoclonal antibodies other than immune checkpoint inhibitors
+      - Other immunomodulatory substances
+      title: ImmunotherapyTypeEnum
+      type: string
+    Input:
+      properties:
+        page:
+          minimum: 1
+          title: Page
+          type: integer
+        page_size:
+          minimum: 1
+          title: Page Size
+          type: integer
+      title: Input
+      type: object
+    LostToFollowupReasonEnum:
+      enum:
+      - Completed study
+      - Discharged to palliative care
+      - Lost contact
+      - Not applicable
+      - Unknown
+      - Withdrew from study
+      title: LostToFollowupReasonEnum
+      type: string
+    LymphNodeMethodEnum:
+      enum:
+      - Imaging
+      - Lymph node dissection/pathological exam
+      - Physical palpation of patient
+      title: LymphNodeMethodEnum
+      type: string
+    LymphNodeStatusEnum:
+      enum:
+      - Cannot be determined
+      - 'No'
+      - No lymph nodes found in resected specimen
+      - Not applicable
+      - 'Yes'
+      title: LymphNodeStatusEnum
+      type: string
+    LymphovascularInvasionEnum:
+      enum:
+      - Absent
+      - Both lymphatic and small vessel and venous (large vessel) invasion
+      - Lymphatic and small vessel invasion only
+      - Not applicable
+      - Present
+      - Venous (large vessel) invasion only
+      - Unknown
+      title: LymphovascularInvasionEnum
+      type: string
+    MCategoryEnum:
+      enum:
+      - M0
+      - M0(i+)
+      - M1
+      - M1a
+      - M1a(0)
+      - M1a(1)
+      - M1b
+      - M1b(0)
+      - M1b(1)
+      - M1c
+      - M1c(0)
+      - M1c(1)
+      - M1d
+      - M1d(0)
+      - M1d(1)
+      - M1e
+      - MX
+      title: MCategoryEnum
+      type: string
+    MalignancyLateralityEnum:
+      enum:
+      - Bilateral
+      - Left
+      - Midline
+      - Not applicable
+      - Right
+      - Unilateral, Side not specified
+      - Unknown
+      title: MalignancyLateralityEnum
+      type: string
+    MarginTypesEnum:
+      enum:
+      - Circumferential resection margin
+      - Common bile duct margin
+      - Distal margin
+      - Not applicable
+      - Proximal margin
+      - Unknown
+      title: MarginTypesEnum
+      type: string
+    NCategoryEnum:
+      enum:
+      - N0
+      - N0a
+      - N0a (biopsy)
+      - N0b
+      - N0b (no biopsy)
+      - N0(i+)
+      - N0(i-)
+      - N0(mol+)
+      - N0(mol-)
+      - N1
+      - N1a
+      - N1a(sn)
+      - N1b
+      - N1c
+      - N1mi
+      - N2
+      - N2a
+      - N2b
+      - N2c
+      - N2mi
+      - N3
+      - N3a
+      - N3b
+      - N3c
+      - N4
+      - NX
+      title: NCategoryEnum
+      type: string
+    NestedBiomarkerSchema:
+      properties:
+        ca125:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Ca125
+        cea:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cea
+        er_percent_positive:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Er Percent Positive
+        er_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        her2_ihc_status:
+          anyOf:
+          - $ref: '#/components/schemas/Her2StatusEnum'
+          - type: 'null'
+        her2_ish_status:
+          anyOf:
+          - $ref: '#/components/schemas/Her2StatusEnum'
+          - type: 'null'
+        hpv_ihc_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        hpv_pcr_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        hpv_strain:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/HpvStrainEnum'
+            type: array
+          - type: 'null'
+          title: Hpv Strain
+        pr_percent_positive:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pr Percent Positive
+        pr_status:
+          anyOf:
+          - $ref: '#/components/schemas/ErPrHpvStatusEnum'
+          - type: 'null'
+        psa_level:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Psa Level
+        submitter_follow_up_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Follow Up Id
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_specimen_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        submitter_treatment_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+        test_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+      title: NestedBiomarkerSchema
+      type: object
+    NestedChemotherapySchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        chemotherapy_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+      title: NestedChemotherapySchema
+      type: object
+    NestedComorbiditySchema:
+      properties:
+        age_at_comorbidity_diagnosis:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Age At Comorbidity Diagnosis
+        comorbidity_treatment:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Comorbidity Treatment
+        comorbidity_treatment_status:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+        comorbidity_type_code:
+          anyOf:
+          - maxLength: 64
+            pattern: ^[A-Z][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$
+            type: string
+          - type: 'null'
+          title: Comorbidity Type Code
+        laterality_of_prior_malignancy:
+          anyOf:
+          - $ref: '#/components/schemas/MalignancyLateralityEnum'
+          - type: 'null'
+        prior_malignancy:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+      title: NestedComorbiditySchema
+      type: object
+    NestedExposureSchema:
+      properties:
+        pack_years_smoked:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pack Years Smoked
+        tobacco_smoking_status:
+          anyOf:
+          - $ref: '#/components/schemas/SmokingStatusEnum'
+          - type: 'null'
+        tobacco_type:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TobaccoTypeEnum'
+            type: array
+          - type: 'null'
+          title: Tobacco Type
+      title: NestedExposureSchema
+      type: object
+    NestedFollowUpSchema:
+      properties:
+        anatomic_site_progression_or_recurrence:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Anatomic Site Progression Or Recurrence
+        date_of_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        date_of_relapse:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        disease_status_at_followup:
+          anyOf:
+          - $ref: '#/components/schemas/DiseaseStatusFollowupEnum'
+          - type: 'null'
+        method_of_progression_status:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/ProgressionStatusMethodEnum'
+            type: array
+          - type: 'null'
+          title: Method Of Progression Status
+        recurrence_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        recurrence_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        recurrence_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        recurrence_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        recurrence_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        relapse_type:
+          anyOf:
+          - $ref: '#/components/schemas/RelapseTypeEnum'
+          - type: 'null'
+        submitter_follow_up_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Follow Up Id
+          type: string
+      required:
+      - submitter_follow_up_id
+      title: NestedFollowUpSchema
+      type: object
+    NestedHormoneTherapySchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        hormone_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+      title: NestedHormoneTherapySchema
+      type: object
+    NestedImmunotherapySchema:
+      properties:
+        actual_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+        drug_name:
+          anyOf:
+          - maxLength: 255
+            type: string
+          - type: 'null'
+          title: Drug Name
+        drug_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/DrugReferenceDbEnum'
+          - type: 'null'
+        drug_reference_identifier:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+        immunotherapy_drug_dose_units:
+          anyOf:
+          - $ref: '#/components/schemas/DosageUnitsEnum'
+          - type: 'null'
+        immunotherapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/ImmunotherapyTypeEnum'
+          - type: 'null'
+        prescribed_cumulative_drug_dose:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+      title: NestedImmunotherapySchema
+      type: object
+    NestedPrimaryDiagnosisSchema:
+      properties:
+        basis_of_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/BasisOfDiagnosisEnum'
+          - type: 'null'
+        cancer_type_code:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Cancer Type Code
+        clinical_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        clinical_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        clinical_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        clinical_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        clinical_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        date_of_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        followups:
+          items:
+            $ref: '#/components/schemas/NestedFollowUpSchema'
+          title: Followups
+          type: array
+        laterality:
+          anyOf:
+          - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
+          - type: 'null'
+        lymph_nodes_examined_method:
+          anyOf:
+          - $ref: '#/components/schemas/LymphNodeMethodEnum'
+          - type: 'null'
+        lymph_nodes_examined_status:
+          anyOf:
+          - $ref: '#/components/schemas/LymphNodeStatusEnum'
+          - type: 'null'
+        number_lymph_nodes_positive:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Lymph Nodes Positive
+        specimens:
+          items:
+            $ref: '#/components/schemas/NestedSpecimenSchema'
+          title: Specimens
+          type: array
+        submitter_primary_diagnosis_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Primary Diagnosis Id
+          type: string
+        treatments:
+          items:
+            $ref: '#/components/schemas/NestedTreatmentSchema'
+          title: Treatments
+          type: array
+      required:
+      - submitter_primary_diagnosis_id
+      title: NestedPrimaryDiagnosisSchema
+      type: object
+    NestedRadiationSchema:
+      properties:
+        anatomical_site_irradiated:
+          anyOf:
+          - $ref: '#/components/schemas/RadiationAnatomicalSiteEnum'
+          - type: 'null'
+        radiation_boost:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Radiation Boost
+        radiation_therapy_dosage:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Dosage
+        radiation_therapy_fractions:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Fractions
+        radiation_therapy_modality:
+          anyOf:
+          - $ref: '#/components/schemas/RadiationTherapyModalityEnum'
+          - type: 'null'
+        radiation_therapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/TherapyTypeEnum'
+          - type: 'null'
+        reference_radiation_treatment_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Reference Radiation Treatment Id
+      title: NestedRadiationSchema
+      type: object
+    NestedSampleRegistrationSchema:
+      properties:
+        sample_type:
+          anyOf:
+          - $ref: '#/components/schemas/SampleTypeEnum'
+          - type: 'null'
+        specimen_tissue_source:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenTissueSourceEnum'
+          - type: 'null'
+        specimen_type:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenTypeEnum'
+          - type: 'null'
+        submitter_sample_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Sample Id
+          type: string
+        tumour_normal_designation:
+          anyOf:
+          - $ref: '#/components/schemas/TumourDesginationEnum'
+          - type: 'null'
+      required:
+      - submitter_sample_id
+      title: NestedSampleRegistrationSchema
+      type: object
+    NestedSpecimenSchema:
+      properties:
+        pathological_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        pathological_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        pathological_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        pathological_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        pathological_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        percent_tumour_cells_measurement_method:
+          anyOf:
+          - $ref: '#/components/schemas/CellsMeasureMethodEnum'
+          - type: 'null'
+        percent_tumour_cells_range:
+          anyOf:
+          - $ref: '#/components/schemas/PercentCellsRangeEnum'
+          - type: 'null'
+        reference_pathology_confirmed_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/ConfirmedDiagnosisTumourEnum'
+          - type: 'null'
+        reference_pathology_confirmed_tumour_presence:
+          anyOf:
+          - $ref: '#/components/schemas/ConfirmedDiagnosisTumourEnum'
+          - type: 'null'
+        sample_registrations:
+          items:
+            $ref: '#/components/schemas/NestedSampleRegistrationSchema'
+          title: Sample Registrations
+          type: array
+        specimen_anatomic_location:
+          anyOf:
+          - maxLength: 32
+            pattern: ^[C][0-9]{2}(.[0-9]{1})?$
+            type: string
+          - type: 'null'
+          title: Specimen Anatomic Location
+        specimen_collection_date:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Specimen Collection Date
+        specimen_laterality:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenLateralityEnum'
+          - type: 'null'
+        specimen_processing:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenProcessingEnum'
+          - type: 'null'
+        specimen_storage:
+          anyOf:
+          - $ref: '#/components/schemas/StorageEnum'
+          - type: 'null'
+        submitter_specimen_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Specimen Id
+          type: string
+        tumour_grade:
+          anyOf:
+          - $ref: '#/components/schemas/TumourGradeEnum'
+          - type: 'null'
+        tumour_grading_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourGradingSystemEnum'
+          - type: 'null'
+        tumour_histological_type:
+          anyOf:
+          - maxLength: 128
+            pattern: ^[8,9]{1}[0-9]{3}/[0,1,2,3,6,9]{1}[1-9]{0,1}$
+            type: string
+          - type: 'null'
+          title: Tumour Histological Type
+      required:
+      - submitter_specimen_id
+      title: NestedSpecimenSchema
+      type: object
+    NestedSurgerySchema:
+      properties:
+        greatest_dimension_tumour:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Greatest Dimension Tumour
+        lymphovascular_invasion:
+          anyOf:
+          - $ref: '#/components/schemas/LymphovascularInvasionEnum'
+          - type: 'null'
+        margin_types_involved:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Involved
+        margin_types_not_assessed:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Not Assessed
+        margin_types_not_involved:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Not Involved
+        perineural_invasion:
+          anyOf:
+          - $ref: '#/components/schemas/PerineuralInvasionEnum'
+          - type: 'null'
+        residual_tumour_classification:
+          anyOf:
+          - $ref: '#/components/schemas/TumourClassificationEnum'
+          - type: 'null'
+        submitter_specimen_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        surgery_location:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryLocationEnum'
+          - type: 'null'
+        surgery_site:
+          anyOf:
+          - maxLength: 255
+            pattern: ^[C][0-9]{2}(.[0-9]{1})?$
+            type: string
+          - type: 'null'
+          title: Surgery Site
+        surgery_type:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryTypeEnum'
+          - type: 'null'
+        tumour_focality:
+          anyOf:
+          - $ref: '#/components/schemas/TumourFocalityEnum'
+          - type: 'null'
+        tumour_length:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Length
+        tumour_width:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Width
+      title: NestedSurgerySchema
+      type: object
+    NestedTreatmentSchema:
+      properties:
+        chemotherapies:
+          items:
+            $ref: '#/components/schemas/NestedChemotherapySchema'
+          title: Chemotherapies
+          type: array
+        days_per_cycle:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+        followups:
+          items:
+            $ref: '#/components/schemas/NestedFollowUpSchema'
+          title: Followups
+          type: array
+        hormone_therapies:
+          items:
+            $ref: '#/components/schemas/NestedHormoneTherapySchema'
+          title: Hormone Therapies
+          type: array
+        immunotherapies:
+          items:
+            $ref: '#/components/schemas/NestedImmunotherapySchema'
+          title: Immunotherapies
+          type: array
+        is_primary_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+        line_of_treatment:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Line Of Treatment
+        number_of_cycles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
+        radiations:
+          items:
+            $ref: '#/components/schemas/NestedRadiationSchema'
+          title: Radiations
+          type: array
+        response_to_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentResponseEnum'
+          - type: 'null'
+        response_to_treatment_criteria_method:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentResponseMethodEnum'
+          - type: 'null'
+        status_of_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentStatusEnum'
+          - type: 'null'
+        submitter_treatment_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Treatment Id
+          type: string
+        surgeries:
+          items:
+            $ref: '#/components/schemas/NestedSurgerySchema'
+          title: Surgeries
+          type: array
+        treatment_end_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        treatment_intent:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentIntentEnum'
+          - type: 'null'
+        treatment_setting:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentSettingEnum'
+          - type: 'null'
+        treatment_start_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        treatment_type:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TreatmentTypeEnum'
+            type: array
+          - type: 'null'
+          title: Treatment Type
+      required:
+      - submitter_treatment_id
+      title: NestedTreatmentSchema
+      type: object
+    PagedBiomarkerModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/BiomarkerModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedBiomarkerModelSchema
+      type: object
+    PagedChemotherapyModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/ChemotherapyModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedChemotherapyModelSchema
+      type: object
+    PagedComorbidityModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/ComorbidityModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedComorbidityModelSchema
+      type: object
+    PagedDonorModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/DonorModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedDonorModelSchema
+      type: object
+    PagedExposureModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/ExposureModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedExposureModelSchema
+      type: object
+    PagedFollowUpModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/FollowUpModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedFollowUpModelSchema
+      type: object
+    PagedHormoneTherapyModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/HormoneTherapyModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedHormoneTherapyModelSchema
+      type: object
+    PagedImmunotherapyModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/ImmunotherapyModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedImmunotherapyModelSchema
+      type: object
+    PagedPrimaryDiagnosisModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/PrimaryDiagnosisModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedPrimaryDiagnosisModelSchema
+      type: object
+    PagedProgramModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/ProgramModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedProgramModelSchema
+      type: object
+    PagedRadiationModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/RadiationModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedRadiationModelSchema
+      type: object
+    PagedSampleRegistrationModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/SampleRegistrationModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedSampleRegistrationModelSchema
+      type: object
+    PagedSpecimenModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/SpecimenModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedSpecimenModelSchema
+      type: object
+    PagedSurgeryModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/SurgeryModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedSurgeryModelSchema
+      type: object
+    PagedTreatmentModelSchema:
+      properties:
+        count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+        items:
+          items:
+            $ref: '#/components/schemas/TreatmentModelSchema'
+          title: Items
+          type: array
+        next_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Page
+        previous_page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Previous Page
+      required:
+      - items
+      - count
+      - next_page
+      - previous_page
+      title: PagedTreatmentModelSchema
+      type: object
+    PatientPerCohortSchema:
+      properties:
+        patients_count:
+          title: Patients Count
+          type: string
+        program_id:
+          title: Program Id
+          type: string
+      required:
+      - program_id
+      - patients_count
+      title: PatientPerCohortSchema
+      type: object
+    PercentCellsRangeEnum:
+      enum:
+      - 0-19%
+      - 20-50%
+      - 51-100%
+      title: PercentCellsRangeEnum
+      type: string
+    PerineuralInvasionEnum:
+      enum:
+      - Absent
+      - Cannot be assessed
+      - Not applicable
+      - Present
+      - Unknown
+      title: PerineuralInvasionEnum
+      type: string
+    PrimaryDiagnosisFilterSchema:
+      properties:
+        basis_of_diagnosis:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Basis Of Diagnosis
+        cancer_type_code:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cancer Type Code
+        clinical_m_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical M Category
+        clinical_n_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical N Category
+        clinical_stage_group:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical Stage Group
+        clinical_t_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical T Category
+        clinical_tumour_staging_system:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical Tumour Staging System
+        laterality:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Laterality
+        lymph_nodes_examined_method:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lymph Nodes Examined Method
+        lymph_nodes_examined_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lymph Nodes Examined Status
+        number_lymph_nodes_positive:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Lymph Nodes Positive
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+      title: PrimaryDiagnosisFilterSchema
+      type: object
+    PrimaryDiagnosisIngestSchema:
+      properties:
+        basis_of_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/BasisOfDiagnosisEnum'
+          - type: 'null'
+        cancer_type_code:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Cancer Type Code
+        clinical_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        clinical_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        clinical_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        clinical_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        clinical_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        date_of_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        laterality:
+          anyOf:
+          - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
+          - type: 'null'
+        lymph_nodes_examined_method:
+          anyOf:
+          - $ref: '#/components/schemas/LymphNodeMethodEnum'
+          - type: 'null'
+        lymph_nodes_examined_status:
+          anyOf:
+          - $ref: '#/components/schemas/LymphNodeStatusEnum'
+          - type: 'null'
+        number_lymph_nodes_positive:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Lymph Nodes Positive
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_primary_diagnosis_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Primary Diagnosis Id
+          type: string
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - submitter_primary_diagnosis_id
+      - program_id
+      - submitter_donor_id
+      title: PrimaryDiagnosisIngestSchema
+      type: object
+    PrimaryDiagnosisLateralityEnum:
+      enum:
+      - Bilateral
+      - Left
+      - Midline
+      - Not a paired site
+      - Right
+      - Unilateral, side not specified
+      - Unknown
+      title: PrimaryDiagnosisLateralityEnum
+      type: string
+    PrimaryDiagnosisModelSchema:
+      properties:
+        basis_of_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/BasisOfDiagnosisEnum'
+          - type: 'null'
+        cancer_type_code:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Cancer Type Code
+        clinical_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        clinical_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        clinical_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        clinical_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        clinical_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        date_of_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        laterality:
+          anyOf:
+          - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
+          - type: 'null'
+        lymph_nodes_examined_method:
+          anyOf:
+          - $ref: '#/components/schemas/LymphNodeMethodEnum'
+          - type: 'null'
+        lymph_nodes_examined_status:
+          anyOf:
+          - $ref: '#/components/schemas/LymphNodeStatusEnum'
+          - type: 'null'
+        number_lymph_nodes_positive:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Lymph Nodes Positive
+        program_id:
+          title: Program Id
+          type: string
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_primary_diagnosis_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Primary Diagnosis Id
+          type: string
+      required:
+      - submitter_primary_diagnosis_id
+      - program_id
+      - submitter_donor_id
+      title: PrimaryDiagnosisModelSchema
+      type: object
+    PrimarySiteCountSchema:
+      properties:
+        primary_site_count:
+          title: Primary Site Count
+          type: string
+        primary_site_name:
+          title: Primary Site Name
+          type: string
+      required:
+      - primary_site_name
+      - primary_site_count
+      title: PrimarySiteCountSchema
+      type: object
+    PrimarySiteEnum:
+      enum:
+      - Accessory sinuses
+      - Adrenal gland
+      - Anus and anal canal
+      - Base of tongue
+      - Bladder
+      - Bones, joints and articular cartilage of limbs
+      - Bones, joints and articular cartilage of other and unspecified sites
+      - Brain
+      - Breast
+      - Bronchus and lung
+      - Cervix uteri
+      - Colon
+      - Connective, subcutaneous and other soft tissues
+      - Corpus uteri
+      - Esophagus
+      - Eye and adnexa
+      - Floor of mouth
+      - Gallbladder
+      - Gum
+      - Heart, mediastinum, and pleura
+      - Hematopoietic and reticuloendothelial systems
+      - Hypopharynx
+      - Kidney
+      - Larynx
+      - Lip
+      - Liver and intrahepatic bile ducts
+      - Lymph nodes
+      - Meninges
+      - Nasal cavity and middle ear
+      - Nasopharynx
+      - Oropharynx
+      - Other and ill-defined digestive organs
+      - Other and ill-defined sites
+      - Other and ill-defined sites in lip, oral cavity and pharynx
+      - Other and ill-defined sites within respiratory system and intrathoracic organs
+      - Other and unspecified female genital organs
+      - Other and unspecified major salivary glands
+      - Other and unspecified male genital organs
+      - Other and unspecified parts of biliary tract
+      - Other and unspecified parts of mouth
+      - Other and unspecified parts of tongue
+      - Other and unspecified urinary organs
+      - Other endocrine glands and related structures
+      - Ovary
+      - Palate
+      - Pancreas
+      - Parotid gland
+      - Penis
+      - Peripheral nerves and autonomic nervous system
+      - Placenta
+      - Prostate gland
+      - Pyriform sinus
+      - Rectosigmoid junction
+      - Rectum
+      - Renal pelvis
+      - Retroperitoneum and peritoneum
+      - Skin
+      - Small intestine
+      - Spinal cord, cranial nerves, and other parts of central nervous system
+      - Stomach
+      - Testis
+      - Thymus
+      - Thyroid gland
+      - Tonsil
+      - Trachea
+      - Ureter
+      - Uterus, NOS
+      - Vagina
+      - Vulva
+      - Unknown primary site
+      title: PrimarySiteEnum
+      type: string
+    ProgramDiscoverySchema:
+      properties:
+        metadata:
+          title: Metadata
+        program_id:
+          title: Program Id
+          type: string
+      required:
+      - program_id
+      - metadata
+      title: ProgramDiscoverySchema
+      type: object
+    ProgramFilterSchema:
+      properties:
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      title: ProgramFilterSchema
+      type: object
+    ProgramIngestSchema:
+      properties:
+        created:
+          format: date-time
+          title: Created
+          type: string
+        metadata:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Metadata
+        program_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Program Id
+          type: string
+        updated:
+          format: date-time
+          title: Updated
+          type: string
+      required:
+      - program_id
+      title: ProgramIngestSchema
+      type: object
+    ProgramModelSchema:
+      properties:
+        created:
+          format: date-time
+          title: Created
+          type: string
+        metadata:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Metadata
+        program_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Program Id
+          type: string
+        updated:
+          format: date-time
+          title: Updated
+          type: string
+      required:
+      - program_id
+      title: ProgramModelSchema
+      type: object
+    ProgressionStatusMethodEnum:
+      enum:
+      - Imaging (procedure)
+      - Histopathology test (procedure)
+      - Assessment of symptom control (procedure)
+      - Physical examination procedure (procedure)
+      - Tumor marker measurement (procedure)
+      - Laboratory data interpretation (procedure)
+      title: ProgressionStatusMethodEnum
+      type: string
+    RadiationAnatomicalSiteEnum:
+      enum:
+      - Left Abdomen
+      - Whole Abdomen
+      - Right Abdomen
+      - Lower Abdomen
+      - Left Lower Abdomen
+      - Right Lower Abdomen
+      - Upper Abdomen
+      - Left Upper Abdomen
+      - Right Upper Abdomen
+      - Left Adrenal
+      - Right Adrenal
+      - Bilateral Ankle
+      - Left Ankle
+      - Right Ankle
+      - Bilateral Antrum (Bull's Eye)
+      - Left Antrum
+      - Right Antrum
+      - Anus
+      - Lower Left Arm
+      - Lower Right Arm
+      - Bilateral Arms
+      - Left Arm
+      - Right Arm
+      - Upper Left Arm
+      - Upper Right Arm
+      - Left Axilla
+      - Right Axilla
+      - Skin or Soft Tissue of Back
+      - Bile Duct
+      - Bladder
+      - Lower Body
+      - Middle Body
+      - Upper Body
+      - Whole Body
+      - Boost - Area Previously Treated
+      - Brain
+      - Left Breast Boost
+      - Right Breast Boost
+      - Bilateral Breast
+      - Left Breast
+      - Right Breast
+      - Bilateral Breasts with Nodes
+      - Left Breast with Nodes
+      - Right Breast with Nodes
+      - Bilateral Buttocks
+      - Left Buttock
+      - Right Buttock
+      - Inner Canthus
+      - Outer Canthus
+      - Cervix
+      - Bilateral Chest Lung & Area Involve
+      - Left Chest
+      - Right Chest
+      - Chin
+      - Left Cheek
+      - Right Cheek
+      - Bilateral Chest Wall (W/o Breast)
+      - Left Chest Wall
+      - Right Chest Wall
+      - Bilateral Clavicle
+      - Left Clavicle
+      - Right Clavicle
+      - Coccyx
+      - Colon
+      - Whole C.N.S. (Medulla Techinque)
+      - Csf Spine (Medull Tech 2 Diff Machi
+      - Left Chestwall Boost
+      - Right Chestwall Boost
+      - Bilateral Chestwall with Nodes
+      - Left Chestwall with Nodes
+      - Right Chestwall with Nodes
+      - Left Ear
+      - Right Ear
+      - Epigastrium
+      - Lower Esophagus
+      - Middle Esophagus
+      - Upper Esophagus
+      - Entire Esophagus
+      - Ethmoid Sinus
+      - Bilateral Eyes
+      - Left Eye
+      - Right Eye
+      - Bilateral Face
+      - Left Face
+      - Right Face
+      - Left Fallopian Tubes
+      - Right Fallopian Tubes
+      - Bilateral Femur
+      - Left Femur
+      - Right Femur
+      - Left Fibula
+      - Right Fibula
+      - Finger (Including Thumbs)
+      - Floor of Mouth (Boosts)
+      - Bilateral Feet
+      - Left Foot
+      - Right Foot
+      - Forehead
+      - Posterior Fossa
+      - Gall Bladder
+      - Gingiva
+      - Bilateral Hand
+      - Left Hand
+      - Right Hand
+      - Head
+      - Bilateral Heel
+      - Left Heel
+      - Right Heel
+      - Left Hemimantle
+      - Right Hemimantle
+      - Heart
+      - Bilateral Hip
+      - Left Hip
+      - Right Hip
+      - Left Humerus
+      - Right Humerus
+      - Hypopharynx
+      - Bilateral Internal Mammary Chain
+      - Bilateral Inguinal Nodes
+      - Left Inguinal Nodes
+      - Right Inguinal Nodes
+      - Inverted 'Y' (Dog-Leg,Hockey-Stick)
+      - Left Kidney
+      - Right Kidney
+      - Bilateral Knee
+      - Left Knee
+      - Right Knee
+      - Bilateral Lacrimal Gland
+      - Left Lacrimal Gland
+      - Right Lacrimal Gland
+      - Larygopharynx
+      - Larynx
+      - Bilateral Leg
+      - Left Leg
+      - Right Leg
+      - Lower Bilateral Leg
+      - Lower Left Leg
+      - Lower Right Leg
+      - Upper Bilateral Leg
+      - Upper Left Leg
+      - Upper Right Leg
+      - Both Eyelid(s)
+      - Left Eyelid
+      - Right Eyelid
+      - Both Lip(s)
+      - Lower Lip
+      - Upper Lip
+      - Liver
+      - Bilateral Lung
+      - Left Lung
+      - Right Lung
+      - Bilateral Mandible
+      - Left Mandible
+      - Right Mandible
+      - Mantle
+      - Bilateral Maxilla
+      - Left Maxilla
+      - Right Maxilla
+      - Mediastinum
+      - Multiple Skin
+      - Nasal Fossa
+      - Nasopharynx
+      - Bilateral Neck Includes Nodes
+      - Left Neck Includes Nodes
+      - Right Neck Includes Nodes
+      - Neck - Skin
+      - Nose
+      - Oral Cavity / Buccal Mucosa
+      - Bilateral Orbit
+      - Left Orbit
+      - Right Orbit
+      - Oropharynx
+      - Bilateral Ovary
+      - Left Ovary
+      - Right Ovary
+      - Hard Palate
+      - Soft Palate
+      - Palate Unspecified
+      - Pancreas
+      - Para-Aortic Nodes
+      - Left Parotid
+      - Right Parotid
+      - Bilateral Pelvis
+      - Left Pelvis
+      - Right Pelvis
+      - Penis
+      - Perineum
+      - Pituitary
+      - Left Pleura (As in Mesothelioma)
+      - Right Pleura
+      - Prostate
+      - Pubis
+      - Pyriform Fossa (Sinuses)
+      - Left Radius
+      - Right Radius
+      - Rectum (Includes Sigmoid)
+      - Left Ribs
+      - Right Ribs
+      - Sacrum
+      - Left Salivary Gland
+      - Right Salivary Gland
+      - Bilateral Scapula
+      - Left Scapula
+      - Right Scapula
+      - Bilateral Supraclavicular Nodes
+      - Left Supraclavicular Nodes
+      - Right Supraclavicular Nodes
+      - Bilateral Scalp
+      - Left Scalp
+      - Right Scalp
+      - Scrotum
+      - Bilateral Shoulder
+      - Left Shoulder
+      - Right Shoulder
+      - Whole Body - Skin
+      - Skull
+      - Cervical & Thoracic Spine
+      - Sphenoid Sinus
+      - Cervical Spine
+      - Lumbar Spine
+      - Thoracic Spine
+      - Whole Spine
+      - Spleen
+      - Lumbo-Sacral Spine
+      - Thoracic & Lumbar Spine
+      - Sternum
+      - Stomach
+      - Submandibular Glands
+      - Left Temple
+      - Right Temple
+      - Bilateral Testis
+      - Left Testis
+      - Right Testis
+      - Thyroid
+      - Left Tibia
+      - Right Tibia
+      - Left Toes
+      - Right Toes
+      - Tongue
+      - Tonsil
+      - Trachea
+      - Left Ulna
+      - Right Ulna
+      - Left Ureter
+      - Right Ureter
+      - Urethra
+      - Uterus
+      - Uvula
+      - Vagina
+      - Vulva
+      - Abdomen
+      - Body
+      - Chest
+      - Lower Limb
+      - Neck
+      - Other
+      - Pelvis
+      - Skin
+      - Spine
+      - Upper Limb
+      title: RadiationAnatomicalSiteEnum
+      type: string
+    RadiationFilterSchema:
+      properties:
+        anatomical_site_irradiated:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Anatomical Site Irradiated
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        radiation_boost:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Radiation Boost
+        radiation_therapy_dosage:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Dosage
+        radiation_therapy_fractions:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Fractions
+        radiation_therapy_modality:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Radiation Therapy Modality
+        radiation_therapy_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Radiation Therapy Type
+        reference_radiation_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reference Radiation Treatment Id
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      title: RadiationFilterSchema
+      type: object
+    RadiationIngestSchema:
+      properties:
+        anatomical_site_irradiated:
+          anyOf:
+          - $ref: '#/components/schemas/RadiationAnatomicalSiteEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        radiation_boost:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Radiation Boost
+        radiation_therapy_dosage:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Dosage
+        radiation_therapy_fractions:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Fractions
+        radiation_therapy_modality:
+          anyOf:
+          - $ref: '#/components/schemas/RadiationTherapyModalityEnum'
+          - type: 'null'
+        radiation_therapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/TherapyTypeEnum'
+          - type: 'null'
+        reference_radiation_treatment_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Reference Radiation Treatment Id
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: RadiationIngestSchema
+      type: object
+    RadiationModelSchema:
+      properties:
+        anatomical_site_irradiated:
+          anyOf:
+          - $ref: '#/components/schemas/RadiationAnatomicalSiteEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        radiation_boost:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Radiation Boost
+        radiation_therapy_dosage:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Dosage
+        radiation_therapy_fractions:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Fractions
+        radiation_therapy_modality:
+          anyOf:
+          - $ref: '#/components/schemas/RadiationTherapyModalityEnum'
+          - type: 'null'
+        radiation_therapy_type:
+          anyOf:
+          - $ref: '#/components/schemas/TherapyTypeEnum'
+          - type: 'null'
+        reference_radiation_treatment_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Reference Radiation Treatment Id
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: RadiationModelSchema
+      type: object
+    RadiationTherapyModalityEnum:
+      enum:
+      - Megavoltage radiation therapy using photons (procedure)
+      - Radiopharmaceutical
+      - Teleradiotherapy using electrons (procedure)
+      - Teleradiotherapy protons (procedure)
+      - Teleradiotherapy neutrons (procedure)
+      - Brachytherapy (procedure)
+      - Other
+      title: RadiationTherapyModalityEnum
+      type: string
+    RelapseTypeEnum:
+      enum:
+      - Distant recurrence/metastasis
+      - Local recurrence
+      - Local recurrence and distant metastasis
+      - Progression (liquid tumours)
+      - Biochemical progression
+      title: RelapseTypeEnum
+      type: string
+    SampleRegistrationFilterSchema:
+      properties:
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        sample_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sample Type
+        specimen_tissue_source:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Tissue Source
+        specimen_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Type
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_sample_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Sample Id
+        submitter_specimen_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        tumour_normal_designation:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Normal Designation
+      title: SampleRegistrationFilterSchema
+      type: object
+    SampleRegistrationIngestSchema:
+      properties:
+        program_id:
+          title: Program Id
+          type: string
+        sample_type:
+          anyOf:
+          - $ref: '#/components/schemas/SampleTypeEnum'
+          - type: 'null'
+        specimen_tissue_source:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenTissueSourceEnum'
+          - type: 'null'
+        specimen_type:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenTypeEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_sample_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Sample Id
+          type: string
+        submitter_specimen_id:
+          title: Submitter Specimen Id
+          type: string
+        tumour_normal_designation:
+          anyOf:
+          - $ref: '#/components/schemas/TumourDesginationEnum'
+          - type: 'null'
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - submitter_sample_id
+      - program_id
+      - submitter_donor_id
+      - submitter_specimen_id
+      title: SampleRegistrationIngestSchema
+      type: object
+    SampleRegistrationModelSchema:
+      properties:
+        program_id:
+          title: Program Id
+          type: string
+        sample_type:
+          anyOf:
+          - $ref: '#/components/schemas/SampleTypeEnum'
+          - type: 'null'
+        specimen_tissue_source:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenTissueSourceEnum'
+          - type: 'null'
+        specimen_type:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenTypeEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_sample_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Sample Id
+          type: string
+        submitter_specimen_id:
+          title: Submitter Specimen Id
+          type: string
+        tumour_normal_designation:
+          anyOf:
+          - $ref: '#/components/schemas/TumourDesginationEnum'
+          - type: 'null'
+      required:
+      - submitter_sample_id
+      - program_id
+      - submitter_donor_id
+      - submitter_specimen_id
+      title: SampleRegistrationModelSchema
+      type: object
+    SampleTypeEnum:
+      enum:
+      - Amplified DNA
+      - ctDNA
+      - Other DNA enrichments
+      - Other RNA fractions
+      - polyA+ RNA
+      - Protein
+      - rRNA-depleted RNA
+      - Total DNA
+      - Total RNA
+      title: SampleTypeEnum
+      type: string
+    SexAtBirthEnum:
+      enum:
+      - Male
+      - Female
+      - Other
+      - Unknown
+      title: SexAtBirthEnum
+      type: string
+    SmokingStatusEnum:
+      enum:
+      - Current reformed smoker for <= 15 years
+      - Current reformed smoker for > 15 years
+      - Current reformed smoker, duration not specified
+      - Current smoker
+      - Lifelong non-smoker (<100 cigarettes smoked in lifetime)
+      - Not applicable
+      - Smoking history not documented
+      title: SmokingStatusEnum
+      type: string
+    SpecimenFilterSchema:
+      properties:
+        pathological_m_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological M Category
+        pathological_n_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological N Category
+        pathological_stage_group:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological Stage Group
+        pathological_t_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological T Category
+        pathological_tumour_staging_system:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological Tumour Staging System
+        percent_tumour_cells_measurement_method:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Percent Tumour Cells Measurement Method
+        percent_tumour_cells_range:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Percent Tumour Cells Range
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        reference_pathology_confirmed_diagnosis:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reference Pathology Confirmed Diagnosis
+        reference_pathology_confirmed_tumour_presence:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reference Pathology Confirmed Tumour Presence
+        specimen_anatomic_location:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Anatomic Location
+        specimen_laterality:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Laterality
+        specimen_processing:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Processing
+        specimen_storage:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Storage
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_specimen_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        tumour_grade:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Grade
+        tumour_grading_system:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Grading System
+        tumour_histological_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Histological Type
+      title: SpecimenFilterSchema
+      type: object
+    SpecimenIngestSchema:
+      properties:
+        pathological_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        pathological_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        pathological_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        pathological_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        pathological_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        percent_tumour_cells_measurement_method:
+          anyOf:
+          - $ref: '#/components/schemas/CellsMeasureMethodEnum'
+          - type: 'null'
+        percent_tumour_cells_range:
+          anyOf:
+          - $ref: '#/components/schemas/PercentCellsRangeEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        reference_pathology_confirmed_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/ConfirmedDiagnosisTumourEnum'
+          - type: 'null'
+        reference_pathology_confirmed_tumour_presence:
+          anyOf:
+          - $ref: '#/components/schemas/ConfirmedDiagnosisTumourEnum'
+          - type: 'null'
+        specimen_anatomic_location:
+          anyOf:
+          - maxLength: 32
+            pattern: ^[C][0-9]{2}(.[0-9]{1})?$
+            type: string
+          - type: 'null'
+          title: Specimen Anatomic Location
+        specimen_collection_date:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Specimen Collection Date
+        specimen_laterality:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenLateralityEnum'
+          - type: 'null'
+        specimen_processing:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenProcessingEnum'
+          - type: 'null'
+        specimen_storage:
+          anyOf:
+          - $ref: '#/components/schemas/StorageEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_primary_diagnosis_id:
+          title: Submitter Primary Diagnosis Id
+          type: string
+        submitter_specimen_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Specimen Id
+          type: string
+        tumour_grade:
+          anyOf:
+          - $ref: '#/components/schemas/TumourGradeEnum'
+          - type: 'null'
+        tumour_grading_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourGradingSystemEnum'
+          - type: 'null'
+        tumour_histological_type:
+          anyOf:
+          - maxLength: 128
+            pattern: ^[8,9]{1}[0-9]{3}/[0,1,2,3,6,9]{1}[1-9]{0,1}$
+            type: string
+          - type: 'null'
+          title: Tumour Histological Type
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - submitter_specimen_id
+      - program_id
+      - submitter_donor_id
+      - submitter_primary_diagnosis_id
+      title: SpecimenIngestSchema
+      type: object
+    SpecimenLateralityEnum:
+      enum:
+      - Left
+      - Not applicable
+      - Right
+      - Unknown
+      title: SpecimenLateralityEnum
+      type: string
+    SpecimenModelSchema:
+      properties:
+        pathological_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        pathological_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        pathological_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        pathological_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        pathological_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
+        percent_tumour_cells_measurement_method:
+          anyOf:
+          - $ref: '#/components/schemas/CellsMeasureMethodEnum'
+          - type: 'null'
+        percent_tumour_cells_range:
+          anyOf:
+          - $ref: '#/components/schemas/PercentCellsRangeEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        reference_pathology_confirmed_diagnosis:
+          anyOf:
+          - $ref: '#/components/schemas/ConfirmedDiagnosisTumourEnum'
+          - type: 'null'
+        reference_pathology_confirmed_tumour_presence:
+          anyOf:
+          - $ref: '#/components/schemas/ConfirmedDiagnosisTumourEnum'
+          - type: 'null'
+        specimen_anatomic_location:
+          anyOf:
+          - maxLength: 32
+            pattern: ^[C][0-9]{2}(.[0-9]{1})?$
+            type: string
+          - type: 'null'
+          title: Specimen Anatomic Location
+        specimen_collection_date:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Specimen Collection Date
+        specimen_laterality:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenLateralityEnum'
+          - type: 'null'
+        specimen_processing:
+          anyOf:
+          - $ref: '#/components/schemas/SpecimenProcessingEnum'
+          - type: 'null'
+        specimen_storage:
+          anyOf:
+          - $ref: '#/components/schemas/StorageEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_primary_diagnosis_id:
+          title: Submitter Primary Diagnosis Id
+          type: string
+        submitter_specimen_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Specimen Id
+          type: string
+        tumour_grade:
+          anyOf:
+          - $ref: '#/components/schemas/TumourGradeEnum'
+          - type: 'null'
+        tumour_grading_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourGradingSystemEnum'
+          - type: 'null'
+        tumour_histological_type:
+          anyOf:
+          - maxLength: 128
+            pattern: ^[8,9]{1}[0-9]{3}/[0,1,2,3,6,9]{1}[1-9]{0,1}$
+            type: string
+          - type: 'null'
+          title: Tumour Histological Type
+      required:
+      - submitter_specimen_id
+      - program_id
+      - submitter_donor_id
+      - submitter_primary_diagnosis_id
+      title: SpecimenModelSchema
+      type: object
+    SpecimenProcessingEnum:
+      enum:
+      - Cryopreservation in liquid nitrogen (dead tissue)
+      - Cryopreservation in dry ice (dead tissue)
+      - Cryopreservation of live cells in liquid nitrogen
+      - Cryopreservation - other
+      - Formalin fixed & paraffin embedded
+      - Formalin fixed - buffered
+      - Formalin fixed - unbuffered
+      - Fresh
+      - Other
+      - Unknown
+      title: SpecimenProcessingEnum
+      type: string
+    SpecimenTissueSourceEnum:
+      enum:
+      - Abdominal fluid
+      - Amniotic fluid
+      - Arterial blood
+      - Bile
+      - Blood derived - bone marrow
+      - Blood derived - peripheral blood
+      - Bone marrow fluid
+      - Bone marrow derived mononuclear cells
+      - Buccal cell
+      - Buffy coat
+      - Cerebrospinal fluid
+      - Cervical mucus
+      - Convalescent plasma
+      - Cord blood
+      - Duodenal fluid
+      - Female genital fluid
+      - Fetal blood
+      - Hydrocele fluid
+      - Male genital fluid
+      - Pancreatic fluid
+      - Pericardial effusion
+      - Pleural fluid
+      - Renal cyst fluid
+      - Saliva
+      - Seminal fluid
+      - Serum
+      - Solid tissue
+      - Sputum
+      - Synovial fluid
+      - Urine
+      - Venous blood
+      - Vitreous fluid
+      - Whole blood
+      - Wound
+      title: SpecimenTissueSourceEnum
+      type: string
+    SpecimenTypeEnum:
+      enum:
+      - Cell line - derived from normal
+      - Cell line - derived from primary tumour
+      - Cell line - derived from metastatic tumour
+      - Cell line - derived from xenograft tumour
+      - Metastatic tumour - additional metastatic
+      - Metastatic tumour - metastasis local to lymph node
+      - Metastatic tumour - metastasis to distant location
+      - Metastatic tumour
+      - Normal - tissue adjacent to primary tumour
+      - Normal
+      - Primary tumour - additional new primary
+      - Primary tumour - adjacent to normal
+      - Primary tumour
+      - Recurrent tumour
+      - Tumour - unknown if derived from primary or metastatic tumour
+      - Xenograft - derived from primary tumour
+      - Xenograft - derived from metastatic tumour
+      - Xenograft - derived from tumour cell line
+      title: SpecimenTypeEnum
+      type: string
+    StageGroupEnum:
+      enum:
+      - Stage 0
+      - Stage 0a
+      - Stage 0is
+      - Stage 1
+      - Stage 1A
+      - Stage 1B
+      - Stage A
+      - Stage B
+      - Stage C
+      - Stage I
+      - Stage IA
+      - Stage IA1
+      - Stage IA2
+      - Stage IA3
+      - Stage IAB
+      - Stage IAE
+      - Stage IAES
+      - Stage IAS
+      - Stage IB
+      - Stage IB1
+      - Stage IB2
+      - Stage IBE
+      - Stage IBES
+      - Stage IBS
+      - Stage IC
+      - Stage IE
+      - Stage IEA
+      - Stage IEB
+      - Stage IES
+      - Stage II
+      - Stage II bulky
+      - Stage IIA
+      - Stage IIA1
+      - Stage IIA2
+      - Stage IIAE
+      - Stage IIAES
+      - Stage IIAS
+      - Stage IIB
+      - Stage IIBE
+      - Stage IIBES
+      - Stage IIBS
+      - Stage IIC
+      - Stage IIE
+      - Stage IIEA
+      - Stage IIEB
+      - Stage IIES
+      - Stage III
+      - Stage IIIA
+      - Stage IIIA1
+      - Stage IIIA2
+      - Stage IIIAE
+      - Stage IIIAES
+      - Stage IIIAS
+      - Stage IIIB
+      - Stage IIIBE
+      - Stage IIIBES
+      - Stage IIIBS
+      - Stage IIIC
+      - Stage IIIC1
+      - Stage IIIC2
+      - Stage IIID
+      - Stage IIIE
+      - Stage IIIES
+      - Stage IIIS
+      - Stage IIS
+      - Stage IS
+      - Stage IV
+      - Stage IVA
+      - Stage IVA1
+      - Stage IVA2
+      - Stage IVAE
+      - Stage IVAES
+      - Stage IVAS
+      - Stage IVB
+      - Stage IVBE
+      - Stage IVBES
+      - Stage IVBS
+      - Stage IVC
+      - Stage IVE
+      - Stage IVES
+      - Stage IVS
+      - In situ
+      - Localized
+      - Regionalized
+      - Distant
+      - Stage L1
+      - Stage L2
+      - Stage M
+      - Stage Ms
+      - Stage 2A
+      - Stage 2B
+      - Stage 3
+      - Stage 4
+      - Stage 4S
+      - Occult Carcinoma
+      title: StageGroupEnum
+      type: string
+    StorageEnum:
+      enum:
+      - Cut slide
+      - Frozen in -70 freezer
+      - Frozen in liquid nitrogen
+      - Frozen in vapour phase
+      - Not Applicable
+      - Other
+      - Paraffin block
+      - RNA later frozen
+      - Unknown
+      title: StorageEnum
+      type: string
+    SurgeryFilterSchema:
+      properties:
+        greatest_dimension_tumour:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Greatest Dimension Tumour
+        lymphovascular_invasion:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lymphovascular Invasion
+        margin_types_involved:
+          items:
+            type: string
+          q: margin_types_involved__overlap
+          title: Margin Types Involved
+          type: array
+        margin_types_not_assessed:
+          items:
+            type: string
+          q: margin_types_not_assessed__overlap
+          title: Margin Types Not Assessed
+          type: array
+        margin_types_not_involved:
+          items:
+            type: string
+          q: margin_types_not_involved__overlap
+          title: Margin Types Not Involved
+          type: array
+        perineural_invasion:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Perineural Invasion
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        residual_tumour_classification:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Residual Tumour Classification
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_specimen_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+        surgery_location:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Location
+        surgery_site:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Site
+        surgery_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Type
+        tumour_focality:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Focality
+        tumour_length:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Length
+        tumour_width:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Width
+      title: SurgeryFilterSchema
+      type: object
+    SurgeryIngestSchema:
+      properties:
+        greatest_dimension_tumour:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Greatest Dimension Tumour
+        lymphovascular_invasion:
+          anyOf:
+          - $ref: '#/components/schemas/LymphovascularInvasionEnum'
+          - type: 'null'
+        margin_types_involved:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Involved
+        margin_types_not_assessed:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Not Assessed
+        margin_types_not_involved:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Not Involved
+        perineural_invasion:
+          anyOf:
+          - $ref: '#/components/schemas/PerineuralInvasionEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        residual_tumour_classification:
+          anyOf:
+          - $ref: '#/components/schemas/TumourClassificationEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_specimen_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+        surgery_location:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryLocationEnum'
+          - type: 'null'
+        surgery_site:
+          anyOf:
+          - maxLength: 255
+            pattern: ^[C][0-9]{2}(.[0-9]{1})?$
+            type: string
+          - type: 'null'
+          title: Surgery Site
+        surgery_type:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryTypeEnum'
+          - type: 'null'
+        tumour_focality:
+          anyOf:
+          - $ref: '#/components/schemas/TumourFocalityEnum'
+          - type: 'null'
+        tumour_length:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Length
+        tumour_width:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Width
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: SurgeryIngestSchema
+      type: object
+    SurgeryLocationEnum:
+      enum:
+      - Local recurrence
+      - Metastatic
+      - Primary
+      title: SurgeryLocationEnum
+      type: string
+    SurgeryModelSchema:
+      properties:
+        greatest_dimension_tumour:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Greatest Dimension Tumour
+        lymphovascular_invasion:
+          anyOf:
+          - $ref: '#/components/schemas/LymphovascularInvasionEnum'
+          - type: 'null'
+        margin_types_involved:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Involved
+        margin_types_not_assessed:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Not Assessed
+        margin_types_not_involved:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/MarginTypesEnum'
+            type: array
+          - type: 'null'
+          title: Margin Types Not Involved
+        perineural_invasion:
+          anyOf:
+          - $ref: '#/components/schemas/PerineuralInvasionEnum'
+          - type: 'null'
+        program_id:
+          title: Program Id
+          type: string
+        residual_tumour_classification:
+          anyOf:
+          - $ref: '#/components/schemas/TumourClassificationEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_specimen_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
+        surgery_location:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryLocationEnum'
+          - type: 'null'
+        surgery_site:
+          anyOf:
+          - maxLength: 255
+            pattern: ^[C][0-9]{2}(.[0-9]{1})?$
+            type: string
+          - type: 'null'
+          title: Surgery Site
+        surgery_type:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryTypeEnum'
+          - type: 'null'
+        tumour_focality:
+          anyOf:
+          - $ref: '#/components/schemas/TumourFocalityEnum'
+          - type: 'null'
+        tumour_length:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Length
+        tumour_width:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Width
+      required:
+      - program_id
+      - submitter_donor_id
+      - submitter_treatment_id
+      title: SurgeryModelSchema
+      type: object
+    SurgeryTypeEnum:
+      enum:
+      - Ablation
+      - Axillary Clearance
+      - Axillary lymph nodes sampling
+      - Bilateral complete salpingo-oophorectomy
+      - Biopsy
+      - Bypass Gastrojejunostomy
+      - Cholecystectomy
+      - Cholecystojejunostomy
+      - Completion Gastrectomy
+      - Debridement of pancreatic and peripancreatic necrosis
+      - Distal subtotal pancreatectomy
+      - Drainage of abscess
+      - Duodenal preserving pancreatic head resection
+      - Endoscopic biopsy
+      - Endoscopic brushings of gastrointestinal tract
+      - Enucleation
+      - Esophageal bypass surgery/jejunostomy only
+      - Exploratory laparotomy
+      - Fine needle aspiration biopsy
+      - Gastric Antrectomy
+      - Glossectomy
+      - Hepatojejunostomy
+      - Hysterectomy
+      - Incision of thorax
+      - Ivor Lewis subtotal esophagectomy
+      - Laparotomy
+      - Left thoracoabdominal incision
+      - Lobectomy
+      - Mammoplasty
+      - Mastectomy
+      - McKeown esophagectomy
+      - Merendino procedure
+      - Minimally invasive esophagectomy
+      - Omentectomy
+      - Ovariectomy
+      - Pancreaticoduodenectomy (Whipple procedure)
+      - Pancreaticojejunostomy, side-to-side anastomosis
+      - Partial pancreatectomy
+      - Pneumonectomy
+      - Prostatectomy
+      - Proximal subtotal gastrectomy
+      - Pylorus-sparing Whipple operation
+      - Radical pancreaticoduodenectomy
+      - Radical prostatectomy
+      - Reexcision
+      - Segmentectomy
+      - Sentinal Lymph Node Biopsy
+      - Spleen preserving distal pancreatectomy
+      - Splenectomy
+      - Total gastrectomy
+      - Total gastrectomy with extended lymphadenectomy
+      - Total pancreatectomy
+      - Transhiatal esophagectomy
+      - Triple bypass of pancreas
+      - Tumor Debulking
+      - Wedge/localised gastric resection
+      - Wide Local Excision
+      title: SurgeryTypeEnum
+      type: string
+    TCategoryEnum:
+      enum:
+      - T0
+      - T1
+      - T1a
+      - T1a1
+      - T1a2
+      - T1a(s)
+      - T1a(m)
+      - T1b
+      - T1b1
+      - T1b2
+      - T1b(s)
+      - T1b(m)
+      - T1c
+      - T1d
+      - T1mi
+      - T2
+      - T2(s)
+      - T2(m)
+      - T2a
+      - T2a1
+      - T2a2
+      - T2b
+      - T2c
+      - T2d
+      - T3
+      - T3(s)
+      - T3(m)
+      - T3a
+      - T3b
+      - T3c
+      - T3d
+      - T3e
+      - T4
+      - T4a
+      - T4a(s)
+      - T4a(m)
+      - T4b
+      - T4b(s)
+      - T4b(m)
+      - T4c
+      - T4d
+      - T4e
+      - Ta
+      - Tis
+      - Tis(DCIS)
+      - Tis(LAMN)
+      - Tis(LCIS)
+      - Tis(Paget)
+      - Tis(Paget's)
+      - Tis pu
+      - Tis pd
+      - TX
+      title: TCategoryEnum
+      type: string
+    TherapyTypeEnum:
+      enum:
+      - External
+      - Internal
+      title: TherapyTypeEnum
+      type: string
+    TobaccoTypeEnum:
+      enum:
+      - Chewing Tobacco
+      - Cigar
+      - Cigarettes
+      - Electronic cigarettes
+      - Not applicable
+      - Pipe
+      - Roll-ups
+      - Snuff
+      - Unknown
+      - Waterpipe
+      title: TobaccoTypeEnum
+      type: string
+    TreatmentFilterSchema:
+      properties:
+        days_per_cycle:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+        is_primary_treatment:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Is Primary Treatment
+        line_of_treatment:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Line Of Treatment
+        number_of_cycles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
+        program_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+        response_to_treatment:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Response To Treatment
+        response_to_treatment_criteria_method:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Response To Treatment Criteria Method
+        status_of_treatment:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status Of Treatment
+        submitter_donor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+        submitter_primary_diagnosis_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+        treatment_intent:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Treatment Intent
+        treatment_setting:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Treatment Setting
+        treatment_type:
+          items:
+            type: string
+          q: treatment_type__overlap
+          title: Treatment Type
+          type: array
+      title: TreatmentFilterSchema
+      type: object
+    TreatmentIngestSchema:
+      properties:
+        days_per_cycle:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+        is_primary_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+        line_of_treatment:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Line Of Treatment
+        number_of_cycles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
+        program_id:
+          title: Program Id
+          type: string
+        response_to_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentResponseEnum'
+          - type: 'null'
+        response_to_treatment_criteria_method:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentResponseMethodEnum'
+          - type: 'null'
+        status_of_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentStatusEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_primary_diagnosis_id:
+          title: Submitter Primary Diagnosis Id
+          type: string
+        submitter_treatment_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Treatment Id
+          type: string
+        treatment_end_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        treatment_intent:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentIntentEnum'
+          - type: 'null'
+        treatment_setting:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentSettingEnum'
+          - type: 'null'
+        treatment_start_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        treatment_type:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TreatmentTypeEnum'
+            type: array
+          - type: 'null'
+          title: Treatment Type
+        uuid:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uuid
+      required:
+      - submitter_treatment_id
+      - program_id
+      - submitter_donor_id
+      - submitter_primary_diagnosis_id
+      title: TreatmentIngestSchema
+      type: object
+    TreatmentIntentEnum:
+      enum:
+      - Curative
+      - Palliative
+      - Supportive
+      - Diagnostic
+      - Preventive
+      - Guidance
+      - Screening
+      - Forensic
+      title: TreatmentIntentEnum
+      type: string
+    TreatmentModelSchema:
+      properties:
+        days_per_cycle:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+        is_primary_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/uBooleanEnum'
+          - type: 'null'
+        line_of_treatment:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Line Of Treatment
+        number_of_cycles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
+        program_id:
+          title: Program Id
+          type: string
+        response_to_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentResponseEnum'
+          - type: 'null'
+        response_to_treatment_criteria_method:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentResponseMethodEnum'
+          - type: 'null'
+        status_of_treatment:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentStatusEnum'
+          - type: 'null'
+        submitter_donor_id:
+          title: Submitter Donor Id
+          type: string
+        submitter_primary_diagnosis_id:
+          title: Submitter Primary Diagnosis Id
+          type: string
+        submitter_treatment_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Treatment Id
+          type: string
+        treatment_end_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        treatment_intent:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentIntentEnum'
+          - type: 'null'
+        treatment_setting:
+          anyOf:
+          - $ref: '#/components/schemas/TreatmentSettingEnum'
+          - type: 'null'
+        treatment_start_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+        treatment_type:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TreatmentTypeEnum'
+            type: array
+          - type: 'null'
+          title: Treatment Type
+      required:
+      - submitter_treatment_id
+      - program_id
+      - submitter_donor_id
+      - submitter_primary_diagnosis_id
+      title: TreatmentModelSchema
+      type: object
+    TreatmentResponseEnum:
+      enum:
+      - Complete response
+      - Partial response
+      - Progressive disease
+      - Stable disease
+      - Immune complete response (iCR)
+      - Immune partial response (iPR)
+      - Immune uncomfirmed progressive disease (iUPD)
+      - Immune confirmed progressive disease (iCPD)
+      - Immune stable disease (iSD)
+      - Complete remission
+      - Partial remission
+      - Minor response
+      - Complete remission without measurable residual disease (CR MRD-)
+      - Complete remission with incomplete hematologic recovery (CRi)
+      - Morphologic leukemia-free state
+      - Primary refractory disease
+      - Hematologic relapse (after CR MRD-, CR, CRi)
+      - Molecular relapse (after CR MRD-)
+      - Physician assessed complete response
+      - Physician assessed partial response
+      - Physician assessed stable disease
+      - No evidence of disease (NED)
+      - Major response
+      title: TreatmentResponseEnum
+      type: string
+    TreatmentResponseMethodEnum:
+      enum:
+      - RECIST 1.1
+      - iRECIST
+      - Cheson CLL 2012 Oncology Response Criteria
+      - Response Assessment in Neuro-Oncology (RANO)
+      - AML Response Criteria
+      - Physician Assessed Response Criteria
+      - Blazer score
+      title: TreatmentResponseMethodEnum
+      type: string
+    TreatmentSettingEnum:
+      enum:
+      - Adjuvant
+      - Advanced/Metastatic
+      - Neoadjuvant
+      - Conditioning
+      - Induction
+      - Locally advanced
+      - Maintenance
+      - Mobilization
+      - Preventative
+      - Radiosensitization
+      - Salvage
+      title: TreatmentSettingEnum
+      type: string
+    TreatmentStatusEnum:
+      enum:
+      - Treatment completed as prescribed
+      - Treatment incomplete due to technical or organizational problems
+      - Treatment incomplete because patient died
+      - Patient choice (stopped or interrupted treatment)
+      - Physician decision (stopped or interrupted treatment)
+      - Treatment stopped due to lack of efficacy (disease progression)
+      - Treatment stopped due to acute toxicity
+      - Other
+      - Not applicable
+      - Unknown
+      title: TreatmentStatusEnum
+      type: string
+    TreatmentTypeCountSchema:
+      properties:
+        treatment_type_count:
+          title: Treatment Type Count
+          type: string
+        treatment_type_name:
+          title: Treatment Type Name
+          type: string
+      required:
+      - treatment_type_name
+      - treatment_type_count
+      title: TreatmentTypeCountSchema
+      type: object
+    TreatmentTypeEnum:
+      enum:
+      - Bone marrow transplant
+      - Chemotherapy
+      - Hormonal therapy
+      - Immunotherapy
+      - No treatment
+      - Other targeting molecular therapy
+      - Photodynamic therapy
+      - Radiation therapy
+      - Stem cell transplant
+      - Surgery
+      title: TreatmentTypeEnum
+      type: string
+    TumourClassificationEnum:
+      enum:
+      - Not applicable
+      - RX
+      - R0
+      - R1
+      - R2
+      - Unknown
+      title: TumourClassificationEnum
+      type: string
+    TumourDesginationEnum:
+      enum:
+      - Normal
+      - Tumour
+      title: TumourDesginationEnum
+      type: string
+    TumourFocalityEnum:
+      enum:
+      - Cannot be assessed
+      - Multifocal
+      - Not applicable
+      - Unifocal
+      - Unknown
+      title: TumourFocalityEnum
+      type: string
+    TumourGradeEnum:
+      enum:
+      - Low grade
+      - High grade
+      - GX
+      - G1
+      - G2
+      - G3
+      - G4
+      - Low
+      - High
+      - Grade 1
+      - Grade 2
+      - Grade 3
+      - Grade 4
+      - Grade I
+      - Grade II
+      - Grade III
+      - Grade IV
+      - Grade Group 1
+      - Grade Group 2
+      - Grade Group 3
+      - Grade Group 4
+      - Grade Group 5
+      title: TumourGradeEnum
+      type: string
+    TumourGradingSystemEnum:
+      enum:
+      - FNCLCC grading system
+      - Four-tier grading system
+      - Gleason grade group system
+      - Grading system for GISTs
+      - Grading system for GNETs
+      - IASLC grading system
+      - ISUP grading system
+      - Nottingham grading system
+      - Nuclear grading system for DCIS
+      - Scarff-Bloom-Richardson grading system
+      - Three-tier grading system
+      - Two-tier grading system
+      - WHO grading system for CNS tumours
+      title: TumourGradingSystemEnum
+      type: string
+    TumourStagingSystemEnum:
+      enum:
+      - AJCC 8th edition
+      - AJCC 7th edition
+      - AJCC 6th edition
+      - Ann Arbor staging system
+      - Binet staging system
+      - Durie-Salmon staging system
+      - FIGO staging system
+      - International Neuroblastoma Risk Group Staging System
+      - International Neuroblastoma Staging System
+      - Lugano staging system
+      - Rai staging system
+      - Revised International staging system (RISS)
+      - SEER staging system
+      - St Jude staging system
+      title: TumourStagingSystemEnum
+      type: string
+    uBooleanEnum:
+      enum:
+      - 'Yes'
+      - 'No'
+      - Unknown
+      title: uBooleanEnum
+      type: string
+  securitySchemes:
+    LoginAuth:
+      scheme: bearer
+      type: http
+    ServiceTokenAuth:
+      in: header
+      name: X-Service-Token
+      type: apiKey
+info:
+  description: This is the RESTful API for the MoH Service.
+  title: MoH Service API
+  version: 4.4.0
+openapi: 3.1.0
+paths:
+  /v2/authorized/biomarkers/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_biomarkers
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_specimen_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+      - in: query
+        name: submitter_primary_diagnosis_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
+        name: submitter_follow_up_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Follow Up Id
+      - in: query
+        name: psa_level
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Psa Level
+      - in: query
+        name: ca125
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Ca125
+      - in: query
+        name: cea
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cea
+      - in: query
+        name: er_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Er Status
+      - in: query
+        name: er_percent_positive
+        required: false
+        schema:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Er Percent Positive
+      - in: query
+        name: pr_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pr Status
+      - in: query
+        name: pr_percent_positive
+        required: false
+        schema:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pr Percent Positive
+      - in: query
+        name: her2_ihc_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Her2 Ihc Status
+      - in: query
+        name: her2_ish_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Her2 Ish Status
+      - in: query
+        name: hpv_ihc_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hpv Ihc Status
+      - in: query
+        name: hpv_pcr_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hpv Pcr Status
+      - in: query
+        name: hpv_strain
+        required: false
+        schema:
+          items:
+            type: string
+          q: hpv_strain__overlap
+          title: Hpv Strain
+          type: array
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedBiomarkerModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Biomarkers
+      tags:
+      - authorized
+  /v2/authorized/chemotherapies/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_chemotherapies
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
+        name: drug_reference_database
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Database
+      - in: query
+        name: drug_name
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Name
+      - in: query
+        name: drug_reference_identifier
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+      - in: query
+        name: chemotherapy_drug_dose_units
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Chemotherapy Drug Dose Units
+      - in: query
+        name: prescribed_cumulative_drug_dose
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+      - in: query
+        name: actual_cumulative_drug_dose
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedChemotherapyModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Chemotherapies
+      tags:
+      - authorized
+  /v2/authorized/comorbidities/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_comorbidities
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: prior_malignancy
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Prior Malignancy
+      - in: query
+        name: laterality_of_prior_malignancy
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Laterality Of Prior Malignancy
+      - in: query
+        name: age_at_comorbidity_diagnosis
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Age At Comorbidity Diagnosis
+      - in: query
+        name: comorbidity_type_code
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comorbidity Type Code
+      - in: query
+        name: comorbidity_treatment_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comorbidity Treatment Status
+      - in: query
+        name: comorbidity_treatment
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comorbidity Treatment
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedComorbidityModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Comorbidities
+      tags:
+      - authorized
+  /v2/authorized/donor_with_clinical_data/program/{program_id}/donor/{donor_id}:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_get_donor_with_clinical_data
+      parameters:
+      - in: path
+        name: program_id
+        required: true
+        schema:
+          title: Program Id
+          type: string
+      - in: path
+        name: donor_id
+        required: true
+        schema:
+          title: Donor Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DonorWithClinicalDataSchema'
+          description: OK
+        '404':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                title: Response
+                type: object
+          description: Not Found
+      security:
+      - LoginAuth: []
+      summary: Get Donor With Clinical Data
+      tags:
+      - authorized
+  /v2/authorized/donors/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_donors
+      parameters:
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: gender
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          q: gender__icontains
+          title: Gender
+      - in: query
+        name: sex_at_birth
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sex At Birth
+      - in: query
+        name: is_deceased
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Deceased
+      - in: query
+        name: lost_to_followup_after_clinical_event_identifier
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lost To Followup After Clinical Event Identifier
+      - in: query
+        name: lost_to_followup_reason
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lost To Followup Reason
+      - in: query
+        name: cause_of_death
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cause Of Death
+      - in: query
+        name: primary_site
+        required: false
+        schema:
+          items:
+            type: string
+          q: primary_site__overlap
+          title: Primary Site
+          type: array
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedDonorModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Donors
+      tags:
+      - authorized
+  /v2/authorized/exposures/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_exposures
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: tobacco_smoking_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tobacco Smoking Status
+      - in: query
+        name: tobacco_type
+        required: false
+        schema:
+          items:
+            type: string
+          q: tobacco_type__overlap
+          title: Tobacco Type
+          type: array
+      - in: query
+        name: pack_years_smoked
+        required: false
+        schema:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Pack Years Smoked
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedExposureModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Exposures
+      tags:
+      - authorized
+  /v2/authorized/follow_ups/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_follow_ups
+      parameters:
+      - in: query
+        name: submitter_follow_up_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Follow Up Id
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_primary_diagnosis_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
+        name: disease_status_at_followup
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Disease Status At Followup
+      - in: query
+        name: relapse_type
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Relapse Type
+      - in: query
+        name: method_of_progression_status
+        required: false
+        schema:
+          items:
+            type: string
+          q: method_of_progression_status__overlap
+          title: Method Of Progression Status
+          type: array
+      - in: query
+        name: anatomic_site_progression_or_recurrence
+        required: false
+        schema:
+          items:
+            type: string
+          q: anatomic_site_progression_or_recurrence__overlap
+          title: Anatomic Site Progression Or Recurrence
+          type: array
+      - in: query
+        name: recurrence_tumour_staging_system
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence Tumour Staging System
+      - in: query
+        name: recurrence_t_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence T Category
+      - in: query
+        name: recurrence_n_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence N Category
+      - in: query
+        name: recurrence_m_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence M Category
+      - in: query
+        name: recurrence_stage_group
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Recurrence Stage Group
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedFollowUpModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Follow Ups
+      tags:
+      - authorized
+  /v2/authorized/hormone_therapies/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_hormone_therapies
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
+        name: drug_reference_database
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Database
+      - in: query
+        name: drug_name
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Name
+      - in: query
+        name: drug_reference_identifier
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+      - in: query
+        name: hormone_drug_dose_units
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hormone Drug Dose Units
+      - in: query
+        name: prescribed_cumulative_drug_dose
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+      - in: query
+        name: actual_cumulative_drug_dose
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedHormoneTherapyModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Hormone Therapies
+      tags:
+      - authorized
+  /v2/authorized/immunotherapies/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_immunotherapies
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
+        name: drug_reference_database
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Database
+      - in: query
+        name: immunotherapy_type
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Immunotherapy Type
+      - in: query
+        name: drug_name
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Name
+      - in: query
+        name: drug_reference_identifier
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Drug Reference Identifier
+      - in: query
+        name: immunotherapy_drug_dose_units
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Immunotherapy Drug Dose Units
+      - in: query
+        name: prescribed_cumulative_drug_dose
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Prescribed Cumulative Drug Dose
+      - in: query
+        name: actual_cumulative_drug_dose
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Actual Cumulative Drug Dose
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedImmunotherapyModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Immunotherapies
+      tags:
+      - authorized
+  /v2/authorized/primary_diagnoses/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_primary_diagnoses
+      parameters:
+      - in: query
+        name: submitter_primary_diagnosis_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: cancer_type_code
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cancer Type Code
+      - in: query
+        name: basis_of_diagnosis
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Basis Of Diagnosis
+      - in: query
+        name: laterality
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Laterality
+      - in: query
+        name: lymph_nodes_examined_status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lymph Nodes Examined Status
+      - in: query
+        name: lymph_nodes_examined_method
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lymph Nodes Examined Method
+      - in: query
+        name: number_lymph_nodes_positive
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Lymph Nodes Positive
+      - in: query
+        name: clinical_tumour_staging_system
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical Tumour Staging System
+      - in: query
+        name: clinical_t_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical T Category
+      - in: query
+        name: clinical_n_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical N Category
+      - in: query
+        name: clinical_m_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical M Category
+      - in: query
+        name: clinical_stage_group
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clinical Stage Group
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedPrimaryDiagnosisModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Primary Diagnoses
+      tags:
+      - authorized
+  /v2/authorized/program/{program_id}/:
+    delete:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_delete_program
+      parameters:
+      - in: path
+        name: program_id
+        required: true
+        schema:
+          title: Program Id
+          type: string
+      responses:
+        '204':
+          description: No Content
+        '404':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                title: Response
+                type: object
+          description: Not Found
+      security:
+      - LoginAuth: []
+      summary: Delete Program
+      tags:
+      - authorized
+  /v2/authorized/programs/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_programs
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedProgramModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Programs
+      tags:
+      - authorized
+  /v2/authorized/radiations/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_radiations
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
+        name: radiation_therapy_modality
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Radiation Therapy Modality
+      - in: query
+        name: radiation_therapy_type
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Radiation Therapy Type
+      - in: query
+        name: radiation_therapy_fractions
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Fractions
+      - in: query
+        name: radiation_therapy_dosage
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Radiation Therapy Dosage
+      - in: query
+        name: anatomical_site_irradiated
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Anatomical Site Irradiated
+      - in: query
+        name: radiation_boost
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Radiation Boost
+      - in: query
+        name: reference_radiation_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reference Radiation Treatment Id
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedRadiationModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Radiations
+      tags:
+      - authorized
+  /v2/authorized/sample_registrations/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_sample_registrations
+      parameters:
+      - in: query
+        name: submitter_sample_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Sample Id
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_specimen_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+      - in: query
+        name: specimen_tissue_source
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Tissue Source
+      - in: query
+        name: tumour_normal_designation
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Normal Designation
+      - in: query
+        name: specimen_type
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Type
+      - in: query
+        name: sample_type
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sample Type
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedSampleRegistrationModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Sample Registrations
+      tags:
+      - authorized
+  /v2/authorized/specimens/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_specimens
+      parameters:
+      - in: query
+        name: submitter_specimen_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_primary_diagnosis_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+      - in: query
+        name: pathological_tumour_staging_system
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological Tumour Staging System
+      - in: query
+        name: pathological_t_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological T Category
+      - in: query
+        name: pathological_n_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological N Category
+      - in: query
+        name: pathological_m_category
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological M Category
+      - in: query
+        name: pathological_stage_group
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological Stage Group
+      - in: query
+        name: specimen_storage
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Storage
+      - in: query
+        name: specimen_processing
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Processing
+      - in: query
+        name: tumour_histological_type
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Histological Type
+      - in: query
+        name: specimen_anatomic_location
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Anatomic Location
+      - in: query
+        name: specimen_laterality
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Specimen Laterality
+      - in: query
+        name: reference_pathology_confirmed_diagnosis
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reference Pathology Confirmed Diagnosis
+      - in: query
+        name: reference_pathology_confirmed_tumour_presence
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reference Pathology Confirmed Tumour Presence
+      - in: query
+        name: tumour_grading_system
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Grading System
+      - in: query
+        name: tumour_grade
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Grade
+      - in: query
+        name: percent_tumour_cells_range
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Percent Tumour Cells Range
+      - in: query
+        name: percent_tumour_cells_measurement_method
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Percent Tumour Cells Measurement Method
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedSpecimenModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Specimens
+      tags:
+      - authorized
+  /v2/authorized/surgeries/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_surgeries
+      parameters:
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
+        name: submitter_specimen_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Specimen Id
+      - in: query
+        name: surgery_type
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Type
+      - in: query
+        name: surgery_site
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Site
+      - in: query
+        name: surgery_location
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Location
+      - in: query
+        name: tumour_length
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Length
+      - in: query
+        name: tumour_width
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Tumour Width
+      - in: query
+        name: greatest_dimension_tumour
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Greatest Dimension Tumour
+      - in: query
+        name: tumour_focality
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tumour Focality
+      - in: query
+        name: residual_tumour_classification
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Residual Tumour Classification
+      - in: query
+        name: margin_types_involved
+        required: false
+        schema:
+          items:
+            type: string
+          q: margin_types_involved__overlap
+          title: Margin Types Involved
+          type: array
+      - in: query
+        name: margin_types_not_involved
+        required: false
+        schema:
+          items:
+            type: string
+          q: margin_types_not_involved__overlap
+          title: Margin Types Not Involved
+          type: array
+      - in: query
+        name: margin_types_not_assessed
+        required: false
+        schema:
+          items:
+            type: string
+          q: margin_types_not_assessed__overlap
+          title: Margin Types Not Assessed
+          type: array
+      - in: query
+        name: lymphovascular_invasion
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lymphovascular Invasion
+      - in: query
+        name: perineural_invasion
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Perineural Invasion
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedSurgeryModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Surgeries
+      tags:
+      - authorized
+  /v2/authorized/treatments/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_clinical_data_list_treatments
+      parameters:
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
+        name: program_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Program Id
+      - in: query
+        name: submitter_donor_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Donor Id
+      - in: query
+        name: submitter_primary_diagnosis_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Primary Diagnosis Id
+      - in: query
+        name: treatment_type
+        required: false
+        schema:
+          items:
+            type: string
+          q: treatment_type__overlap
+          title: Treatment Type
+          type: array
+      - in: query
+        name: is_primary_treatment
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Is Primary Treatment
+      - in: query
+        name: line_of_treatment
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Line Of Treatment
+      - in: query
+        name: treatment_setting
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Treatment Setting
+      - in: query
+        name: treatment_intent
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Treatment Intent
+      - in: query
+        name: days_per_cycle
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+      - in: query
+        name: number_of_cycles
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
+      - in: query
+        name: response_to_treatment_criteria_method
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Response To Treatment Criteria Method
+      - in: query
+        name: response_to_treatment
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Response To Treatment
+      - in: query
+        name: status_of_treatment
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status Of Treatment
+      - in: query
+        name: page
+        required: false
+        schema:
+          minimum: 1
+          title: Page
+          type: integer
+      - in: query
+        name: page_size
+        required: false
+        schema:
+          minimum: 1
+          title: Page Size
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedTreatmentModelSchema'
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: List Treatments
+      tags:
+      - authorized
+  /v2/discovery/donors/:
+    get:
+      description: 'Return the number of donors per cohort in the database.
+
+        Note: This function is identical to `discover_patients_per_cohort`
+
+        and is here because the frontend ingest uses it. It''s probably best
+
+        to clean up later.'
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_donors
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/DiscoveryDonorSchema'
+                title: Response
+                type: array
+          description: OK
+      summary: Discover Donors
+      tags:
+      - discovery
+  /v2/discovery/overview/cohort_count/:
+    get:
+      description: Return the number of cohorts in the database.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_cohort_count
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: integer
+                title: Response
+                type: object
+          description: OK
+      summary: Discover Cohort Count
+      tags:
+      - overview
+  /v2/discovery/overview/diagnosis_age_count/:
+    get:
+      description: Return the count for age of diagnosis by calculating the date of
+        birth interval.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_diagnosis_age_count
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/DiagnosisAgeCountSchema'
+                title: Response
+                type: array
+          description: OK
+      summary: Discover Diagnosis Age Count
+      tags:
+      - overview
+  /v2/discovery/overview/gender_count/:
+    get:
+      description: Return the count for every gender in the database.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_gender_count
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/GenderCountSchema'
+                title: Response
+                type: array
+          description: OK
+      summary: Discover Gender Count
+      tags:
+      - overview
+  /v2/discovery/overview/individual_count/:
+    get:
+      description: Return the number of individuals in the database.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_individual_count
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                title: Response
+                type: object
+          description: OK
+      summary: Discover Individual Count
+      tags:
+      - overview
+  /v2/discovery/overview/patients_per_cohort/:
+    get:
+      description: Return the number of patients per cohort in the database.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_patients_per_cohort
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PatientPerCohortSchema'
+                title: Response
+                type: array
+          description: OK
+      summary: Discover Patients Per Cohort
+      tags:
+      - overview
+  /v2/discovery/overview/primary_site_count/:
+    get:
+      description: Return the count for every cancer type in the database.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_primary_site_count
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PrimarySiteCountSchema'
+                title: Response
+                type: array
+          description: OK
+      summary: Discover Primary Site Count
+      tags:
+      - overview
+  /v2/discovery/overview/treatment_type_count/:
+    get:
+      description: Return the count for every treatment type in the database.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_treatment_type_count
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/TreatmentTypeCountSchema'
+                title: Response
+                type: array
+          description: OK
+      summary: Discover Treatment Type Count
+      tags:
+      - overview
+  /v2/discovery/programs/:
+    get:
+      description: Return all the programs in the database.
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_programs
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ProgramDiscoverySchema'
+                title: Response
+                type: array
+          description: OK
+      summary: Discover Programs
+      tags:
+      - discovery
+  /v2/discovery/sidebar_list/:
+    get:
+      description: Retrieve the list of drug names and treatment for frontend usage
+      operationId: chord_metadata_service_mohpackets_apis_discovery_discover_sidebar_list
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                title: Response
+                type: object
+          description: OK
+      summary: Discover Sidebar List
+      tags:
+      - discovery
+  /v2/explorer/donors/:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_explorer_explorer_donor
+      parameters:
+      - in: query
+        name: treatment_type
+        required: false
+        schema:
+          items:
+            type: string
+          q: treatment_type__overlap
+          title: Treatment Type
+          type: array
+      - in: query
+        name: primary_site
+        required: false
+        schema:
+          items:
+            type: string
+          q: primary_site__overlap
+          title: Primary Site
+          type: array
+      - in: query
+        name: chemotherapy_drug_name
+        required: false
+        schema:
+          items:
+            type: string
+          title: Chemotherapy Drug Name
+          type: array
+      - in: query
+        name: immunotherapy_drug_name
+        required: false
+        schema:
+          items:
+            type: string
+          title: Immunotherapy Drug Name
+          type: array
+      - in: query
+        name: hormone_therapy_drug_name
+        required: false
+        schema:
+          items:
+            type: string
+          title: Hormone Therapy Drug Name
+          type: array
+      - in: query
+        name: exclude_cohorts
+        required: false
+        schema:
+          items:
+            type: string
+          title: Exclude Cohorts
+          type: array
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/DonorExplorerSchema'
+                title: Response
+                type: array
+          description: OK
+      security:
+      - ServiceTokenAuth: []
+      summary: Explorer Donor
+      tags:
+      - explorer
+  /v2/ingest/biomarker/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_biomarker
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BiomarkerIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Biomarker
+      tags:
+      - ingest
+  /v2/ingest/chemotherapy/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_chemotherapy
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChemotherapyIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Chemotherapy
+      tags:
+      - ingest
+  /v2/ingest/comorbidity/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_comorbidity
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComorbidityIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Comorbidity
+      tags:
+      - ingest
+  /v2/ingest/donor/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_donor
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DonorIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Donor
+      tags:
+      - ingest
+  /v2/ingest/exposure/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_exposure
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExposureIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Exposure
+      tags:
+      - ingest
+  /v2/ingest/follow_up/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_follow_up
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FollowUpIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Follow Up
+      tags:
+      - ingest
+  /v2/ingest/hormone_therapy/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_hormone_therapy
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HormoneTherapyIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Hormone Therapy
+      tags:
+      - ingest
+  /v2/ingest/immunotherapy/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_immunotherapy
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImmunotherapyIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Immunotherapy
+      tags:
+      - ingest
+  /v2/ingest/primary_diagnosis/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_primary_diagnosis
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrimaryDiagnosisIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Primary Diagnosis
+      tags:
+      - ingest
+  /v2/ingest/program/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_program
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProgramIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Program
+      tags:
+      - ingest
+  /v2/ingest/radiation/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_radiation
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RadiationIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Radiation
+      tags:
+      - ingest
+  /v2/ingest/sample_registration/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_sample_registration
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SampleRegistrationIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Sample Registration
+      tags:
+      - ingest
+  /v2/ingest/specimen/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_specimen
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpecimenIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Specimen
+      tags:
+      - ingest
+  /v2/ingest/surgery/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_surgery
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SurgeryIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Surgery
+      tags:
+      - ingest
+  /v2/ingest/treatment/:
+    post:
+      operationId: chord_metadata_service_mohpackets_apis_ingestion_create_treatment
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TreatmentIngestSchema'
+        required: true
+      responses:
+        '200':
+          description: OK
+      security:
+      - LoginAuth: []
+      summary: Create Treatment
+      tags:
+      - ingest
+  /v2/service-info:
+    get:
+      operationId: chord_metadata_service_mohpackets_apis_core_service_info
+      parameters: []
+      responses:
+        '200':
+          description: OK
+      summary: Service Info
+servers: []
+

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -440,6 +440,7 @@ components:
       - program_id
       - submitter_donor_id
       - submitter_treatment_id
+      - systemic_therapy_type
       title: SystemicTherapyIngestSchema
       type: object
     SystemicTherapyModelSchema:
@@ -502,6 +503,7 @@ components:
       - program_id
       - submitter_donor_id
       - submitter_treatment_id
+      - systemic_therapy_type
       title: SystemicTherapyModelSchema
       type: object
     ComorbidityFilterSchema:
@@ -2008,12 +2010,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/TumourClassificationEnum'
           - type: 'null'
-        submitter_treatment_id:
-          anyOf:
-          - maxLength: 64
-            type: string
-          - type: 'null'
-          title: Submitter Treatment Id
         surgery_reference_database:
           anyOf:
           - $ref: '#/components/schemas/SurgeryReferenceDatabaseEnum'
@@ -3461,9 +3457,6 @@ components:
         submitter_specimen_id:
           title: Submitter Specimen Id
           type: string
-        submitter_treatment_id:
-          title: Submitter Treatment Id
-          type: string
         tumour_normal_designation:
           anyOf:
           - $ref: '#/components/schemas/TumourDesginationEnum'
@@ -3507,9 +3500,6 @@ components:
           type: string
         submitter_specimen_id:
           title: Submitter Specimen Id
-          type: string
-        submitter_treatment_id:
-          title: Submitter Treatment Id
           type: string
         tumour_normal_designation:
           anyOf:

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -412,6 +412,16 @@ components:
           - $ref: '#/components/schemas/SystemicTherapyTypeEnum'
           - type: 'null'
           title: Systemic Therapy Type
+        start_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+          title: Start date
+        end_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+          title: End date
         program_id:
           title: Program Id
           type: string
@@ -468,6 +478,17 @@ components:
           anyOf:
           - $ref: '#/components/schemas/SystemicTherapyTypeEnum'
           - type: 'null'
+          title: Systemic Therapy Type
+        start_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+          title: Start date
+        end_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+          title: End date
         program_id:
           title: Program Id
           type: string
@@ -1610,6 +1631,17 @@ components:
           anyOf:
           - $ref: '#/components/schemas/SystemicTherapyTypeEnum'
           - type: 'null'
+          title: Systemic Therapy Type
+        start_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+          title: Start date
+        end_date:
+          anyOf:
+          - $ref: '#/components/schemas/DateInterval'
+          - type: 'null'
+          title: End date
       title: NestedSystemicTherapySchema
       type: object
     NestedComorbiditySchema:

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -1041,13 +1041,6 @@ components:
             $ref: '#/components/schemas/NestedPrimaryDiagnosisSchema'
           title: Primary Diagnoses
           type: array
-        primary_site:
-          anyOf:
-          - items:
-              $ref: '#/components/schemas/PrimarySiteEnum'
-            type: array
-          - type: 'null'
-          title: Primary Site
         program_id:
           title: Program Id
           type: string

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -688,12 +688,6 @@ components:
             type: string
           title: Immunotherapy Drug Name
           type: array
-        primary_site:
-          items:
-            type: string
-          q: primary_site__overlap
-          title: Primary Site
-          type: array
         treatment_type:
           items:
             type: string
@@ -840,13 +834,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/LostToFollowupReasonEnum'
           - type: 'null'
-        primary_site:
-          anyOf:
-          - items:
-              $ref: '#/components/schemas/PrimarySiteEnum'
-            type: array
-          - type: 'null'
-          title: Primary Site
         program_id:
           title: Program Id
           type: string
@@ -912,13 +899,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/LostToFollowupReasonEnum'
           - type: 'null'
-        primary_site:
-          anyOf:
-          - items:
-              $ref: '#/components/schemas/PrimarySiteEnum'
-            type: array
-          - type: 'null'
-          title: Primary Site
         program_id:
           title: Program Id
           type: string
@@ -2187,6 +2167,31 @@ components:
       type: object
     NestedPrimaryDiagnosisSchema:
       properties:
+        pathological_m_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological M Category
+        pathological_n_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological N Category
+        pathological_stage_group:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological Stage Group
+        pathological_t_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological T Category
+        pathological_tumour_staging_system:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pathological Tumour Staging System
         basis_of_diagnosis:
           anyOf:
           - $ref: '#/components/schemas/BasisOfDiagnosisEnum'
@@ -2230,19 +2235,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
           - type: 'null'
-        lymph_nodes_examined_method:
-          anyOf:
-          - $ref: '#/components/schemas/LymphNodeMethodEnum'
-          - type: 'null'
-        lymph_nodes_examined_status:
-          anyOf:
-          - $ref: '#/components/schemas/LymphNodeStatusEnum'
-          - type: 'null'
-        number_lymph_nodes_positive:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Lymph Nodes Positive
         specimens:
           items:
             $ref: '#/components/schemas/NestedSpecimenSchema'
@@ -2328,26 +2320,6 @@ components:
       type: object
     NestedSpecimenSchema:
       properties:
-        pathological_m_category:
-          anyOf:
-          - $ref: '#/components/schemas/MCategoryEnum'
-          - type: 'null'
-        pathological_n_category:
-          anyOf:
-          - $ref: '#/components/schemas/NCategoryEnum'
-          - type: 'null'
-        pathological_stage_group:
-          anyOf:
-          - $ref: '#/components/schemas/StageGroupEnum'
-          - type: 'null'
-        pathological_t_category:
-          anyOf:
-          - $ref: '#/components/schemas/TCategoryEnum'
-          - type: 'null'
-        pathological_tumour_staging_system:
-          anyOf:
-          - $ref: '#/components/schemas/TumourStagingSystemEnum'
-          - type: 'null'
         percent_tumour_cells_measurement_method:
           anyOf:
           - $ref: '#/components/schemas/CellsMeasureMethodEnum'
@@ -2397,6 +2369,11 @@ components:
           maxLength: 64
           pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Specimen Id
+          type: string
+        submitter_treatment_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Treatment Id
           type: string
         tumour_grade:
           anyOf:
@@ -2463,6 +2440,12 @@ components:
             type: string
           - type: 'null'
           title: Submitter Specimen Id
+        submitter_treatment_id:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Submitter Treatment Id
         surgery_location:
           anyOf:
           - $ref: '#/components/schemas/SurgeryLocationEnum'
@@ -3095,21 +3078,6 @@ components:
           - type: string
           - type: 'null'
           title: Laterality
-        lymph_nodes_examined_method:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Lymph Nodes Examined Method
-        lymph_nodes_examined_status:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Lymph Nodes Examined Status
-        number_lymph_nodes_positive:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Lymph Nodes Positive
         program_id:
           anyOf:
           - type: string
@@ -3129,6 +3097,26 @@ components:
       type: object
     PrimaryDiagnosisIngestSchema:
       properties:
+        pathological_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        pathological_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        pathological_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        pathological_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        pathological_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
         basis_of_diagnosis:
           anyOf:
           - $ref: '#/components/schemas/BasisOfDiagnosisEnum'
@@ -3167,19 +3155,9 @@ components:
           anyOf:
           - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
           - type: 'null'
-        lymph_nodes_examined_method:
-          anyOf:
-          - $ref: '#/components/schemas/LymphNodeMethodEnum'
-          - type: 'null'
-        lymph_nodes_examined_status:
-          anyOf:
-          - $ref: '#/components/schemas/LymphNodeStatusEnum'
-          - type: 'null'
-        number_lymph_nodes_positive:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Lymph Nodes Positive
+        primary_site:
+          type: string
+          title: Primary Site
         program_id:
           title: Program Id
           type: string
@@ -3215,6 +3193,26 @@ components:
       type: string
     PrimaryDiagnosisModelSchema:
       properties:
+        pathological_m_category:
+          anyOf:
+          - $ref: '#/components/schemas/MCategoryEnum'
+          - type: 'null'
+        pathological_n_category:
+          anyOf:
+          - $ref: '#/components/schemas/NCategoryEnum'
+          - type: 'null'
+        pathological_stage_group:
+          anyOf:
+          - $ref: '#/components/schemas/StageGroupEnum'
+          - type: 'null'
+        pathological_t_category:
+          anyOf:
+          - $ref: '#/components/schemas/TCategoryEnum'
+          - type: 'null'
+        pathological_tumour_staging_system:
+          anyOf:
+          - $ref: '#/components/schemas/TumourStagingSystemEnum'
+          - type: 'null'
         basis_of_diagnosis:
           anyOf:
           - $ref: '#/components/schemas/BasisOfDiagnosisEnum'
@@ -3253,19 +3251,13 @@ components:
           anyOf:
           - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
           - type: 'null'
-        lymph_nodes_examined_method:
-          anyOf:
-          - $ref: '#/components/schemas/LymphNodeMethodEnum'
-          - type: 'null'
         lymph_nodes_examined_status:
           anyOf:
           - $ref: '#/components/schemas/LymphNodeStatusEnum'
           - type: 'null'
-        number_lymph_nodes_positive:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Lymph Nodes Positive
+        primary_site:
+          title: Primary Site
+          type: string
         program_id:
           title: Program Id
           type: string
@@ -3964,6 +3956,9 @@ components:
         submitter_specimen_id:
           title: Submitter Specimen Id
           type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
+          type: string
         tumour_normal_designation:
           anyOf:
           - $ref: '#/components/schemas/TumourDesginationEnum'
@@ -4007,6 +4002,9 @@ components:
           type: string
         submitter_specimen_id:
           title: Submitter Specimen Id
+          type: string
+        submitter_treatment_id:
+          title: Submitter Treatment Id
           type: string
         tumour_normal_designation:
           anyOf:
@@ -4053,31 +4051,6 @@ components:
       type: string
     SpecimenFilterSchema:
       properties:
-        pathological_m_category:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Pathological M Category
-        pathological_n_category:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Pathological N Category
-        pathological_stage_group:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Pathological Stage Group
-        pathological_t_category:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Pathological T Category
-        pathological_tumour_staging_system:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Pathological Tumour Staging System
         percent_tumour_cells_measurement_method:
           anyOf:
           - type: string
@@ -4138,6 +4111,11 @@ components:
           - type: string
           - type: 'null'
           title: Submitter Specimen Id
+        submitter_treatment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
         tumour_grade:
           anyOf:
           - type: string
@@ -4157,26 +4135,6 @@ components:
       type: object
     SpecimenIngestSchema:
       properties:
-        pathological_m_category:
-          anyOf:
-          - $ref: '#/components/schemas/MCategoryEnum'
-          - type: 'null'
-        pathological_n_category:
-          anyOf:
-          - $ref: '#/components/schemas/NCategoryEnum'
-          - type: 'null'
-        pathological_stage_group:
-          anyOf:
-          - $ref: '#/components/schemas/StageGroupEnum'
-          - type: 'null'
-        pathological_t_category:
-          anyOf:
-          - $ref: '#/components/schemas/TCategoryEnum'
-          - type: 'null'
-        pathological_tumour_staging_system:
-          anyOf:
-          - $ref: '#/components/schemas/TumourStagingSystemEnum'
-          - type: 'null'
         percent_tumour_cells_measurement_method:
           anyOf:
           - $ref: '#/components/schemas/CellsMeasureMethodEnum'
@@ -4231,6 +4189,11 @@ components:
           pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Specimen Id
           type: string
+        submitter_treatment_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Specimen Id
+          type: string
         tumour_grade:
           anyOf:
           - $ref: '#/components/schemas/TumourGradeEnum'
@@ -4268,26 +4231,6 @@ components:
       type: string
     SpecimenModelSchema:
       properties:
-        pathological_m_category:
-          anyOf:
-          - $ref: '#/components/schemas/MCategoryEnum'
-          - type: 'null'
-        pathological_n_category:
-          anyOf:
-          - $ref: '#/components/schemas/NCategoryEnum'
-          - type: 'null'
-        pathological_stage_group:
-          anyOf:
-          - $ref: '#/components/schemas/StageGroupEnum'
-          - type: 'null'
-        pathological_t_category:
-          anyOf:
-          - $ref: '#/components/schemas/TCategoryEnum'
-          - type: 'null'
-        pathological_tumour_staging_system:
-          anyOf:
-          - $ref: '#/components/schemas/TumourStagingSystemEnum'
-          - type: 'null'
         percent_tumour_cells_measurement_method:
           anyOf:
           - $ref: '#/components/schemas/CellsMeasureMethodEnum'
@@ -4338,6 +4281,11 @@ components:
           title: Submitter Primary Diagnosis Id
           type: string
         submitter_specimen_id:
+          maxLength: 64
+          pattern: ^[A-Za-z0-9\-\._]{1,64}
+          title: Submitter Specimen Id
+          type: string
+        submitter_treatment_id:
           maxLength: 64
           pattern: ^[A-Za-z0-9\-\._]{1,64}
           title: Submitter Specimen Id
@@ -6410,30 +6358,6 @@ paths:
           - type: 'null'
           title: Laterality
       - in: query
-        name: lymph_nodes_examined_status
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Lymph Nodes Examined Status
-      - in: query
-        name: lymph_nodes_examined_method
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Lymph Nodes Examined Method
-      - in: query
-        name: number_lymph_nodes_positive
-        required: false
-        schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Lymph Nodes Positive
-      - in: query
         name: clinical_tumour_staging_system
         required: false
         schema:
@@ -6711,6 +6635,14 @@ paths:
           - type: 'null'
           title: Submitter Specimen Id
       - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
+      - in: query
         name: specimen_tissue_source
         required: false
         schema:
@@ -6780,6 +6712,14 @@ paths:
           - type: string
           - type: 'null'
           title: Submitter Specimen Id
+      - in: query
+        name: submitter_treatment_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
       - in: query
         name: program_id
         required: false

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -358,6 +358,16 @@ components:
           - type: string
           - type: 'null'
           title: Systemic Therapy Type
+        days_per_cycle:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+        number_of_cycles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
         program_id:
           anyOf:
           - type: string
@@ -422,6 +432,16 @@ components:
           - $ref: '#/components/schemas/DateInterval'
           - type: 'null'
           title: End date
+        days_per_cycle:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+        number_of_cycles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
         program_id:
           title: Program Id
           type: string
@@ -490,6 +510,16 @@ components:
           - $ref: '#/components/schemas/DateInterval'
           - type: 'null'
           title: End date
+        days_per_cycle:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+        number_of_cycles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
         program_id:
           title: Program Id
           type: string
@@ -1644,6 +1674,16 @@ components:
           - $ref: '#/components/schemas/DateInterval'
           - type: 'null'
           title: End date
+        days_per_cycle:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+        number_of_cycles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
       title: NestedSystemicTherapySchema
       type: object
     NestedComorbiditySchema:
@@ -2057,11 +2097,6 @@ components:
             $ref: '#/components/schemas/NestedSystemicTherapySchema'
           title: Systemic Therapies
           type: array
-        days_per_cycle:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Days Per Cycle
         followups:
           items:
             $ref: '#/components/schemas/NestedFollowUpSchema'
@@ -2076,11 +2111,6 @@ components:
           - type: integer
           - type: 'null'
           title: Line Of Treatment
-        number_of_cycles:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Of Cycles
         radiations:
           items:
             $ref: '#/components/schemas/NestedRadiationSchema'
@@ -4444,11 +4474,6 @@ components:
       type: string
     TreatmentFilterSchema:
       properties:
-        days_per_cycle:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Days Per Cycle
         is_primary_treatment:
           anyOf:
           - type: string
@@ -4459,11 +4484,6 @@ components:
           - type: integer
           - type: 'null'
           title: Line Of Treatment
-        number_of_cycles:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Of Cycles
         program_id:
           anyOf:
           - type: string
@@ -4519,11 +4539,6 @@ components:
       type: object
     TreatmentIngestSchema:
       properties:
-        days_per_cycle:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Days Per Cycle
         is_primary_treatment:
           anyOf:
           - $ref: '#/components/schemas/uBooleanEnum'
@@ -4533,11 +4548,6 @@ components:
           - type: integer
           - type: 'null'
           title: Line Of Treatment
-        number_of_cycles:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Of Cycles
         program_id:
           title: Program Id
           type: string
@@ -4613,11 +4623,6 @@ components:
       type: string
     TreatmentModelSchema:
       properties:
-        days_per_cycle:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Days Per Cycle
         is_primary_treatment:
           anyOf:
           - $ref: '#/components/schemas/uBooleanEnum'
@@ -4627,11 +4632,6 @@ components:
           - type: integer
           - type: 'null'
           title: Line Of Treatment
-        number_of_cycles:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Of Cycles
         program_id:
           title: Program Id
           type: string
@@ -5148,6 +5148,22 @@ paths:
           - type: string
           - type: 'null'
           title: Systemic Therapy Type
+      - in: query
+        name: days_per_cycle
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Days Per Cycle
+      - in: query
+        name: number_of_cycles
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Number Of Cycles
       - in: query
         name: page
         required: false
@@ -6431,22 +6447,6 @@ paths:
           - type: string
           - type: 'null'
           title: Treatment Intent
-      - in: query
-        name: days_per_cycle
-        required: false
-        schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Days Per Cycle
-      - in: query
-        name: number_of_cycles
-        required: false
-        schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Number Of Cycles
       - in: query
         name: response_to_treatment_criteria_method
         required: false

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -3251,10 +3251,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/PrimaryDiagnosisLateralityEnum'
           - type: 'null'
-        lymph_nodes_examined_status:
-          anyOf:
-          - $ref: '#/components/schemas/LymphNodeStatusEnum'
-          - type: 'null'
         primary_site:
           title: Primary Site
           type: string

--- a/chord_metadata_service/mohpackets/docs/schema_manual.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_manual.yml
@@ -2440,6 +2440,15 @@ components:
             type: string
           - type: 'null'
           title: Submitter Treatment Id
+        surgery_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryReferenceDatabaseEnum'
+          - type: 'null'
+        surgery_reference_identifier:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
         surgery_location:
           anyOf:
           - $ref: '#/components/schemas/SurgeryLocationEnum'
@@ -4543,6 +4552,15 @@ components:
           - type: string
           - type: 'null'
           title: Submitter Treatment Id
+        surgery_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryReferenceDatabaseEnum'
+          - type: 'null'
+        surgery_reference_identifier:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Submitter Treatment Id
         surgery_location:
           anyOf:
           - type: string
@@ -4627,6 +4645,18 @@ components:
             type: string
           - type: 'null'
           title: Submitter Treatment Id
+          type: string
+        surgery_reference_database:
+          anyOf:
+          - $ref: '#/components/schemas/SurgeryReferenceDatabaseEnum'
+          - type: 'null'
+          title: Surgery Reference Database
+          type: string
+        surgery_reference_identifier:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Reference Identifier
           type: string
         surgery_location:
           anyOf:
@@ -4724,6 +4754,12 @@ components:
         submitter_treatment_id:
           title: Submitter Treatment Id
           type: string
+        surgery_reference_database:
+          title: Surgery Reference Database
+          type: string
+        surgery_reference_identifier:
+          title: Surgery Reference Identifier
+          type: string
         surgery_location:
           anyOf:
           - $ref: '#/components/schemas/SurgeryLocationEnum'
@@ -4819,6 +4855,13 @@ components:
       - Wedge/localised gastric resection
       - Wide Local Excision
       title: SurgeryTypeEnum
+      type: string
+    SurgeryReferenceDatabaseEnum:
+      enum:
+      - SNOMED
+      - NCIt
+      - UMLS
+      title: SurgeryReferenceDatabaseEnum
       type: string
     TCategoryEnum:
       enum:
@@ -6903,6 +6946,22 @@ paths:
           - type: string
           - type: 'null'
           title: Submitter Treatment Id
+      - in: query
+        name: surgery_reference_database
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Reference Database
+      - in: query
+        name: surgery_reference_identifier
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Surgery Reference Identifier
       - in: query
         name: surgery_type
         required: false

--- a/chord_metadata_service/mohpackets/docs/schema_v3.yml
+++ b/chord_metadata_service/mohpackets/docs/schema_v3.yml
@@ -1,3 +1,7 @@
+openapi: 3.0.3
+info:
+    title: Katsu
+    version: 3.0.0
 components:
   schemas:
     BasisOfDiagnosisEnum:


### PR DESCRIPTION
# Description
This implements the CanDIGv3 data model changes as outlined in [this document](https://docs.google.com/document/d/12GACkvTxKc0KhmV3bS8BIySu0qwPBfPzaKqp8NrXaaU/edit).

The updated schema can be found at [this link (includes only the diffs to the schema)](https://github.com/CanDIG/katsu/pull/239/files/119fee76a237de9cbb93330876c25a17486c0800..ed7311f059bf3296de477356eb2afe33c5240f90).

## Intended list of changes

Changes to the models includes:

Moving a few fields around: 

1. `primary_site` from donor to primary diagnosis, though the endpoints are still able to query based on it
2. `pathological_*`
3. `[“days_per_cycle”, “number_of_cycles”]`, 

Removing a few fields:

1. Surgery's `submitter_specimen_id`
2. Follow-up's `recurrence_*`
3. Treatment's `[“line_of_treatment”, “treatment_setting”]`
4. Primary Diagnosis' `[“lymph_nodes_examined_status”, “lymph_nodes_examined_method”, “number_lymph_nodes_positive”]`

Adding a few fields: 

1. Specimen's `submitter_treatment_id`
2. `[“surgery_reference_database”, “surgery_reference_identifier”]`

And adding the new Systemic Therapy table, which supercedes (and removes) Chemo/Hormonal/Immunotherapy.

This PR does not address how the implementation of the new table, nor the new/changed endpoints, but only outlines what will need to be changed