### PR TITLE
DIG-2068: katsu uses default CANDIG_USER_KEY for logging

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,5 +3,5 @@ whitenoise==6.9.0 # serve static files
 redis[hiredis]==5.2.1 # cache server
 gunicorn==23.0.0 #  web server
 uvicorn[standard]==0.34.2 #  web server
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1 # CANDIG logging wrapper
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.2 # CANDIG logging wrapper
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.2 # CANDIG authorization wrapper


### PR DESCRIPTION
Pick up change for logging that uses `preferred_username` instead of `email` for `CANDIG_USER_KEY`