### PR TITLE
rename db

### DIFF
--- a/create_db.sh
+++ b/create_db.sh
@@ -2,21 +2,21 @@
 
 # This script checks if a database exists, and creates it if necessary.
 # It relies on environment variables from docker-compose, default are:
-# - POSTGRES_HOST: metadata-db
+# - POSTGRES_HOST: postgres-db
 # - POSTGRES_USER: admin
-# - POSTGRES_DATABASE: metadata
-# - PGPASSWORD: password stored at /run/secrets/metadata_db_secret.
+# - POSTGRES_DATABASE: clinical
+# - PGPASSWORD: password stored at /run/secrets/postgres_db_secret.
 
 set -Euo pipefail
 
-export PGPASSWORD=$(< /run/secrets/metadata_db_secret)
+export PGPASSWORD=$(< /run/secrets/postgres_db_secret)
 
-# check if the metadata database exists
+# check if the database exists
 check_db_exist() {
     psql --quiet -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -lqt | cut -d \| -f 1 | grep -qw "$POSTGRES_DATABASE"
 }
 
-# create metadata database
+# create database
 create_db() {
     echo "Initializing database..."
     createdb -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$POSTGRES_DATABASE"


### PR DESCRIPTION
## What's new
- Rename postgres container from `metadata-db` to `postgres-db`
- Rename katsu's postgres db from `metadata` to `clinical`

### How to test
- Follow instruction from candigv2 https://github.com/CanDIG/CanDIGv2/pull/708
