### PR TITLE
Optimization: only check allowed for unique programs

### DIFF
--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -106,24 +106,16 @@ class NetworkAuth:
         def authenticate(self, request, bearer_token):
             """
             Authenticates a request for ingest.
-            Grants full permission to site admins.
-            Curators must have ingesting datasets authorized.
+            For each program, if the user is listed as a program curator for the program, Opa will allow ingest. User must be allowed to ingest into ALL programs requested, otherwise it will return false.
+            Opa allows site admins to ingest into all programs.
             """
             if not bearer_token:
                 return False
 
             try:
-                if is_site_admin(request):
-                    logger.debug(
-                        "Site admin authenticated for request '%s'.",
-                        request.get_full_path(),
-                    )
-                    return True
-
-                # For curator
                 request_body = request.body.decode("utf-8")
                 data = json.loads(request_body)
-                program_ids = [item["program_id"] for item in data]
+                program_ids = list(set([item["program_id"] for item in data]))
                 write_datasets = all(
                     is_action_allowed_for_program(
                         bearer_token,

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -6,7 +6,6 @@ import orjson
 from authx.auth import (
     get_opa_datasets,
     verify_service_token,
-    is_site_admin,
     is_action_allowed_for_program,
 )
 from django.conf import settings

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -216,15 +216,11 @@ class LocalAuth:
         def authenticate(self, request, bearer_token):
             if bearer_token in settings.LOCAL_OPA_DATASET:
                 opa_data = settings.LOCAL_OPA_DATASET[bearer_token]
-                is_admin = opa_data["is_admin"]
                 write_datasets = opa_data["write_datasets"]
-
-                if is_admin:
-                    return True
 
                 request_body = request.body.decode("utf-8")
                 data = json.loads(request_body)
-                program_ids = [item["program_id"] for item in data]
+                program_ids = list(set([item["program_id"] for item in data]))
                 authorized = all(
                     program_id in write_datasets for program_id in program_ids
                 )

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -105,7 +105,9 @@ class NetworkAuth:
         def authenticate(self, request, bearer_token):
             """
             Authenticates a request for ingest.
-            For each program, if the user is listed as a program curator for the program, Opa will allow ingest. User must be allowed to ingest into ALL programs requested, otherwise it will return false.
+            For each program, if the user is listed as a program curator for the program,
+            Opa will allow ingest. User must be allowed to ingest into ALL programs
+            requested, otherwise it will return false.
             Opa allows site admins to ingest into all programs.
             """
             if not bearer_token:

--- a/chord_metadata_service/mohpackets/tests/endpoints/base.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/base.py
@@ -93,7 +93,11 @@ class BaseTestCase(TestCase):
         cls.user_2 = TestUser(
             token="site_admin",
             is_admin=True,
-            write_datasets=[],  # admin can write regardless
+            write_datasets=[
+                cls.programs[0].program_id,
+                cls.programs[1].program_id,
+                "admin_authorized_program_id",
+            ],
             read_datasets=[
                 cls.programs[0].program_id,
                 cls.programs[1].program_id,

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_chemotherapy.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_chemotherapy.py
@@ -72,11 +72,11 @@ class IngestTestCase(BaseTestCase):
         - User cannot perform a POST request for chemotherapy record creation.
         """
         chemotherapy = ChemotherapyFactory.build(treatment_uuid=self.treatments[0])
-        chemotherapy_dict = model_to_dict(chemotherapy)
-        chemotherapy_dict["drug_reference_database"] = "invalid"
+        data_dict = model_to_dict(chemotherapy)
+        data_dict["drug_reference_database"] = "invalid"
         response = self.client.post(
             self.chemotherapy_url,
-            data=chemotherapy_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_donor.py
@@ -83,11 +83,11 @@ class IngestTestCase(BaseTestCase):
         - User cannot perform a POST request for donor creation.
         """
         donor = DonorFactory.build(program_id=self.programs[0])
-        donor_dict = model_to_dict(donor)
-        donor_dict["cause_of_death"] = "invalid"
+        data_dict = model_to_dict(donor)
+        data_dict["cause_of_death"] = "invalid"
         response = self.client.post(
             self.donor_url,
-            data=donor_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_follow_up.py
@@ -70,11 +70,11 @@ class IngestTestCase(BaseTestCase):
         - User cannot perform a POST request for follow-up creation.
         """
         follow_up = FollowUpFactory.build(treatment_uuid=self.treatments[0])
-        follow_up_dict = model_to_dict(follow_up)
-        follow_up_dict["relapse_type"] = "invalid"
+        data_dict = model_to_dict(follow_up)
+        data_dict["relapse_type"] = "invalid"
         response = self.client.post(
             self.follow_up_url,
-            data=follow_up_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_primary_diagnoses.py
@@ -72,11 +72,11 @@ class IngestTestCase(BaseTestCase):
         - User cannot perform a POST request for primary diagnosis creation.
         """
         primary_diagnosis = PrimaryDiagnosisFactory.build(donor_uuid=self.donors[0])
-        primary_diagnosis_dict = model_to_dict(primary_diagnosis)
-        primary_diagnosis_dict["basis_of_diagnosis"] = "invalid"
+        data_dict = model_to_dict(primary_diagnosis)
+        data_dict["basis_of_diagnosis"] = "invalid"
         response = self.client.post(
             self.primary_diagnosis_url,
-            data=primary_diagnosis_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_program.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_program.py
@@ -29,7 +29,7 @@ class IngestTestCase(BaseTestCase):
         - An authorized user (user_2) with admin permission.
         - User can perform a POST request for program ingestion.
         """
-        ingest_program = ProgramFactory.build()
+        ingest_program = ProgramFactory.build(program_id="admin_authorized_program_id")
         data_dict = model_to_dict(ingest_program)
         response = self.client.post(
             self.ingest_url,

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_sample_registration.py
@@ -79,11 +79,11 @@ class SampleRegistrationTestCase(BaseTestCase):
         sample_registration = SampleRegistrationFactory.build(
             specimen_uuid=self.specimens[0]
         )
-        sample_registration_dict = model_to_dict(sample_registration)
-        sample_registration_dict["sample_type"] = "invalid"
+        data_dict = model_to_dict(sample_registration)
+        data_dict["sample_type"] = "invalid"
         response = self.client.post(
             self.sample_registration_url,
-            data=sample_registration_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_specimen.py
@@ -76,11 +76,11 @@ class IngestTestCase(BaseTestCase):
         specimen = SpecimenFactory.build(
             primary_diagnosis_uuid=self.primary_diagnoses[0]
         )
-        specimen_dict = model_to_dict(specimen)
-        specimen_dict["tumour_grade"] = "invalid"
+        data_dict = model_to_dict(specimen)
+        data_dict["tumour_grade"] = "invalid"
         response = self.client.post(
             self.specimen_url,
-            data=specimen_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",

--- a/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
+++ b/chord_metadata_service/mohpackets/tests/endpoints/test_treatment.py
@@ -76,11 +76,11 @@ class TreatmentsIngestTestCase(BaseTestCase):
         treatment = TreatmentFactory.build(
             primary_diagnosis_uuid=self.primary_diagnoses[0]
         )
-        treatment_dict = model_to_dict(treatment)
-        treatment_dict["treatment_type"] = "invalid"
+        data_dict = model_to_dict(treatment)
+        data_dict["treatment_type"] = "invalid"
         response = self.client.post(
             self.treatment_url,
-            data=treatment_dict,
+            data=[data_dict],
             content_type="application/json",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.user_2.token}",

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -65,7 +65,7 @@ LOCAL_OPA_DATASET = {
     },
     "site_admin": {
         "is_admin": True,
-        "write_datasets": [],
+        "write_datasets": ["SYNTHETIC-1", "SYNTHETIC-2"],
         "read_datasets": ["SYNTHETIC-1", "SYNTHETIC-2"],
     },
 }


### PR DESCRIPTION
It looks to me like you're checking OPA for program ID for every object to be ingested, so if there were 300 treatments in 5 programs, you'd have to call OPA 300 times. If that's the case, no wonder you'd want to check for site admin first, because that would bypass a lot of calls. But if instead you only check for unique program IDs, you'd only have to call OPA 5 times. Even if it's a little wasteful to call it those 4 extra times for the site admin, it's not so bad, and it would simplify the code. I tried to update the comment to help explain the exact behavior.

This is all moot because katsu_ingest.py sorts the ingest file by program first, and ingests only one program at a time, so it will take the same amount of calls (1) whether the user is a site admin or not.

Should behave as before.