### PR TITLE
DIG-1719: switch to candigv2-logging module

### DIFF
--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -40,7 +40,8 @@ Module with configurations for APIs
 Author: Son Chau
 """
 
-logger = logging.getLogger(__name__)
+from candigv2_logging.logging import log_message
+
 SAFE_METHODS = ("GET", "HEAD", "OPTIONS")
 
 
@@ -88,17 +89,12 @@ class NetworkAuth:
                     path=request.path,
                     program=program_id,
                 )
-                logger.debug(
-                    "DELETE request authentication for '%s' with token: %s. Program ID: %s. Write permission: %s.",
-                    request.get_full_path(),
-                    bearer_token,
-                    program_id,
-                    write_permission,
-                )
+                log_message("DEBUG",
+                    f"DELETE request authentication for '{request.get_full_path()}'. Program ID: {program_id}. Write permission: {write_permission}.", request)
                 return write_permission
 
             except Exception as e:
-                logger.exception(f"An error occurred in OPA: {e}")
+                log_message("EXCEPTION",f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class IngestAuth(HttpBearer):
@@ -127,18 +123,13 @@ class NetworkAuth:
                     for program_id in program_ids
                 )
 
-                logger.debug(
-                    "INGEST request authentication for '%s' with token: %s and programs: %s. Write datasets: %s.",
-                    request.get_full_path(),
-                    bearer_token,
-                    program_ids,
-                    write_datasets,
-                )
+                log_message("DEBUG",
+                f"INGEST request authentication for '{request.get_full_path()}'. Program ID: {program_ids}. Write permission: {write_datasets}.", request)
 
                 return write_datasets
 
             except Exception as e:
-                logger.exception(f"An error occurred in OPA: {e}")
+                log_message("EXCEPTION",f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class GetAuth(HttpBearer):
@@ -163,21 +154,15 @@ class NetworkAuth:
             try:
                 read_datasets = get_opa_datasets(request)
                 result = True if read_datasets else None
-                logger.debug(
-                    "OPA Authentication completed for request '%s' with token: %s. "
-                    "Read datasets: %s. Result: %s.",
-                    request.get_full_path(),
-                    bearer_token,
-                    read_datasets,
-                    result,
-                )
+                log_message("DEBUG",
+                f"READ request authentication for '{request.get_full_path()}'. Datasets: {read_datasets}. Result: {result}", request)
 
                 if result:
                     request.read_datasets = read_datasets
                 return result
 
             except Exception as e:
-                logger.exception(f"An error occurred in OPA: {e}")
+                log_message("EXCEPTION",f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class ServiceTokenAuth(APIKeyHeader):
@@ -188,13 +173,12 @@ class NetworkAuth:
                 is_valid_token = verify_service_token(
                     service="query", token=service_token
                 )
-                logger.debug(
-                    f"verify_service_token for {request.get_full_path()}: {is_valid_token}."
-                    f" X-Service-Token is: {service_token}"
+                log_message("DEBUG",
+                    f"verify_service_token for {request.get_full_path()}: {is_valid_token}. X-Service-Token is: {service_token}", request
                 )
                 return is_valid_token
 
-            logger.debug("No X-Service-Token in headers. Not a query service request.")
+            log_message("DEBUG", "No X-Service-Token in headers. Not a query service request.")
             return False
 
 

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -89,8 +89,7 @@ class NetworkAuth:
                     path=request.path,
                     program=program_id,
                 )
-                log_message("DEBUG",
-                    f"DELETE request authentication for '{request.get_full_path()}'. Program ID: {program_id}. Write permission: {write_permission}.", request)
+                log_message("DEBUG", f"Requesting DELETE for: {program_id}. Result: {write_permission}.", request)
                 return write_permission
 
             except Exception as e:
@@ -123,9 +122,7 @@ class NetworkAuth:
                     for program_id in program_ids
                 )
 
-                log_message("DEBUG",
-                f"INGEST request authentication for '{request.get_full_path()}'. Program ID: {program_ids}. Write permission: {write_datasets}.", request)
-
+                log_message("DEBUG", f"Requesting WRITE for: {program_ids}. Authorized WRITE programs: {write_datasets}.", request)
                 return write_datasets
 
             except Exception as e:
@@ -155,7 +152,7 @@ class NetworkAuth:
                 read_datasets = get_opa_datasets(request)
                 result = True if read_datasets else None
                 log_message("DEBUG",
-                f"READ request authentication for '{request.get_full_path()}'. Datasets: {read_datasets}. Result: {result}", request)
+                f"Authorized READ programs: {read_datasets}. Result: {result}", request)
 
                 if result:
                     request.read_datasets = read_datasets
@@ -174,8 +171,7 @@ class NetworkAuth:
                     service="query", token=service_token
                 )
                 log_message("DEBUG",
-                    f"verify_service_token for {request.get_full_path()}: {is_valid_token}. X-Service-Token is: {service_token}", request
-                )
+                    f"verify_service_token: {is_valid_token}. X-Service-Token is: {service_token}", request)
                 return is_valid_token
 
             log_message("DEBUG", "No X-Service-Token in headers. Not a query service request.")

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -39,10 +39,6 @@ Module with configurations for APIs
 Author: Son Chau
 """
 
-from candigv2_logging.logging import CanDIGLogger
-
-
-logger = CanDIGLogger(__file__)
 
 SAFE_METHODS = ("GET", "HEAD", "OPTIONS")
 
@@ -235,8 +231,16 @@ class LocalAuth:
 settings_module = os.environ.get("DJANGO_SETTINGS_MODULE")
 # Use OPA in prod/dev environment
 if "dev" in settings_module or "prod" in settings_module:
+    from candigv2_logging.logging import CanDIGLogger, initialize
+
+    initialize()
+    logger = CanDIGLogger(__file__)
+
     auth = NetworkAuth()
 else:
+    import logging
+
+    logger = logging.getLogger(__name__)
     auth = LocalAuth()
 
 if "test" in sys.argv:

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -40,7 +40,10 @@ Module with configurations for APIs
 Author: Son Chau
 """
 
-from candigv2_logging.logging import log_message
+from candigv2_logging.logging import CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
 
 SAFE_METHODS = ("GET", "HEAD", "OPTIONS")
 
@@ -89,11 +92,11 @@ class NetworkAuth:
                     path=request.path,
                     program=program_id,
                 )
-                log_message("DEBUG", f"Requesting DELETE for: {program_id}. Result: {write_permission}.", request)
+                logger.log_message("DEBUG", f"Requesting DELETE for: {program_id}. Result: {write_permission}.", request)
                 return write_permission
 
             except Exception as e:
-                log_message("EXCEPTION",f"An error occurred in OPA: {e}")
+                logger.log_message("EXCEPTION",f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class IngestAuth(HttpBearer):
@@ -122,11 +125,11 @@ class NetworkAuth:
                     for program_id in program_ids
                 )
 
-                log_message("DEBUG", f"Requesting WRITE for: {program_ids}. Authorized WRITE programs: {write_datasets}.", request)
+                logger.log_message("DEBUG", f"Requesting WRITE for: {program_ids}. Authorized WRITE programs: {write_datasets}.", request)
                 return write_datasets
 
             except Exception as e:
-                log_message("EXCEPTION",f"An error occurred in OPA: {e}")
+                logger.log_message("EXCEPTION",f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class GetAuth(HttpBearer):
@@ -151,7 +154,7 @@ class NetworkAuth:
             try:
                 read_datasets = get_opa_datasets(request)
                 result = True if read_datasets else None
-                log_message("DEBUG",
+                logger.log_message("DEBUG",
                 f"Authorized READ programs: {read_datasets}. Result: {result}", request)
 
                 if result:
@@ -159,7 +162,7 @@ class NetworkAuth:
                 return result
 
             except Exception as e:
-                log_message("EXCEPTION",f"An error occurred in OPA: {e}")
+                logger.log_message("EXCEPTION",f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class ServiceTokenAuth(APIKeyHeader):
@@ -170,11 +173,11 @@ class NetworkAuth:
                 is_valid_token = verify_service_token(
                     service="query", token=service_token
                 )
-                log_message("DEBUG",
+                logger.log_message("DEBUG",
                     f"verify_service_token: {is_valid_token}. X-Service-Token is: {service_token}", request)
                 return is_valid_token
 
-            log_message("DEBUG", "No X-Service-Token in headers. Not a query service request.")
+            logger.log_message("DEBUG", "No X-Service-Token in headers. Not a query service request.")
             return False
 
 

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -124,7 +124,7 @@ class NetworkAuth:
                     for program_id in program_ids
                 )
 
-                logger.debug(f"Requesting WRITE for: {program_ids}. Authorized WRITE programs: {write_datasets}.", request)
+                logger.debug(f"Requesting WRITE for: {program_ids}. Authorized to write: {write_datasets}.", request)
                 return write_datasets
 
             except Exception as e:

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import json
 import sys

--- a/chord_metadata_service/mohpackets/apis/core.py
+++ b/chord_metadata_service/mohpackets/apis/core.py
@@ -92,11 +92,11 @@ class NetworkAuth:
                     path=request.path,
                     program=program_id,
                 )
-                logger.log_message("DEBUG", f"Requesting DELETE for: {program_id}. Result: {write_permission}.", request)
+                logger.debug(f"Requesting DELETE for: {program_id}. Result: {write_permission}.", request)
                 return write_permission
 
             except Exception as e:
-                logger.log_message("EXCEPTION",f"An error occurred in OPA: {e}")
+                logger.error(f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class IngestAuth(HttpBearer):
@@ -125,11 +125,11 @@ class NetworkAuth:
                     for program_id in program_ids
                 )
 
-                logger.log_message("DEBUG", f"Requesting WRITE for: {program_ids}. Authorized WRITE programs: {write_datasets}.", request)
+                logger.debug(f"Requesting WRITE for: {program_ids}. Authorized WRITE programs: {write_datasets}.", request)
                 return write_datasets
 
             except Exception as e:
-                logger.log_message("EXCEPTION",f"An error occurred in OPA: {e}")
+                logger.error(f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class GetAuth(HttpBearer):
@@ -154,15 +154,14 @@ class NetworkAuth:
             try:
                 read_datasets = get_opa_datasets(request)
                 result = True if read_datasets else None
-                logger.log_message("DEBUG",
-                f"Authorized READ programs: {read_datasets}. Result: {result}", request)
+                logger.debug(f"Authorized READ programs: {read_datasets}. Result: {result}", request)
 
                 if result:
                     request.read_datasets = read_datasets
                 return result
 
             except Exception as e:
-                logger.log_message("EXCEPTION",f"An error occurred in OPA: {e}")
+                logger.error(f"An error occurred in OPA: {e}")
                 raise Exception("Error with OPA authentication.")
 
     class ServiceTokenAuth(APIKeyHeader):
@@ -173,11 +172,10 @@ class NetworkAuth:
                 is_valid_token = verify_service_token(
                     service="query", token=service_token
                 )
-                logger.log_message("DEBUG",
-                    f"verify_service_token: {is_valid_token}. X-Service-Token is: {service_token}", request)
+                logger.debug(f"verify_service_token: {is_valid_token}. X-Service-Token is: {service_token}", request)
                 return is_valid_token
 
-            logger.log_message("DEBUG", "No X-Service-Token in headers. Not a query service request.")
+            logger.warning("No X-Service-Token in headers. Not a query service request.")
             return False
 
 

--- a/chord_metadata_service/mohpackets/signals.py
+++ b/chord_metadata_service/mohpackets/signals.py
@@ -1,10 +1,9 @@
-import logging
-
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
+from chord_metadata_service.mohpackets.apis.core import logger
 from chord_metadata_service.mohpackets.models import (
     Biomarker,
     Chemotherapy,
@@ -22,7 +21,6 @@ from chord_metadata_service.mohpackets.models import (
     Treatment,
 )
 
-logger = logging.getLogger(__name__)
 """
     This module contains the SIGNALS for the MoH Models.
     Due to the change to include UUID in each models, the UUID and FK have to be either provided

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -140,3 +140,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # ------------------------------------------------
 
 KATSU_VERSION = "4.6.0"
+
+
+import candigv2_logging.logging
+
+candigv2_logging.logging.initialize()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -140,8 +140,3 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # ------------------------------------------------
 
 KATSU_VERSION = "4.6.0"
-
-
-import candigv2_logging.logging
-
-candigv2_logging.logging.initialize()

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -24,20 +24,3 @@ DEBUG_TOOLBAR_CONFIG = {
     "RESULTS_CACHE_SIZE": 100,
 }
 
-# Logging
-# -------
-LOGGING["handlers"]["console"]["level"] = "DEBUG"
-LOGGING["handlers"]["file"]["level"] = "DEBUG"
-LOGGING["loggers"][""]["level"] = "DEBUG"
-
-# Additional loggers specific to the development environment
-LOGGING["loggers"].update(
-    {
-        "factory": {
-            "level": "ERROR",
-        },
-        "faker": {
-            "level": "ERROR",
-        },
-    }
-)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -72,29 +72,6 @@ LOCAL_OPA_DATASET = {
 
 QUERY_SERVICE_TOKEN = "query"
 
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "console": {
-            "format": "[%(asctime)s] [%(name)s] %(levelname)s: %(message)s",
-            "datefmt": "%d/%b/%Y %H:%M:%S",
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "console",
-        },
-    },
-    "loggers": {
-        "": {
-            "level": "INFO",
-            "handlers": ["console"],
-        },
-    },
-}
-
 # Debug toolbar settings
 # ----------------------
 hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -79,3 +79,26 @@ INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + [
     "127.0.0.1",
     "10.0.2.2",
 ]
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "console": {
+            "format": "[%(asctime)s] [%(name)s] %(levelname)s: %(message)s",
+            "datefmt": "%d/%b/%Y %H:%M:%S",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+    },
+    "loggers": {
+        "": {
+            "level": "DEBUG",
+            "handlers": ["console"],
+        },
+    },
+}

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -83,46 +83,6 @@ CACHES = {
     }
 }
 
-# Logging
-# -------
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "console": {
-            "format": "[%(asctime)s] [%(name)s] %(levelname)s: %(message)s",
-            "datefmt": "%d/%b/%Y %H:%M:%S",
-        },
-        "file": {
-            "format": "[%(asctime)s] [%(name)s] %(levelname)s: %(message)s",
-            "datefmt": "%d/%b/%Y %H:%M:%S",
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "console",
-            "level": "ERROR",  # Set the log level for the console handler
-        },
-        "file": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "filename": os.path.join(BASE_DIR, "logs", "django"),
-            "formatter": "file",
-            "maxBytes": 1024 * 1024 * 5,
-            "backupCount": 5,
-            "level": "ERROR",  # Set the log level for the file handler
-        },
-    },
-    "loggers": {
-        "": {
-            "level": "ERROR",  # Set the root logger level
-            "handlers": ["console", "file"],
-        },
-        "psycopg": {
-            "level": "ERROR",
-        },
-    },
-}
 
 # ==============================================================================
 # SECURITY SETTINGS

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ psycopg[binary]==3.1.19 # PostgreSQL driver for Python
 django-cors-headers==4.3.1 # handling the server headers required for CORS
 django-ninja==1.1.0 # API & schema
 orjson==3.10.3 # JSON library
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@develop


### PR DESCRIPTION
After rebuilding with this and https://github.com/CanDIG/CanDIGv2/pull/680, log messages should go into tmp/logging/buffer.*.log.