### PR TITLE
Bump candig-logging version

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,5 +3,5 @@ whitenoise==6.9.0 # serve static files
 redis[hiredis]==5.2.1 # cache server
 gunicorn==23.0.0 #  web server
 uvicorn[standard]==0.34.2 #  web server
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.2 # CANDIG logging wrapper
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3 # CANDIG logging wrapper
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.2 # CANDIG authorization wrapper

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,6 +3,6 @@ whitenoise==6.9.0 # serve static files
 redis[hiredis]==5.2.1 # cache server
 gunicorn==23.0.0 #  web server
 uvicorn[standard]==0.34.2 #  web server
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1 # CANDIG logging wrapper
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3 # CANDIG logging wrapper
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.7.3 # CANDIG authorization wrapper
 


### PR DESCRIPTION
Vulnerability found with Dependabot in candig-logging, so we've got to bump the version everywhere